### PR TITLE
fix: 비밀번호 정책 프론트/백엔드 동기화 및 사이드바 스크롤

### DIFF
--- a/docs/API_SPEC.md
+++ b/docs/API_SPEC.md
@@ -1,4 +1,4 @@
-# GSM SV — 기능 명세서 v1.0
+# GSM SV — 기능 명세서 v2.0
 
 > Proxmox 기반 IaaS VM 관리 플랫폼. 실제 구현 코드와 동기화된 명세서입니다.
 
@@ -7,7 +7,7 @@
 ## 1. 프로젝트 개요
 
 Proxmox 기반의 물리 GPU 서버 클러스터(3노드)를 클라우드 서비스처럼 사용할 수 있도록 제공하는 **VM 프로비저닝 및 제어 플랫폼**입니다.
-사용자는 웹 콘솔을 통해 VM 생성, 전원 제어, 방화벽, 리소스 모니터링, 핫플러그 리사이징 등을 수행할 수 있습니다.
+사용자는 웹 콘솔을 통해 VM 생성, 전원 제어, 스냅샷, 리소스 모니터링, 핫플러그 리사이징 등을 수행할 수 있습니다.
 
 ### 네트워크 구조
 
@@ -30,16 +30,18 @@ Proxmox 기반의 물리 GPU 서버 클러스터(3노드)를 클라우드 서비
 | 분류 | 기술 |
 |------|------|
 | Backend | FastAPI (Python 3.14) |
-| Frontend | Next.js 15 (App Router, TypeScript) |
+| Frontend | Next.js 16 (App Router, React 19, TypeScript) |
 | ORM | SQLAlchemy |
-| DB | SQLite |
-| 인증 | JWT (Access + Refresh Token), DataGSM OAuth 2.0 + PKCE |
-| Proxmox 연동 | Proxmoxer |
+| DB | PostgreSQL (psycopg2-binary) |
+| 인증 | JWT (httpOnly Cookie), DataGSM OAuth 2.0 + PKCE |
+| 암호화 | Fernet 대칭 암호화 (VM 비밀번호), bcrypt (사용자 비밀번호) |
+| Proxmox 연동 | Proxmoxer (서버별 5분 TTL 캐싱) |
 | SSH/SFTP | Paramiko (포트포워딩, 스니펫 업로드) |
 | Cloud-Init | 동적 user-data 스니펫 (SSH 업로드 → cicustom) |
 | OS 템플릿 | Ubuntu 22.04 LTS (Cloud Image) |
 | 시간대 | KST (Asia/Seoul) — DB 직접 저장 |
 | UI 라이브러리 | shadcn/ui, Tailwind CSS, Recharts, Lucide Icons |
+| Rate Limiting | SlowAPI |
 
 ---
 
