### PR TITLE
fix: VM 소켓 1 고정 및 방화벽 탭 복사 피드백 추가

### DIFF
--- a/api/routes/vmcontrol.py
+++ b/api/routes/vmcontrol.py
@@ -331,14 +331,14 @@ async def resize_vm(
         raise HTTPException(status_code=400, detail="변경할 값이 없습니다.")
 
     update_params = {}
-    max_vcpus = 8  # 2코어 × 4소켓
+    max_vcpus = 8
     max_memory = 32768  # 32GB
 
     if body.cores is not None:
-        # cores 값은 총 vCPU 수 (2,4,6,8), 소켓 단위로 변환
+        # cores 값은 총 vCPU 수 (2,4,6,8), 소켓 1 고정 + cores로 조절
         if body.cores not in (2, 4, 6, 8):
             raise HTTPException(status_code=400, detail="vCPU는 2, 4, 6, 8 중 선택해주세요.")
-        update_params["sockets"] = body.cores // 2
+        update_params["cores"] = body.cores
 
     if body.memory is not None:
         if not (4096 <= body.memory <= max_memory):

--- a/frontend/components/instances/tabs/firewall-tab.tsx
+++ b/frontend/components/instances/tabs/firewall-tab.tsx
@@ -1,8 +1,9 @@
 "use client"
 
+import { useState } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Globe, Copy } from "lucide-react"
+import { Globe, Copy, Check } from "lucide-react"
 
 import type { Instance } from "@/lib/types"
 import { type PortInfo } from "@/lib/api"
@@ -14,6 +15,16 @@ export function FirewallTab({
   instance: Instance
   ports?: PortInfo[]
 }) {
+  const [copiedIndex, setCopiedIndex] = useState<number | null>(null)
+
+  const handleCopy = (text: string, index: number) => {
+    navigator.clipboard.writeText(text)
+    setTimeout(() => {
+      setCopiedIndex(index)
+      setTimeout(() => setCopiedIndex(null), 1500)
+    }, 100)
+  }
+
   return (
     <div className="space-y-6">
       {ports.length > 0 ? (
@@ -38,9 +49,12 @@ export function FirewallTab({
                   variant="ghost"
                   size="icon"
                   className="h-8 w-8"
-                  onClick={() => navigator.clipboard.writeText(`ssh.gsmsv.site:${port.public_port}`)}
+                  onClick={() => handleCopy(`ssh.gsmsv.site:${port.public_port}`, i)}
                 >
-                  <Copy className="h-3.5 w-3.5" />
+                  {copiedIndex === i
+                    ? <Check className="h-3.5 w-3.5 text-emerald-500" />
+                    : <Copy className="h-3.5 w-3.5" />
+                  }
                 </Button>
               </div>
             ))}

--- a/services/vm_service.py
+++ b/services/vm_service.py
@@ -377,15 +377,11 @@ def create_vm(
             "sockets": 1,
         }
 
-        # 프로젝트 커스텀 티어: 핫플러그 활성화 (소켓 기반 CPU 변경, NUMA 필수)
+        # 프로젝트 커스텀 티어: 핫플러그 활성화 (소켓 1 고정, cores로 vCPU 조절)
         if tier == VMTierEnum.PROJECT_CUSTOM:
             config_params["hotplug"] = "cpu,memory"
             config_params["balloon"] = specs["memory"] // 2
             config_params["numa"] = 1
-            # 소켓 기반: cores=2 고정, sockets로 총 vCPU 조절 (2,4,6,8)
-            sockets = max(1, specs["cores"] // 2)
-            config_params["cores"] = 2
-            config_params["sockets"] = sockets
 
         proxmox.nodes(server.name).qemu(vmid).config.put(**config_params)
 


### PR DESCRIPTION
## Summary
- PROJECT_CUSTOM 티어 VM 생성 시 소켓 기반 CPU 조절 제거, 소켓 1 고정 + cores로 vCPU 수 설정
  → NUMA 노드 메모리 불일치(소켓 3개일 때 1바이트 차이)로 QEMU 시작 실패하던 문제 수정
- 핫플러그 리사이징도 `sockets` 대신 `cores` 변경하도록 수정
- 방화벽 탭 복사 버튼 클릭 시 Check 아이콘으로 1.5초간 피드백 표시

## Test plan
- [x] Project Owner로 VM 생성 시 QEMU 시작 에러 없이 정상 부팅되는지 확인
- [x] 핫플러그로 vCPU 변경 시 Proxmox에서 cores가 변경되는지 확인 (sockets는 1 유지)
- [x] 방화벽 탭에서 복사 버튼 클릭 시 Check 아이콘으로 전환 후 원복되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)