### PR TITLE
fix: 보안 감사 기반 취약점 및 안정성 개선

### DIFF
--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -693,9 +693,18 @@ async def change_password(
 
 AVATAR_DIR = Path("uploads/avatars")
 AVATAR_DIR.mkdir(parents=True, exist_ok=True)
+AVATAR_DIR_RESOLVED = AVATAR_DIR.resolve()
 ALLOWED_AVATAR_TYPES = {"image/jpeg", "image/png", "image/webp"}
 ALLOWED_AVATAR_EXTENSIONS = {"jpg", "jpeg", "png", "webp"}
 MAX_AVATAR_SIZE = 2 * 1024 * 1024  # 2MB
+
+
+def _safe_avatar_path(avatar_url: str) -> Path | None:
+    """avatar_url을 안전한 로컬 경로로 변환. AVATAR_DIR 외부 경로는 None 반환."""
+    resolved = Path(avatar_url.lstrip("/")).resolve()
+    if not str(resolved).startswith(str(AVATAR_DIR_RESOLVED)):
+        return None
+    return resolved
 
 
 @router.post("/avatar")
@@ -712,10 +721,10 @@ async def upload_avatar(
     if len(contents) > MAX_AVATAR_SIZE:
         raise HTTPException(status_code=400, detail="파일 크기는 2MB 이하여야 합니다.")
 
-    # 기존 아바타 삭제
+    # 기존 아바타 삭제 (경로 순회 방지)
     if current_user.avatar_url:
-        old_path = Path(current_user.avatar_url.lstrip("/"))
-        if old_path.exists():
+        old_path = _safe_avatar_path(current_user.avatar_url)
+        if old_path and old_path.exists():
             old_path.unlink(missing_ok=True)
 
     # 저장 (확장자 화이트리스트)
@@ -742,8 +751,8 @@ async def delete_avatar(
 ):
     """프로필 사진 삭제"""
     if current_user.avatar_url:
-        old_path = Path(current_user.avatar_url.lstrip("/"))
-        if old_path.exists():
+        old_path = _safe_avatar_path(current_user.avatar_url)
+        if old_path and old_path.exists():
             old_path.unlink(missing_ok=True)
 
     current_user.avatar_url = None

--- a/api/routes/vmcontrol.py
+++ b/api/routes/vmcontrol.py
@@ -208,6 +208,7 @@ async def get_vm_status(
 ):
     """특정 VM의 상세 상태 조회 (소유자 또는 관리자만 가능)"""
     vm_record = get_vm_with_owner_check(db, vmid, current_user, node)
+    node = vm_record.server.name  # URL 파라미터 대신 DB 값 사용 (IDOR 방지)
     proxmox = get_proxmox_for_server(vm_record.server)
 
     try:
@@ -262,8 +263,9 @@ async def get_vm_metrics(
     VM 실시간 메트릭 조회 (Proxmox rrddata).
     timeframe: hour | day (1h → hour, 6h/24h → day)
     """
-    logger.info(f"[metrics] 요청: node={node}, vmid={vmid}, timeframe={timeframe}")
     vm_record = get_vm_with_owner_check(db, vmid, current_user, node)
+    node = vm_record.server.name
+    logger.info(f"[metrics] 요청: node={node}, vmid={vmid}, timeframe={timeframe}")
     proxmox = get_proxmox_for_server(vm_record.server)
 
     if timeframe not in ("hour", "day"):
@@ -410,6 +412,7 @@ async def control_vm(
 ):
     """VM 전원 제어 (시작/중지/재시작) — 소유자 또는 관리자만 가능"""
     vm_record = get_vm_with_owner_check(db, vmid, current_user, node)
+    node = vm_record.server.name
     proxmox = get_proxmox_for_server(vm_record.server)
 
     try:
@@ -466,6 +469,7 @@ async def list_snapshots(
 ):
     """VM 스냅샷 목록 조회"""
     vm_record = get_vm_with_owner_check(db, vmid, current_user, node)
+    node = vm_record.server.name
     proxmox = get_proxmox_for_server(vm_record.server)
     try:
         snapshots = proxmox.nodes(node).qemu(vmid).snapshot.get()
@@ -486,6 +490,7 @@ async def create_snapshot(
 ):
     """VM 스냅샷 생성 (최대 3개)"""
     vm_record = get_vm_with_owner_check(db, vmid, current_user, node)
+    node = vm_record.server.name
     proxmox = get_proxmox_for_server(vm_record.server)
 
     snap_name = body.get("name", "").strip()
@@ -528,6 +533,7 @@ async def rollback_snapshot(
 ):
     """VM을 특정 스냅샷 시점으로 복원"""
     vm_record = get_vm_with_owner_check(db, vmid, current_user, node)
+    node = vm_record.server.name
     proxmox = get_proxmox_for_server(vm_record.server)
     try:
         result = proxmox.nodes(node).qemu(vmid).snapshot(snapname).rollback.post()
@@ -547,6 +553,7 @@ async def delete_snapshot(
 ):
     """VM 스냅샷 삭제"""
     vm_record = get_vm_with_owner_check(db, vmid, current_user, node)
+    node = vm_record.server.name
     proxmox = get_proxmox_for_server(vm_record.server)
     try:
         result = proxmox.nodes(node).qemu(vmid).snapshot(snapname).delete()

--- a/core/config.py
+++ b/core/config.py
@@ -131,12 +131,25 @@ class Settings(BaseSettings):
 # 싱글톤 패턴으로 설정 인스턴스 생성
 settings = Settings()
 
-# SECRET_KEY 미설정 시 서버 시작 차단
+# 필수 환경변수 검증 — 누락 시 서버 시작 차단
+import sys
+
 if not settings.SECRET_KEY or settings.SECRET_KEY == "your-super-secret-key-change-this-in-production":
-    import sys
     print("❌ [FATAL] SECRET_KEY가 설정되지 않았습니다. .env 파일에 SECRET_KEY를 설정해주세요.")
     print("   예: SECRET_KEY=$(python -c \"import secrets; print(secrets.token_urlsafe(64))\")")
     sys.exit(1)
+
+_REQUIRED_VARS = {
+    "GATEWAY_IP": settings.GATEWAY_IP,
+    "GATEWAY_USER": settings.GATEWAY_USER,
+    "SMTP_USER": settings.SMTP_USER,
+    "SMTP_PASSWORD": settings.SMTP_PASSWORD,
+    "DATAGSM_API_KEY": settings.DATAGSM_API_KEY,
+}
+_missing = [k for k, v in _REQUIRED_VARS.items() if not v]
+if _missing:
+    print(f"⚠️  [WARNING] 다음 환경변수가 설정되지 않았습니다: {', '.join(_missing)}")
+    print("   일부 기능(VM 생성, 이메일 인증, 재학생 검증)이 동작하지 않을 수 있습니다.")
 
 if __name__ == "__main__":
     print("--- Loaded Configuration from .env ---")

--- a/frontend/app/(dashboard)/error.tsx
+++ b/frontend/app/(dashboard)/error.tsx
@@ -12,7 +12,7 @@ export default function DashboardError({
   reset: () => void
 }) {
   useEffect(() => {
-    console.error("[Dashboard Error]", error)
+    console.error("[Dashboard Error]", error.message)
   }, [error])
 
   return (

--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -12,7 +12,7 @@ export default function Error({
   reset: () => void
 }) {
   useEffect(() => {
-    console.error("[Error Boundary]", error)
+    console.error("[Error Boundary]", error.message)
   }, [error])
 
   return (

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -13,6 +13,7 @@ const API_BASE = "/api/v1";
 let refreshPromise: Promise<boolean> | null = null;
 
 async function refreshAccessToken(): Promise<boolean> {
+  // 이미 진행 중인 갱신이 있으면 그 결과를 대기 (중복 호출 방지)
   if (refreshPromise) return refreshPromise;
 
   refreshPromise = (async () => {
@@ -26,12 +27,15 @@ async function refreshAccessToken(): Promise<boolean> {
       return res.ok;
     } catch {
       return false;
-    } finally {
-      refreshPromise = null;
     }
   })();
 
-  return refreshPromise;
+  try {
+    return await refreshPromise;
+  } finally {
+    // 모든 대기자가 결과를 받은 후에 리셋
+    refreshPromise = null;
+  }
 }
 
 // ── 범용 fetch 래퍼 ─────────────────────────────────────────

--- a/main.py
+++ b/main.py
@@ -33,8 +33,8 @@ async def _expire_vms_loop():
     from datetime import timedelta
 
     while True:
+        db = SessionLocal()
         try:
-            db = SessionLocal()
             now = now_kst()
 
             # 1. 만료된 VM 삭제
@@ -91,10 +91,10 @@ async def _expire_vms_loop():
                 Notification.created_at < cutoff,
             ).delete()
             db.commit()
-
-            db.close()
         except Exception as e:
             logger.error(f"[expire] 백그라운드 태스크 오류: {e}")
+        finally:
+            db.close()
 
         await asyncio.sleep(3600)  # 1시간마다 확인
 
@@ -106,8 +106,8 @@ async def _iptables_weekly_backup_loop():
     from services.network_service import _backup_iptables
 
     while True:
+        db = SessionLocal()
         try:
-            db = SessionLocal()
             servers = db.query(Server).all()
 
             seen_gateways = set()
@@ -129,10 +129,10 @@ async def _iptables_weekly_backup_loop():
                     ssh.close()
                 except Exception as e:
                     logger.warning(f"[weekly-backup] {server.gateway_ip} 백업 실패: {e}")
-
-            db.close()
         except Exception as e:
             logger.error(f"[weekly-backup] 백그라운드 태스크 오류: {e}")
+        finally:
+            db.close()
 
         await asyncio.sleep(7 * 24 * 3600)  # 7일마다
 
@@ -158,42 +158,54 @@ async def _daily_snapshot_loop():
             # ── 00:00 — 기존 auto-daily 스냅샷 삭제 ──
             logger.info("[auto-snap] 기존 자동 스냅샷 삭제 시작")
             db = SessionLocal()
-            target_vms = db.query(Vm).filter(Vm.auto_snapshot == True).all()
+            try:
+                target_vms = db.query(Vm).filter(Vm.auto_snapshot == True).all()
 
-            for vm in target_vms:
-                try:
-                    proxmox = get_proxmox_for_server(vm.server)
-                    snapshots = proxmox.nodes(vm.server.name).qemu(vm.hypervisor_vmid).snapshot.get()
-                    for snap in snapshots:
-                        if snap.get("name", "").startswith(AUTO_SNAP_PREFIX):
-                            proxmox.nodes(vm.server.name).qemu(vm.hypervisor_vmid).snapshot(snap["name"]).delete()
-                            logger.info(f"[auto-snap] 삭제: {vm.name} / {snap['name']}")
-                except Exception as e:
-                    logger.warning(f"[auto-snap] 삭제 실패 ({vm.name}): {e}")
+                for vm in target_vms:
+                    try:
+                        proxmox = get_proxmox_for_server(vm.server)
+                        snapshots = proxmox.nodes(vm.server.name).qemu(vm.hypervisor_vmid).snapshot.get()
+                        for snap in snapshots:
+                            if snap.get("name", "").startswith(AUTO_SNAP_PREFIX):
+                                proxmox.nodes(vm.server.name).qemu(vm.hypervisor_vmid).snapshot(snap["name"]).delete()
+                                logger.info(f"[auto-snap] 삭제: {vm.name} / {snap['name']}")
+                    except Exception as e:
+                        logger.warning(f"[auto-snap] 삭제 실패 ({vm.name}): {e}")
 
-            # ── 00:10 — 새 스냅샷 생성 ──
-            await asyncio.sleep(600)
+                # ── 00:10 — 새 스냅샷 생성 ──
+                await asyncio.sleep(600)
 
-            today_str = now_kst().strftime("%Y%m%d")
-            snap_name = f"{AUTO_SNAP_PREFIX}-{today_str}"
-            logger.info(f"[auto-snap] 자동 스냅샷 생성 시작: {snap_name}")
+                today_str = now_kst().strftime("%Y%m%d")
+                snap_name = f"{AUTO_SNAP_PREFIX}-{today_str}"
+                logger.info(f"[auto-snap] 자동 스냅샷 생성 시작: {snap_name}")
 
-            for vm in target_vms:
-                try:
-                    proxmox = get_proxmox_for_server(vm.server)
-                    proxmox.nodes(vm.server.name).qemu(vm.hypervisor_vmid).snapshot.post(
-                        snapname=snap_name,
-                        description="자동 일일 스냅샷",
-                        vmstate=0,
-                    )
-                    logger.info(f"[auto-snap] 생성: {vm.name} / {snap_name}")
-                except Exception as e:
-                    logger.warning(f"[auto-snap] 생성 실패 ({vm.name}): {e}")
-
-            db.close()
+                for vm in target_vms:
+                    try:
+                        proxmox = get_proxmox_for_server(vm.server)
+                        proxmox.nodes(vm.server.name).qemu(vm.hypervisor_vmid).snapshot.post(
+                            snapname=snap_name,
+                            description="자동 일일 스냅샷",
+                            vmstate=0,
+                        )
+                        logger.info(f"[auto-snap] 생성: {vm.name} / {snap_name}")
+                    except Exception as e:
+                        logger.warning(f"[auto-snap] 생성 실패 ({vm.name}): {e}")
+            finally:
+                db.close()
         except Exception as e:
             logger.error(f"[auto-snap] 백그라운드 태스크 오류: {e}")
             await asyncio.sleep(3600)
+
+
+async def _oauth_store_cleanup_loop():
+    """OAuth PKCE/토큰 인메모리 스토어 주기적 정리 (메모리 누수 방지)"""
+    from api.routes.oauth import _cleanup_stores
+    while True:
+        try:
+            _cleanup_stores()
+        except Exception as e:
+            logger.warning(f"[oauth-cleanup] 정리 실패: {e}")
+        await asyncio.sleep(300)  # 5분마다
 
 
 @asynccontextmanager
@@ -213,12 +225,15 @@ async def lifespan(app: FastAPI):
     iptables_task = asyncio.create_task(_iptables_weekly_backup_loop())
     # 자동 일일 스냅샷 태스크 시작
     snapshot_task = asyncio.create_task(_daily_snapshot_loop())
+    # OAuth PKCE/토큰 스토어 주기적 정리 (5분 간격)
+    oauth_cleanup_task = asyncio.create_task(_oauth_store_cleanup_loop())
 
     yield
     # ── 종료 시 ──
     expire_task.cancel()
     iptables_task.cancel()
     snapshot_task.cancel()
+    oauth_cleanup_task.cancel()
 
 
 app = FastAPI(

--- a/models/vm.py
+++ b/models/vm.py
@@ -24,10 +24,10 @@ class Vm(Base):
     display_name = Column(String, nullable=True)
     
     # 생성된 VM이 실제로 위치한 물리 서버 ID (servers 테이블 참조)
-    server_id = Column(Integer, ForeignKey("servers.id"), nullable=False)
-    
+    server_id = Column(Integer, ForeignKey("servers.id"), nullable=False, index=True)
+
     # 신규: VM 소유자(사용자) ID 기록
-    owner_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    owner_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
     
     # 할당된 자원
     allocated_ram_mb = Column(Integer, default=2048)

--- a/services/proxmox_client.py
+++ b/services/proxmox_client.py
@@ -1,15 +1,29 @@
 import logging
+import threading
+import time
 from proxmoxer import ProxmoxAPI
 from fastapi import HTTPException
 
 logger = logging.getLogger(__name__)
 
+# 서버별 Proxmox 연결 캐시 (TTL 5분)
+_proxmox_cache: dict[int, tuple[object, float]] = {}  # server_id → (proxmox, expires_at)
+_cache_lock = threading.Lock()
+_CACHE_TTL = 300  # 5분
+
 
 def get_proxmox_for_server(server):
     """
     서버(Server) 모델 기반으로 Proxmox에 연결합니다.
-    각 노드의 ip_address, port, api_user, api_password를 사용합니다.
+    서버별 연결을 캐싱하여 불필요한 재연결을 방지합니다 (TTL 5분).
     """
+    now = time.time()
+
+    with _cache_lock:
+        cached = _proxmox_cache.get(server.id)
+        if cached and cached[1] > now:
+            return cached[0]
+
     try:
         proxmox = ProxmoxAPI(
             server.ip_address,
@@ -19,6 +33,8 @@ def get_proxmox_for_server(server):
             verify_ssl=False,
             timeout=180,
         )
+        with _cache_lock:
+            _proxmox_cache[server.id] = (proxmox, now + _CACHE_TTL)
         return proxmox
     except Exception as e:
         logger.error(f"Proxmox 연결 실패 ({server.name}): {e}")

--- a/services/vm_service.py
+++ b/services/vm_service.py
@@ -135,6 +135,7 @@ def _upload_snippet(server: Server, filename: str, content: str):
             timeout=10,
         )
         sftp = ssh.open_sftp()
+        sftp.get_channel().settimeout(15)  # SFTP 작업 타임아웃
         remote_path = f"{SNIPPETS_DIR}/{filename}"
         with sftp.file(remote_path, "w") as f:
             f.write(content)
@@ -169,15 +170,17 @@ def _delete_snippet(server: Server, filename: str):
 
 
 def _wait_for_clone(proxmox, node_name: str, vmid: int, timeout: int = 60):
-    """클론 태스크가 완료될 때까지 대기합니다."""
+    """클론 태스크가 완료될 때까지 지수 백오프로 대기합니다."""
     deadline = time.time() + timeout
+    delay = 0.5
     while time.time() < deadline:
         try:
             # VM config를 읽을 수 있으면 클론 완료
             proxmox.nodes(node_name).qemu(vmid).config.get()
             return
         except Exception:
-            time.sleep(2)
+            time.sleep(min(delay, max(0, deadline - time.time())))
+            delay = min(delay * 2, 5)  # 0.5 → 1 → 2 → 4 → 5(max)
     raise HTTPException(status_code=500, detail=f"VM {vmid} 클론 타임아웃 ({timeout}초)")
 
 


### PR DESCRIPTION
## Summary
- **Path Traversal 방지**: 아바타 삭제 시 `../../` 경로 순회로 임의 파일 삭제 가능한 취약점 수정
- **IDOR 방지**: VM 엔드포인트에서 URL `node` 파라미터 대신 DB 검증된 서버명 사용
- **DB 세션 누수 방지**: 백그라운드 태스크 3개에 `try/finally` 적용
- **Proxmox 연결 캐싱**: 서버별 5분 TTL 캐시로 불필요한 재연결 방지
- **SFTP 타임아웃**: 스니펫 업로드 시 15초 타임아웃 설정
- **Clone 지수 백오프**: 고정 2초 sleep → 0.5~5초 지수 백오프
- **토큰 리프레시 레이스 컨디션**: finally 블록에서 promise 리셋
- **에러 바운더리**: 스택 트레이스 대신 에러 메시지만 콘솔 출력
- **환경변수 경고**: GATEWAY, SMTP, DATAGSM 미설정 시 시작 경고
- **FK 인덱스**: `server_id`, `owner_id`에 인덱스 추가
- **OAuth PKCE 메모리 누수 방지**: 5분 주기 정리 태스크 추가

## Test plan
- [x] 기존 테스트 49/49 통과 (회귀 없음)
- [x] 아바타 삭제 시 `../../` 경로로 API 호출 → 파일 삭제 안됨 확인
- [x] VM 상세 조회 시 잘못된 node 파라미터 → 404 반환 확인
- [x] 서버 시작 시 환경변수 누락 경고 메시지 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)