@@ -47,19 +49,20 @@ Proxmox 기반의 물리 GPU 서버 클러스터(3노드)를 클라우드 서비
 
 ```text
 newconsole-beta/
-├── main.py                 # FastAPI 앱 진입점, 라우터 등록, CORS
+├── main.py                 # FastAPI 앱 진입점, 라우터 등록, CORS, 백그라운드 태스크
 ├── .env                    # 환경변수 (git 제외)
 ├── core/
-│   ├── config.py           # 환경변수 로딩 (Settings)
+│   ├── config.py           # 환경변수 로딩 (Settings), 필수 변수 경고
 │   ├── constants.py        # VM 티어 스펙 상수
-│   ├── database.py         # SQLAlchemy 엔진, 세션, Base
-│   ├── security.py         # JWT 생성/검증, bcrypt 해싱
+│   ├── database.py         # SQLAlchemy 엔진, 세션, Base (SQLite/PostgreSQL 자동 분기)
+│   ├── security.py         # JWT 생성/검증, bcrypt 해싱, Fernet 암복호화
 │   └── timezone.py         # KST 시간대 유틸리티
 ├── models/
 │   ├── user.py             # 회원 모델 (ADMIN/PROJECT_OWNER/USER)
 │   ├── server.py           # Proxmox 서버 정보 + SSH 자격증명
-│   ├── vm.py               # VM 정보 + 만료일
-│   └── notification.py     # 알림 모델 (DB 영속)
+│   ├── vm.py               # VM 정보 + 만료일 + FK 인덱스
+│   ├── notification.py     # 알림 모델 (DB 영속)
+│   └── email_verification.py # 이메일 인증코드 모델
 ├── schemas/
 │   ├── user_schema.py      # 회원가입, 로그인 검증
 │   ├── vm_schema.py        # VM 생성/제어 검증 (Tier, OS, Node)
@@ -67,18 +70,28 @@ newconsole-beta/
 ├── api/
 │   ├── dependencies.py     # JWT 인증, 관리자 확인, VM 소유권 검증
 │   └── routes/
-│       ├── auth.py         # 인증 (가입, 로그인, 비밀번호 변경)
+│       ├── auth.py         # 인증 (가입, 로그인, 비밀번호 변경, 아바타)
 │       ├── oauth.py        # DataGSM OAuth 2.0 + PKCE
-│       ├── vmcontrol.py    # VM CRUD, 전원제어, 리사이징, 만료연장
+│       ├── vmcontrol.py    # VM CRUD, 전원제어, 스냅샷, 리사이징, 만료연장
 │       ├── firewall.py     # 방화벽 규칙 CRUD
 │       ├── network.py      # 포트포워딩 정보 조회
 │       ├── monitoring.py   # 노드 상태 조회
-│       └── notifications.py # 알림 CRUD
+│       ├── notifications.py # 알림 CRUD
+│       └── faq.py          # FAQ 질문/답변 CRUD
 ├── services/
 │   ├── vm_service.py       # VM 생성/삭제 (클론, Cloud-Init, iptables)
 │   ├── mon_service.py      # 자원 스케줄링 (Auto Provisioning)
 │   ├── network_service.py  # 포트 계산 및 iptables 관리
-│   └── proxmox_client.py   # Proxmox API 클라이언트
+│   ├── proxmox_client.py   # Proxmox API 클라이언트 (연결 캐싱)
+│   └── datagsm_service.py  # DataGSM API 연동 (학생/프로젝트 확인)
+├── tests/                  # 단위/통합 테스트 (49개)
+│   ├── conftest.py
+│   ├── test_api_auth.py
+│   ├── test_encryption.py
+│   ├── test_ip_validation.py
+│   ├── test_models.py
+│   ├── test_password_validation.py
+│   └── test_vm_helpers.py
 └── frontend/
     └── app/
         ├── login/              # 로그인 페이지
@@ -88,10 +101,10 @@ newconsole-beta/
         ├── reset-password/     # 비밀번호 초기화
         ├── auth/callback/      # OAuth 콜백
         └── (dashboard)/
-            ├── instances/      # VM 목록 + 상세 (탭: 개요, 모니터링, 방화벽, 설정)
+            ├── instances/      # VM 목록 + 상세 (탭: 개요, 모니터링, 방화벽, 스냅샷, 설정)
             ├── deploy/         # VM 생성 위자드 (OS → 노드 → 사양 → 확인)
-            ├── settings/       # 사용자 설정 (비밀번호 변경, 테마)
-            └── docs/           # 문서 페이지
+            ├── settings/       # 사용자 설정 (프로필, 비밀번호 변경, 테마)
+            └── docs/           # 문서 페이지 (시작하기, 접속 방법, SSH Key, 인스턴스, FAQ 등)
 ```
 
 ---
@@ -107,13 +120,15 @@ newconsole-beta/
 | 프로젝트 오너 가입 | `POST` | `/signup/project` | 누구나 | 프로젝트 선택 + 비밀번호 + 사유 → 인증코드 발송 |
 | 이메일 인증 | `POST` | `/verify` | 누구나 | 인증코드 확인 후 계정 생성 |
 | 인증코드 재발송 | `POST` | `/resend-code` | 누구나 | 이메일 인증코드 재발송 |
-| 로그인 | `POST` | `/login` | 누구나 | JWT Access + Refresh Token 발급 |
+| 로그인 | `POST` | `/login` | 누구나 | JWT Access + Refresh Token 발급 (httpOnly Cookie) |
 | 토큰 갱신 | `POST` | `/refresh` | 누구나 | Refresh Token으로 새 토큰 쌍 발급 |
 | 내 정보 | `GET` | `/me` | 로그인 | 현재 사용자 프로필 반환 |
 | 비밀번호 변경 | `PUT` | `/change-password` | 로그인 | 기존 비밀번호 확인 후 변경 |
 | 비밀번호 초기화 요청 | `POST` | `/password-reset/request` | 누구나 | 이메일로 초기화 인증코드 발송 |
 | 비밀번호 초기화 확인 | `POST` | `/password-reset/confirm` | 누구나 | 인증코드 확인 후 새 비밀번호 설정 |
