### PR TITLE
docs: SSH Key 생성 시 기존 키 덮어쓰기 방지

### DIFF
--- a/frontend/app/(dashboard)/docs/ssh-key/page.tsx
+++ b/frontend/app/(dashboard)/docs/ssh-key/page.tsx
@@ -85,7 +85,7 @@ export default function SshKeyPage() {
       <p>
         SSH Key 접속이 정상적으로 되는 것을 확인한 뒤, 비밀번호 인증을 비활성화하면 보안이 크게 강화됩니다.
       </p>
-      <pre><code>sudo sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config{"\n"}sudo systemctl restart sshd</code></pre>
+      <pre><code>sudo sed -i 's/PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config.d/60-cloudimg-settings.conf{"\n"}sudo systemctl restart sshd</code></pre>
 
       <h2>주의 사항</h2>
       <ul>

--- a/frontend/app/(dashboard)/docs/ssh-key/page.tsx
+++ b/frontend/app/(dashboard)/docs/ssh-key/page.tsx
@@ -15,21 +15,25 @@ export default function SshKeyPage() {
       </p>
 
       <h2>SSH Key 생성</h2>
-      <p>터미널(Windows는 PowerShell)에서 아래 명령어를 실행합니다.</p>
-      <pre><code>ssh-keygen -t ed25519</code></pre>
+      <p>
+        터미널(Windows는 PowerShell)에서 아래 명령어를 실행합니다.{" "}
+        <code>-f</code> 옵션으로 파일 경로를 지정하면 기존 키(GitHub 등)를 덮어쓰지 않습니다.
+      </p>
+      <pre><code>ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519_gsmsv</code></pre>
       <blockquote>
         <p>
-          <code>-C</code> 옵션으로 코멘트를 추가하면 여러 키를 구분하기 편합니다.{" "}
-          예: <code>ssh-keygen -t ed25519 -C "my-laptop"</code>
+          이미 SSH Key가 없다면 <code>-f</code> 옵션 없이 <code>ssh-keygen -t ed25519</code>만 실행해도 됩니다.
+          <br />만약 <code>Overwrite (y/n)?</code> 메시지가 뜨면 같은 경로에 키가 이미 존재한다는 뜻입니다.
+          <br /><strong>n</strong>을 입력하고 <code>-f</code> 옵션으로 다른 경로를 지정하세요.
+          <br />덮어쓰면 기존 키(GitHub 등)가 사라집니다.
         </p>
       </blockquote>
       <p>
-        저장 경로와 패스프레이즈를 입력합니다.
-        기본 경로를 사용하려면 Enter를 누르세요.
+        패스프레이즈를 입력합니다. 설정하지 않으려면 Enter를 누르세요.
       </p>
 
       <h3>생성된 키 확인</h3>
-      <p>기본 경로에 두 개의 파일이 생성됩니다.</p>
+      <p>지정한 경로에 두 개의 파일이 생성됩니다.</p>
       <table>
         <thead>
           <tr>
@@ -39,11 +43,11 @@ export default function SshKeyPage() {
         </thead>
         <tbody>
           <tr>
-            <td><code>~/.ssh/id_ed25519</code></td>
+            <td><code>~/.ssh/id_ed25519_gsmsv</code></td>
             <td>개인키 (절대 공유하지 마세요)</td>
           </tr>
           <tr>
-            <td><code>~/.ssh/id_ed25519.pub</code></td>
+            <td><code>~/.ssh/id_ed25519_gsmsv.pub</code></td>
             <td>공개키 (VM에 등록할 키)</td>
           </tr>
         </tbody>
@@ -53,13 +57,13 @@ export default function SshKeyPage() {
       <p>공개키 내용을 클립보드에 복사합니다.</p>
 
       <h3>Windows</h3>
-      <pre><code>Get-Content ~/.ssh/id_ed25519.pub | Set-Clipboard</code></pre>
+      <pre><code>Get-Content ~/.ssh/id_ed25519_gsmsv.pub | Set-Clipboard</code></pre>
 
       <h3>macOS</h3>
-      <pre><code>cat ~/.ssh/id_ed25519.pub | pbcopy</code></pre>
+      <pre><code>cat ~/.ssh/id_ed25519_gsmsv.pub | pbcopy</code></pre>
 
       <h3>Linux</h3>
-      <pre><code>cat ~/.ssh/id_ed25519.pub | xclip -selection clipboard</code></pre>
+      <pre><code>cat ~/.ssh/id_ed25519_gsmsv.pub | xclip -selection clipboard</code></pre>
 
       <h2>VM에 공개키 등록</h2>
       <p>비밀번호로 VM에 먼저 접속한 뒤, 공개키를 등록합니다.</p>
@@ -72,7 +76,7 @@ export default function SshKeyPage() {
 
       <h3>3. 접속 테스트</h3>
       <p>새 터미널을 열고 비밀번호 없이 접속되는지 확인합니다.</p>
-      <pre><code>ssh ubuntu@192.168.0.100 -p &lt;SSH 포트&gt;</code></pre>
+      <pre><code>ssh -i ~/.ssh/id_ed25519_gsmsv ubuntu@192.168.0.100 -p &lt;SSH 포트&gt;</code></pre>
       <blockquote>
         <p>비밀번호 입력 없이 바로 접속되면 SSH Key 등록이 완료된 것입니다.</p>
       </blockquote>

--- a/frontend/components/docs/docs-layout.tsx
+++ b/frontend/components/docs/docs-layout.tsx
@@ -41,7 +41,8 @@ export function DocsLayout({ children }: { children: React.ReactNode }) {
           prose-li:text-sm prose-li:text-muted-foreground
           prose-strong:text-foreground
           prose-code:text-sm prose-code:bg-muted prose-code:text-foreground prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded-md prose-code:font-mono
-          prose-pre:bg-muted prose-pre:text-foreground prose-pre:border prose-pre:border-border prose-pre:rounded-lg
+          prose-pre:bg-muted prose-pre:text-foreground prose-pre:border prose-pre:border-border prose-pre:rounded-lg prose-pre:px-4 prose-pre:py-3
+          [&_pre_code]:p-0 [&_pre_code]:bg-transparent [&_pre_code]:border-0
           prose-table:text-sm
           prose-th:text-left prose-th:font-semibold prose-th:px-4 prose-th:py-2.5 prose-th:bg-muted prose-th:border-b prose-th:border-border
           prose-td:px-4 prose-td:py-2.5 prose-td:border-b prose-td:border-border/50


### PR DESCRIPTION
## Summary
- SSH Key 생성 명령어를 `-f ~/.ssh/id_ed25519_gsmsv`로 변경하여 GitHub 등 기존 키를 보호
- `Overwrite (y/n)?` 메시지 발생 시 대처 방법 안내 추가
- 접속 테스트 명령어에 `-i` 옵션으로 키 파일 명시

## Test plan
- [x] `/docs/ssh-key` 페이지에서 변경된 파일명(`id_ed25519_gsmsv`)이 일관되게 표시되는지 확인
- [x] blockquote 안내 문구가 줄바꿈과 함께 가독성 좋게 렌더링되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)