### PR TITLE
fix: VM 생성 실패 시 불필요한 destroy 방지

### DIFF
--- a/services/vm_service.py
+++ b/services/vm_service.py
@@ -40,7 +40,7 @@ def _sanitize_dns_name(name: str) -> str:
     name = re.sub(r"[^a-z0-9-]", "-", name)  # 허용되지 않는 문자 → 하이픈
     name = re.sub(r"-+", "-", name)           # 연속 하이픈 제거
     name = name.strip("-")                    # 앞뒤 하이픈 제거
-    return name
+    return name or "vm"                       # 빈 문자열 방지 (비ASCII 이메일 등)
 
 
 def _generate_vm_name(user: User, tier: str, custom_name: str = None) -> tuple[str, str]:
@@ -338,6 +338,7 @@ def create_vm(
     vmid = _get_next_vmid(proxmox, server.name)
     vm_name, vm_display_name = _generate_vm_name(current_user, tier.value, custom_name=name)
     vm_password = _generate_password()
+    clone_started = False  # clone 시작 여부 추적
 
     try:
         # 5. 템플릿 Full Clone
@@ -347,6 +348,7 @@ def create_vm(
             full=1,                     # full clone (linked clone이 아닌 독립 디스크)
             target=server.name,
         )
+        clone_started = True
 
         # 클론 태스크 완료 + lock 해제 대기
         _wait_for_clone(proxmox, server.name, vmid, upid=clone_upid)
@@ -453,22 +455,23 @@ def create_vm(
         raise
     except Exception as e:
         # 실패 시 생성된 VM + 스니펫 정리 시도
-        try:
-            # lock이 남아있으면 삭제 불가 → lock 해제까지 대기 후 삭제
-            for _ in range(10):
-                try:
-                    config = proxmox.nodes(server.name).qemu(vmid).config.get()
-                    if config.get("lock"):
-                        logger.info(f"VM {vmid} lock 대기 중 (정리 전)...")
+        if clone_started:
+            try:
+                # lock이 남아있으면 삭제 불가 → lock 해제까지 대기 후 삭제
+                for _ in range(10):
+                    try:
+                        config = proxmox.nodes(server.name).qemu(vmid).config.get()
+                        if config.get("lock"):
+                            logger.info(f"VM {vmid} lock 대기 중 (정리 전)...")
+                            time.sleep(3)
+                            continue
+                    except Exception:
                         time.sleep(3)
                         continue
-                except Exception:
-                    time.sleep(3)
-                    continue
-                break
-            proxmox.nodes(server.name).qemu(vmid).delete(purge=1)
-        except Exception:
-            logger.warning(f"VM {vmid} 생성 실패 후 정리 중 오류 (수동 확인 필요)")
+                    break
+                proxmox.nodes(server.name).qemu(vmid).delete(purge=1)
+            except Exception:
+                logger.warning(f"VM {vmid} 생성 실패 후 정리 중 오류 (수동 확인 필요)")
         try:
             _delete_snippet(server, f"user-data-{vmid}.yaml")
         except Exception:


### PR DESCRIPTION
## Summary
- **clone 미시작 시 delete 방지**: `clone.post()`가 이름 검증 등으로 실패(400)하면 VM이 생성되지 않았는데도 except 블록에서 `delete()`를 시도하는 문제 수정 — `clone_started` 플래그로 추적
- **DNS 이름 빈값 방어**: 비ASCII 이메일 등으로 `_sanitize_dns_name()` 결과가 빈 문자열일 경우 `"vm"` 폴백

## 참고
- PR #14 (UPID 클론 대기) + PR #15 (DNS 정규화)가 이미 머지되어 있으나, **배포 환경에 반영(docker rebuild 등)이 필요합니다**
- 현재 에러 로그(`invalid DNS name` → destroy)는 PR #15의 DNS 정규화가 배포되면 해결될 것으로 보입니다

## Test plan
- [x] `test_vm_helpers.py` 10/10 통과
- [ ] 대문자 이메일 계정으로 VM 생성 정상 동작 확인
- [ ] Project Owner 노드3에서 VM 생성 시 clone→destroy 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