-| 로그아웃 | `POST` | `/logout` | 로그인 | Stateless (클라이언트 토큰 파기) |
+| 아바타 업로드 | `POST` | `/avatar` | 로그인 | 프로필 이미지 업로드 (Path Traversal 방어) |
+| 아바타 삭제 | `DELETE` | `/avatar` | 로그인 | 프로필 이미지 삭제 |
+| 로그아웃 | `POST` | `/logout` | 로그인 | httpOnly Cookie 제거 |
 | 승인 대기 목록 | `GET` | `/pending-approvals` | ADMIN | 프로젝트 오너 승인 대기 목록 |
 | 가입 승인 | `POST` | `/approve/{user_id}` | ADMIN | 프로젝트 오너 가입 승인 |
 | 가입 거절 | `POST` | `/reject/{user_id}` | ADMIN | 프로젝트 오너 가입 거절 (계정 삭제) |
@@ -123,10 +138,12 @@ newconsole-beta/
 | 기능 | Method | Endpoint | 권한 | 설명 |
 |------|--------|----------|------|------|
 | OAuth 인증 시작 | `GET` | `/authorize` | 누구나 | PKCE 생성 → DataGSM 로그인 페이지 리다이렉트 |
-| OAuth 콜백 | `GET` | `/callback` | 누구나 | 코드 교환 → userinfo → 계정 연동/생성 → JWT 발급 |
+| OAuth 콜백 | `GET` | `/callback` | 누구나 | 코드 교환 → userinfo → 임시 토큰 발급 → 프론트 리다이렉트 |
+| 임시 토큰 교환 | `POST` | `/exchange` | 누구나 | 임시 코드 → JWT Access/Refresh Token 발급 |
 
 - **계정 연동**: 같은 이메일의 기존 계정이 있으면 OAuth 정보를 연결, 없으면 새 계정 생성
 - **PKCE**: Authorization Code + code_verifier/code_challenge (S256)
+- **인메모리 스토어 정리**: 5분 주기로 만료된 PKCE/토큰 정리 (메모리 누수 방지)
 
 ### 4.3 VM 관리 — `/api/v1/vm`
 
@@ -141,6 +158,12 @@ newconsole-beta/
 | VM 전원 제어 | `POST` | `/{node}/vms/{vmid}/action` | Owner/ADMIN | start, stop, shutdown, reboot |
 | VM 리사이징 | `PUT` | `/{node}/vms/{vmid}/resize` | PO/ADMIN | CPU(소켓)/메모리 핫플러그 변경 |
 | VM 만료 연장 | `POST` | `/{node}/vms/{vmid}/extend` | Owner | 만료 15일 전부터 30일 연장 가능 |
+| 스냅샷 목록 | `GET` | `/{node}/vms/{vmid}/snapshots` | Owner/ADMIN | VM 스냅샷 목록 조회 |
+| 스냅샷 생성 | `POST` | `/{node}/vms/{vmid}/snapshots` | Owner/ADMIN | VM 스냅샷 생성 (이름 정규식 검증) |
+| 스냅샷 롤백 | `POST` | `/{node}/vms/{vmid}/snapshots/{snapname}/rollback` | Owner/ADMIN | 스냅샷으로 VM 복원 |
+| 스냅샷 삭제 | `DELETE` | `/{node}/vms/{vmid}/snapshots/{snapname}` | Owner/ADMIN | 스냅샷 삭제 |
+| 자동 스냅샷 조회 | `GET` | `/{node}/vms/{vmid}/auto-snapshot` | Owner/ADMIN | 자동 스냅샷 활성화 여부 조회 |
+| 자동 스냅샷 토글 | `PUT` | `/{node}/vms/{vmid}/auto-snapshot` | Owner/ADMIN | 자동 스냅샷 활성화/비활성화 |
 | VM 삭제 | `DELETE` | `/{node}/vms/{vmid}` | Owner/ADMIN | VM 삭제 + iptables 정리 + DB 삭제 |
 | 노드 목록 | `GET` | `/nodes` | ADMIN | 활성 Proxmox 노드 목록 |
 | 노드 리소스 | `GET` | `/nodes/resources` | 로그인 | 노드별 CPU/RAM/SSD 사용량 (배포 페이지용) |
