### PR TITLE
fix: 로그인 텍스트, 파비콘, 테마 전환 개선

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -187,7 +187,7 @@
   *,
   *::before,
   *::after {
-    transition: background-color 0.33s ease, border-color 0.33s ease, box-shadow 0.33s ease, opacity 0.33s ease;
+    transition: background-color 0.33s ease, border-color 0.33s ease, box-shadow 0.33s ease, opacity 0.33s ease, filter 0.33s ease;
   }
 
   /* 텍스트 요소: 글자 색상(color)만 빠르게 0.1초로 설정 (사용자 요청 반영) */

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -27,21 +27,7 @@ export const metadata: Metadata = {
   description: '광주소프트웨어마이스터고등학교 교내 클라우드 플랫폼',
   generator: 'GSM SV Team',
   icons: {
-    icon: [
-      {
-        url: '/icon-light-32x32.png',
-        media: '(prefers-color-scheme: light)',
-      },
-      {
-        url: '/icon-dark-32x32.png',
-        media: '(prefers-color-scheme: dark)',
-      },
-      {
-        url: '/icon.svg',
-        type: 'image/svg+xml',
-      },
-    ],
-    apple: '/apple-icon.png',
+    icon: '/favicon.ico',
   },
 }
 

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -76,7 +76,7 @@ function LoginContent() {
           <div className="text-center space-y-1">
             <h1 className="text-2xl font-bold tracking-tight text-foreground">로그인</h1>
             <p className="text-sm text-muted-foreground">
-              DataGSM 계정으로 로그인하세요
+              GSMSV 계정으로 로그인하세요
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- 로그인 페이지 텍스트 `DataGSM` → `GSMSV`로 변경
- 파비콘 설정 복원 (`favicon.ico`)
- 다크/라이트 모드 전환 시 로고 `filter` 트랜지션 0.33s 추가 (배경과 속도 동기화)

## Test plan
- [ ] 로그인 페이지에서 "GSMSV 계정으로 로그인하세요" 텍스트 확인
- [ ] 다크/라이트 모드 전환 시 로고와 배경 전환 속도 일치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)