### PR TITLE
fix: Sidebar useSearchParams 프리렌더 에러 Suspense 래핑 수정

### DIFF
--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect } from "react"
+import { Suspense, useEffect } from "react"
 import { Sidebar } from "@/components/dashboard/sidebar"
 import { TopNavbar } from "@/components/dashboard/top-navbar"
 import { NotificationProvider, useNotifications } from "@/lib/notification-context"
@@ -31,7 +31,9 @@ export default function DashboardLayout({
     <NotificationProvider>
       <SessionNotificationHandler />
       <div className="min-h-screen bg-sidebar">
-        <Sidebar />
+        <Suspense fallback={<aside className="fixed left-0 top-0 z-40 h-screen w-52 bg-sidebar" />}>
+          <Sidebar />
+        </Suspense>
         <div className="pl-52">
           <div className="min-h-screen bg-background rounded-tl-2xl">
             <TopNavbar />


### PR DESCRIPTION
## Summary
- 사이드바에 \`useSearchParams\`를 추가하면서 \`/admin/approvals\` 등 정적 생성 페이지에서 \`missing-suspense-with-csr-bailout\` 빌드 에러 발생
- 대시보드 레이아웃에서 \`<Sidebar />\`를 \`<Suspense>\`로 래핑하여 페이지 쉘은 프리렌더되고 사이드바는 클라이언트에서 하이드레이션되도록 변경

## Test plan
- [ ] 서버에서 \`docker compose build frontend\` 성공 확인
- [ ] 빌드 로그에 \`missing-suspense-with-csr-bailout\` 에러 없는지 확인
- [ ] 대시보드 진입 시 사이드바가 정상 렌더되고 VM 인디케이터가 올바르게 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)