@@ -151,13 +174,16 @@ newconsole-beta/
 1. 요청 검증 (USER 최대 3개, 역할별 노드 접근 제어)
 2. 노드 선택 (지정 또는 Auto Provisioning)
 3. 내부 IP 자동 할당 (10.0.0.x, DB 기반 충돌 방지)
-4. 템플릿 Full Clone + VMID 자동 할당
-5. Cloud-Init 스니펫 생성 → SSH/SFTP 업로드
-6. cicustom user= 설정 → 리소스 스펙 적용 → 디스크 리사이즈
-7. iptables 포트포워딩 등록 (SSH/HTTP/SVC)
-8. VM 부팅
-9. cicustom 해제 + 스니펫 삭제
-10. DB 저장 (만료일: USER는 30일)
+4. VM 이름 DNS 정규화 (소문자+숫자+하이픈만 허용)
+5. 템플릿 Full Clone + VMID 자동 할당
+6. UPID 기반 클론 태스크 완료 대기 + lock 해제 확인
+7. Cloud-Init 스니펫 생성 → SSH/SFTP 업로드 (15초 타임아웃)
+8. cicustom user= 설정 → 리소스 스펙 적용 → 디스크 리사이즈
+9. iptables 포트포워딩 등록 (SSH/HTTP/SVC)
+10. VM 부팅
+11. cicustom 해제 + 스니펫 삭제
+12. DB 저장 (만료일: USER는 30일)
+* 실패 시: clone 시작 여부 확인 후 lock 대기 → VM 정리
 ```
 
 ### 4.4 네트워크 — `/api/v1/network`
@@ -189,19 +215,30 @@ newconsole-beta/
 | 전체 읽음 | `POST` | `/read-all` | 로그인 | 모든 알림 읽음 처리 |
 | 알림 삭제 | `DELETE` | `/{id}` | 로그인 | 단일 알림 삭제 |
 
+### 4.8 FAQ — `/api/v1/faq`
+
+| 기능 | Method | Endpoint | 권한 | 설명 |
+|------|--------|----------|------|------|
+| 질문 목록 | `GET` | `/` | 로그인 | 전체 FAQ 질문 목록 (답변 포함) |
+| 질문 작성 | `POST` | `/` | 로그인 | FAQ 질문 등록 |
+| 답변 작성 | `PUT` | `/{question_id}/answer` | ADMIN | 질문에 답변 작성 |
+| 질문 삭제 | `DELETE` | `/{question_id}` | 작성자/ADMIN | 질문 삭제 |
+
 ---
 
 ## 5. 권한 체계 (RBAC)
 
-| 역할 | VM 생성 | 노드 접근 | VM 만료 | 핫플러그 | 특수 기능 |
-|------|---------|-----------|---------|----------|-----------|
-| `ADMIN` | 무제한 | 전체 노드 | 없음 | O | 가입 승인/거절, 전체 VM 조회 |
-| `PROJECT_OWNER` | 무제한 | 프로젝트 전용 노드 | 없음 | O | 커스텀 사양 VM 생성 |
-| `USER` | 최대 3개 | 일반 노드 (1, 2) | 30일 (연장 가능) | X | - |
+| 역할 | VM 생성 | 노드 접근 | VM 만료 | 핫플러그 | 스냅샷 | 특수 기능 |
+|------|---------|-----------|---------|----------|--------|-----------|
+| `ADMIN` | 무제한 | 전체 노드 | 없음 | O | O | 가입 승인/거절, 전체 VM 조회, FAQ 답변 |
+| `PROJECT_OWNER` | 무제한 | 프로젝트 전용 노드 | 없음 | O | O | 커스텀 사양 VM 생성 |
+| `USER` | 최대 3개 | 일반 노드 (1, 2) | 30일 (연장 가능) | X | O | - |
 
-- JWT Access Token: 30분, Refresh Token: 7일
-- 모든 API: `Authorization: Bearer <token>` 필수
+- JWT Access Token: 30분, Refresh Token: 7일 (httpOnly Cookie)
+- IDOR 방지: VM 엔드포인트에서 URL `node` 파라미터 대신 DB 검증된 서버명 사용
 - 프로젝트 오너 가입: 관리자 승인 필요
+- 비밀번호 정책: 8자 이상, 영문 + 숫자 + 특수문자 포함 필수
+- 인증코드: 최대 5회 시도 제한
 
 ---
 
@@ -243,6 +280,7 @@ VM당 **3개의 포트**가 VMID 기반으로 고정 할당됩니다.
 
 - iptables DNAT: `-d 172.10.104.3` 지정
 - VM 생성/삭제 시 자동 추가/제거
+- SSH 접속 도메인: `ssh.gsmsv.site`
 
 ---
 
@@ -250,7 +288,7 @@ VM당 **3개의 포트**가 VMID 기반으로 고정 할당됩니다.
 
 ```text
 1. VM 클론 후 user-data YAML 동적 생성
