### PR TITLE
fix: VM 이름 DNS 규격 미준수로 인한 생성 실패 수정

### DIFF
--- a/services/vm_service.py
+++ b/services/vm_service.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import string
 import secrets
 import time
@@ -33,15 +34,25 @@ def _generate_password(length: int = 8) -> str:
     return password
 
 
+def _sanitize_dns_name(name: str) -> str:
+    """문자열을 DNS 호환 이름으로 변환 (소문자 + 숫자 + 하이픈만 허용)"""
+    name = name.lower()
+    name = re.sub(r"[^a-z0-9-]", "-", name)  # 허용되지 않는 문자 → 하이픈
+    name = re.sub(r"-+", "-", name)           # 연속 하이픈 제거
+    name = name.strip("-")                    # 앞뒤 하이픈 제거
+    return name
+
+
 def _generate_vm_name(user: User, tier: str, custom_name: str = None) -> tuple[str, str]:
     """
     VM 이름 생성 → (proxmox_name, display_name) 튜플 반환
     - custom_name이 있으면: test1-myvm / myvm
     - 없으면 자동 생성:    test1-micro-a3f2 / micro-a3f2
     """
-    username = user.email.split("@")[0]
+    username = _sanitize_dns_name(user.email.split("@")[0])
     if custom_name:
-        return f"{username}-{custom_name}", custom_name
+        safe_name = _sanitize_dns_name(custom_name)
+        return f"{username}-{safe_name}", custom_name
     suffix = ''.join(secrets.choice(string.ascii_lowercase + string.digits) for _ in range(4))
     short = f"{tier}-{suffix}"
     return f"{username}-{short}", short


### PR DESCRIPTION
## Summary
- **VM 이름 DNS 정규화**: 이메일 username에 밑줄(`_`), 대문자, 점(`.`) 등이 포함될 경우 Proxmox가 `invalid DNS name`으로 거부하는 버그 수정
- `_sanitize_dns_name()` 헬퍼 추가: 소문자 + 숫자 + 하이픈만 허용, 나머지 문자는 하이픈으로 치환
- 커스텀 VM 이름에도 동일 정규화 적용 (display_name은 원본 유지)

## Test plan
- [x] `test_vm_helpers.py` 10/10 통과
- [x] 밑줄/대문자 포함 이메일 계정으로 VM 생성 시 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)