### PR TITLE
cloud-init sshd 보안 설정 강화

### DIFF
--- a/services/vm_service.py
+++ b/services/vm_service.py
@@ -109,7 +109,7 @@ runcmd:
   - ip link set dev eth0 mtu 1400
   - netplan apply
   - echo "root:{root_password}" | chpasswd
-  - echo -e "PasswordAuthentication yes\\nPermitRootLogin no" > /etc/ssh/sshd_config.d/60-cloudimg-settings.conf
+  - echo -e "PasswordAuthentication yes\\nPermitRootLogin no\\nMaxAuthTries 5" > /etc/ssh/sshd_config.d/99-gsmsv.conf
   - systemctl restart ssh
   - apt update
   - apt install -y qemu-guest-agent


### PR DESCRIPTION
## Summary
- sshd 설정 파일명을 `60-cloudimg-settings.conf` → `99-gsmsv.conf`로 변경하여 다른 설정보다 높은 우선순위 확보
- `MaxAuthTries 5` 추가로 SSH 브루트포스 공격 시도 제한

## Test plan
- [ ] 새 VM 생성 후 `/etc/ssh/sshd_config.d/99-gsmsv.conf` 파일 존재 확인
- [ ] `PermitRootLogin no`, `MaxAuthTries 5` 적용 확인
- [x] root SSH 접속 차단 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)