-2. SSH/SFTP로 Proxmox 노드에 업로드 (/var/lib/vz/snippets/)
+2. SSH/SFTP로 Proxmox 노드에 업로드 (/var/lib/vz/snippets/) — 15초 타임아웃
 3. cicustom user=local:snippets/user-data-{vmid}.yaml 적용
 4. VM 부팅 (cloud-init 첫 부팅 시 1회 실행)
 5. cicustom 해제 (재부팅 시 스니펫 참조 오류 방지)
@@ -260,38 +298,62 @@ VM당 **3개의 포트**가 VMID 기반으로 고정 할당됩니다.
 - SSH 전용 계정: `gsmsv-sni` (PVE realm과 별도)
 - 노드별 SSH 포트: 10011, 10012, 10013
 - MTU 1400 설정은 netplan으로 영구 적용
+- sshd 설정: `/etc/ssh/sshd_config.d/99-gsmsv.conf` (PermitRootLogin no, MaxAuthTries 5)
 
 ---
 
 ## 9. VM 만료 정책
 
-| 역할 | 만료 기간 | 연장 조건 | 연장 기간 |
+| 역할 | 만료 기간 | 연장 조건 | 연장 방식 |
 |------|-----------|-----------|-----------|
-| USER | 생성 후 30일 | 만료 15일 전부터 | +30일 |
+| USER | 생성 후 30일 | 만료 15일 전부터 | 남은 기간 + 30일 |
 | PROJECT_OWNER | 없음 | - | - |
 | ADMIN | 없음 | - | - |
 
 - 연장 버튼: 항상 표시, 15일 이내일 때만 활성화
 - 만료일은 인스턴스 개요 탭에서 D-day로 표시
+- 만료 15일 전부터 알림 발송 (매시간 체크)
 
 ---
 
-## 10. 에러 코드
+## 10. 스냅샷 관리
+
+| 기능 | 설명 |
+|------|------|
+| 수동 스냅샷 | 사용자가 직접 생성/롤백/삭제 |
+| 자동 스냅샷 | 매일 자동 생성 (활성화 시), 최대 3개 보관 후 순환 삭제 |
+| 이름 규칙 | 영문, 숫자, 하이픈, 밑줄만 허용 (정규식 검증) |
+
+---
+
+## 11. 백그라운드 태스크
+
+| 태스크 | 주기 | 설명 |
+|--------|------|------|
+| VM 만료 처리 | 1시간 | 만료된 VM 자동 삭제 + 만료 임박(15일) 알림 발송 |
+| iptables 백업 | 1주 | 포트포워딩 규칙 백업 |
+| 자동 스냅샷 | 1일 | 활성화된 VM 자동 스냅샷 생성 (최대 3개 순환) |
+| OAuth 스토어 정리 | 5분 | 만료된 PKCE/임시토큰 인메모리 데이터 정리 |
+
+---
+
+## 12. 에러 코드
 
 | 코드 | 상황 |
 |------|------|
-| `400` | 잘못된 요청 (티어 오류, 필수값 누락, 인증코드 불일치) |
+| `400` | 잘못된 요청 (티어 오류, 필수값 누락, 인증코드 불일치, DNS 이름 규격 위반) |
 | `401` | 인증 토큰 없음 또는 만료 |
-| `403` | 권한 없음 (타인 VM, 노드 접근 제한) |
+| `403` | 권한 없음 (타인 VM, 노드 접근 제한, IDOR 차단) |
 | `404` | VM/노드/사용자 없음 |
 | `409` | VM 개수 초과 (USER 3개 제한) |
 | `422` | 요청 본문 형식 오류 |
-| `500` | Proxmox 연결 실패, SSH 오류 등 |
+| `429` | Rate Limit 초과 |
+| `500` | Proxmox 연결 실패, SSH 오류, 클론 타임아웃 등 |
 | `507` | 자원 부족으로 VM 생성 불가 |
 
 ---
 
-## 11. 프론트엔드 페이지 구조
+## 13. 프론트엔드 페이지 구조
 
 | 페이지 | 경로 | 설명 |
 |--------|------|------|
@@ -303,9 +365,15 @@ VM당 **3개의 포트**가 VMID 기반으로 고정 할당됩니다.
 | OAuth 콜백 | `/auth/callback` | DataGSM 리다이렉트 처리 |
 | VM 배포 | `/deploy` | 4단계 위자드 (OS → 노드 → 사양 → 확인) |
 | 인스턴스 목록 | `/instances` | VM 카드 리스트 + 상태 표시 |
-| 인스턴스 상세 | `/instances/[id]` | 탭: 개요, 모니터링, 방화벽, 설정 |
-| 설정 | `/settings` | 비밀번호 변경, 테마 전환 |
-| 문서 | `/docs` | 사용 가이드 |
+| 인스턴스 상세 | `/instances/[id]` | 탭: 개요, 모니터링, 방화벽, 스냅샷, 설정 |
+| 설정 | `/settings` | 프로필 (아바타), 비밀번호 변경, 테마 전환 |
+| 문서 — 시작하기 | `/docs/getting-started` | 서비스 소개, 주의사항, 제공 기능, 계정 유형 |
+| 문서 — 접속 방법 | `/docs/access` | VM SSH 접속 가이드 |
+| 문서 — SSH Key | `/docs/ssh-key` | SSH Key 생성 및 등록 가이드 |
+| 문서 — 인스턴스 | `/docs/instances` | VM 관리 가이드 |
+| 문서 — 프로젝트 오너 | `/docs/project-owner` | PO 전용 기능 가이드 |
+| 문서 — FAQ | `/docs/faq` | 자주 묻는 질문 |
+| 문서 — 질문하기 | `/docs/questions` | FAQ 질문 등록 |
 
 ### 사이드바 구조
 
@@ -315,10 +383,32 @@ VM당 **3개의 포트**가 VMID 기반으로 고정 할당됩니다.
 
 ---
 
-## 12. 향후 계획
+## 14. 보안 정책
+
+| 항목 | 구현 |
+|------|------|
+| Path Traversal | 아바타 업로드/삭제 시 `AVATAR_DIR` 외부 경로 차단 |
+| IDOR | VM 엔드포인트에서 DB 검증된 `server.name` 사용 |
+| SSH 인젝션 | IP 주소 정규식 검증 후 명령어 조합 |
+| 비밀번호 암호화 | Fernet 대칭 암호화 (VM), bcrypt (사용자) |
+| 인증코드 | 5회 시도 제한, 만료 시간 적용 |
+| 환경변수 | 필수 변수 미설정 시 시작 경고 (GATEWAY, SMTP, DATAGSM) |
+| 에러 바운더리 | 스택 트레이스 대신 에러 메시지만 콘솔 출력 |
+| DB 인덱스 | `server_id`, `owner_id` FK에 인덱스 추가 |
+
+---
+
+## 15. 향후 계획
 
 | 기능 | 상태 |
 |------|------|
+| 비동기 SSH (asyncssh) | 예정 |
+| 스냅샷 동시 요청 방지 (lock) | 예정 |
+| 에러 응답 포맷 통일 | 예정 |
+| 구조화 로깅 (JSON) | 예정 |
+| VM 목록 페이지네이션 | 예정 |
+| Soft Delete + 감사 로그 | 예정 |
+| 요청 추적 ID (X-Request-ID) | 예정 |
 | 지원 페이지 (Discord 리다이렉트) | 예정 |
 | Prometheus + Grafana 연동 (어드민) | 보류 |
 | Windows, CentOS 등 OS 추가 | 보류 |

--- a/frontend/app/(dashboard)/settings/page.tsx
+++ b/frontend/app/(dashboard)/settings/page.tsx
@@ -82,8 +82,8 @@ export default function SettingsPage() {
       setError("모든 항목을 입력해주세요.")
       return
     }
-    if (newPassword.length < 6) {
-      setError("새 비밀번호는 6자 이상이어야 합니다.")
+    if (newPassword.length < 8 || !/[a-zA-Z]/.test(newPassword) || !/\d/.test(newPassword) || !/[!@#$%^&*()_+\-=\[\]{}|;:'",.<>?/~`]/.test(newPassword)) {
+      setError("비밀번호는 8자 이상, 영문+숫자+특수문자를 포함해야 합니다.")
       return
     }
     if (newPassword !== confirmPassword) {
@@ -271,7 +271,7 @@ export default function SettingsPage() {
                 type="password"
                 value={newPassword}
                 onChange={(e) => setNewPassword(e.target.value)}
-                placeholder="새 비밀번호 입력 (6자 이상)"
+                placeholder="새 비밀번호 입력 (8자 이상, 영문+숫자+특수문자)"
               />
             </div>
             <div className="space-y-2">

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -175,6 +175,28 @@
   --color-sidebar-ring: var(--sidebar-ring);
 }
 
+/* 사이드바 스크롤바 */
+.sidebar-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+.sidebar-scroll:hover {
+  scrollbar-color: var(--muted-foreground) transparent;
+}
+.sidebar-scroll::-webkit-scrollbar {
+  width: 4px;
+}
+.sidebar-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+.sidebar-scroll::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 4px;
+}
+.sidebar-scroll:hover::-webkit-scrollbar-thumb {
+  background: var(--muted-foreground);
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -39,11 +39,13 @@ export default function ResetPasswordPage() {
   const [success, setSuccess] = useState(false)
 
   const passwordChecks = [
-    { label: "6자 이상", pass: newPassword.length >= 6 },
+    { label: "8자 이상", pass: newPassword.length >= 8 },
     { label: "영문 포함", pass: /[a-zA-Z]/.test(newPassword) },
     { label: "숫자 포함", pass: /\d/.test(newPassword) },
+    { label: "특수문자 포함", pass: /[!@#$%^&*()_+\-=\[\]{}|;:'",.<>?/~`]/.test(newPassword) },
   ]
   const passwordStrength = passwordChecks.filter((c) => c.pass).length
+  const passwordTotal = passwordChecks.length
 
   useEffect(() => {
     if (resendCooldown <= 0) return
@@ -139,7 +141,7 @@ export default function ResetPasswordPage() {
       setError("비밀번호가 일치하지 않습니다.")
       return
     }
-    if (passwordStrength < 3) {
+    if (passwordStrength < passwordTotal) {
       setError("비밀번호 조건을 모두 충족해주세요.")
       return
     }
@@ -337,16 +339,16 @@ export default function ResetPasswordPage() {
               {newPassword.length > 0 && (
                 <div className="space-y-2 pt-1">
                   <div className="flex gap-1.5">
-                    {[1, 2, 3].map((level) => (
+                    {Array.from({ length: passwordTotal }, (_, i) => i + 1).map((level) => (
                       <div
                         key={level}
                         className="h-1 flex-1 rounded-full transition-colors"
                         style={{
                           background:
                             passwordStrength >= level
-                              ? passwordStrength === 3
+                              ? passwordStrength === passwordTotal
                                 ? "var(--status-active-dot)"
-                                : passwordStrength === 2
+                                : passwordStrength >= passwordTotal - 1
                                 ? "var(--status-pending-dot)"
                                 : "var(--status-error-dot)"
                               : "var(--muted)",

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -27,11 +27,13 @@ export default function SignupPage() {
   const [loading, setLoading] = useState(false)
 
   const passwordChecks = [
-    { label: "6자 이상", pass: password.length >= 6 },
+    { label: "8자 이상", pass: password.length >= 8 },
     { label: "영문 포함", pass: /[a-zA-Z]/.test(password) },
     { label: "숫자 포함", pass: /\d/.test(password) },
+    { label: "특수문자 포함", pass: /[!@#$%^&*()_+\-=\[\]{}|;:'",.<>?/~`]/.test(password) },
   ]
   const passwordStrength = passwordChecks.filter((c) => c.pass).length
+  const passwordTotal = passwordChecks.length
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -41,7 +43,7 @@ export default function SignupPage() {
       setError("비밀번호가 일치하지 않습니다.")
       return
     }
-    if (passwordStrength < 3) {
+    if (passwordStrength < passwordTotal) {
       setError("비밀번호 조건을 모두 충족해주세요.")
       return
     }
@@ -140,16 +142,16 @@ export default function SignupPage() {
             {password.length > 0 && (
               <div className="space-y-2 pt-1">
                 <div className="flex gap-1.5">
-                  {[1, 2, 3].map((level) => (
+                  {Array.from({ length: passwordTotal }, (_, i) => i + 1).map((level) => (
                     <div
                       key={level}
                       className="h-1 flex-1 rounded-full transition-colors"
                       style={{
                         background:
                           passwordStrength >= level
-                            ? passwordStrength === 3
+                            ? passwordStrength === passwordTotal
                               ? "var(--status-active-dot)"
-                              : passwordStrength === 2
+                              : passwordStrength >= passwordTotal - 1
                               ? "var(--status-pending-dot)"
                               : "var(--status-error-dot)"
                             : "var(--muted)",

--- a/frontend/app/signup/project/page.tsx
+++ b/frontend/app/signup/project/page.tsx
@@ -43,11 +43,13 @@ export default function ProjectSignupPage() {
   const [error, setError] = useState("")
 
   const passwordChecks = [
-    { label: "6자 이상", pass: password.length >= 6 },
+    { label: "8자 이상", pass: password.length >= 8 },
     { label: "영문 포함", pass: /[a-zA-Z]/.test(password) },
     { label: "숫자 포함", pass: /\d/.test(password) },
+    { label: "특수문자 포함", pass: /[!@#$%^&*()_+\-=\[\]{}|;:'",.<>?/~`]/.test(password) },
   ]
   const passwordStrength = passwordChecks.filter((c) => c.pass).length
+  const passwordTotal = passwordChecks.length
 
   const handleCheckEmail = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -88,7 +90,7 @@ export default function ProjectSignupPage() {
       setError("비밀번호가 일치하지 않습니다.")
       return
     }
-    if (passwordStrength < 3) {
+    if (passwordStrength < passwordTotal) {
       setError("비밀번호 조건을 모두 충족해주세요.")
       return
     }
@@ -343,16 +345,16 @@ export default function ProjectSignupPage() {
                 {password.length > 0 && (
                   <div className="space-y-2 pt-1">
                     <div className="flex gap-1.5">
-                      {[1, 2, 3].map((level) => (
+                      {Array.from({ length: passwordTotal }, (_, i) => i + 1).map((level) => (
                         <div
                           key={level}
                           className="h-1 flex-1 rounded-full transition-colors"
                           style={{
                             background:
                               passwordStrength >= level
-                                ? passwordStrength === 3
+                                ? passwordStrength === passwordTotal
                                   ? "var(--status-active-dot)"
-                                  : passwordStrength === 2
+                                  : passwordStrength >= passwordTotal - 1
                                   ? "var(--status-pending-dot)"
                                   : "var(--status-error-dot)"
                                 : "var(--muted)",

--- a/frontend/components/dashboard/sidebar.tsx
+++ b/frontend/components/dashboard/sidebar.tsx
@@ -280,7 +280,7 @@ export function Sidebar() {
         </div>
 
         {/* Navigation */}
-        <nav ref={navContainerRef} className="relative flex-1 overflow-hidden py-4">
+        <nav ref={navContainerRef} className="relative flex-1 overflow-y-auto overflow-x-hidden py-4 sidebar-scroll">
           <SlidingIndicator style={indicator} />
 
           {/* 메뉴 */}


### PR DESCRIPTION
## Summary
- **비밀번호 검증 동기화**: 프론트엔드 4개 페이지의 비밀번호 정책을 백엔드와 일치시킴 (6자+영문+숫자 → **8자+영문+숫자+특수문자**)
  - 회원가입 (`/signup`)
  - 프로젝트 오너 가입 (`/signup/project`)
  - 비밀번호 재설정 (`/reset-password`)
  - 설정 — 비밀번호 변경 (`/settings`)
- **비밀번호 강도 바**: 3단계 → 4단계로 변경 (특수문자 항목 추가)
- **사이드바 스크롤**: VM 목록이 많을 때 `overflow-hidden` → `overflow-y-auto`, 호버 시 얇은(4px) 스크롤바 표시

## Test plan
- [ ] 비밀번호 재설정 시 특수문자 없는 비밀번호 → 프론트에서 조건 미충족 표시 확인
- [ ] 회원가입 시 비밀번호 강도 바 4칸 정상 표시 확인
- [ ] 설정 페이지 비밀번호 변경 placeholder 및 검증 메시지 확인
- [ ] 사이드바에 VM 다수 등록 시 스크롤 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)