### PR TITLE
fix: 사이드바 인디케이터 docs 토글 연동 및 UI 개선

### DIFF
--- a/frontend/app/(dashboard)/docs/advanced-resources/page.tsx
+++ b/frontend/app/(dashboard)/docs/advanced-resources/page.tsx
@@ -38,7 +38,7 @@ export default function AdvancedResourcesPage() {
 
       <h2>신청 방법</h2>
       <p>
-        관리자에게 직접 문의하면 사용 사유를 검토한 후 제공드립니다.
+        관리자에게 직접 문의하면 사용 사유를 검토한 후 제공드립니다. <br />
         Discord ming._.jun으로 연락해주시거나 웹 문의를 통해 신청해주시면 감사하겠습니다.
       </p>
     </DocsLayout>

--- a/frontend/components/dashboard/sidebar.tsx
+++ b/frontend/components/dashboard/sidebar.tsx
@@ -31,6 +31,7 @@ import { useAuth } from "@/lib/auth-context"
 
 type NavItemData = {
   title: string
+  label?: React.ReactNode
   href: string
   icon: React.ComponentType<{ className?: string }>
   external?: boolean
@@ -50,7 +51,7 @@ const docCategories: DocCategory[] = [
     children: [
       { title: "인스턴스", href: "/docs/instances", icon: HardDrive },
       { title: "접속 방법", href: "/docs/access", icon: Terminal },
-      { title: "SSH Key 등록", href: "/docs/ssh-key", icon: KeyRound },
+      { title: "SSH Key 등록", label: <>SSH Key<br />등록</>, href: "/docs/ssh-key", icon: KeyRound },
       { title: "Public IP / GPU 안내", href: "/docs/advanced-resources", icon: Cpu },
     ],
   },
@@ -408,7 +409,7 @@ export function Sidebar() {
                                     )}
                                   >
                                     <ChildIcon className={cn("h-3.5 w-3.5 shrink-0 transition-colors", childIsActive ? "text-white" : "")} />
-                                    <span>{child.title}</span>
+                                    <span>{child.label ?? child.title}</span>
                                   </Link>
                                 </div>
                               )

--- a/frontend/components/dashboard/sidebar.tsx
+++ b/frontend/components/dashboard/sidebar.tsx
@@ -263,7 +263,9 @@ export function Sidebar() {
 
   useLayoutEffect(() => {
     updateIndicator()
-  }, [updateIndicator, pathname, vms, adminNodes, currentNode, expandedNodes])
+    const timer = setTimeout(updateIndicator, 310)
+    return () => clearTimeout(timer)
+  }, [updateIndicator, pathname, vms, adminNodes, currentNode, expandedNodes, docsOpen])
 
   useEffect(() => {
     window.addEventListener("resize", updateIndicator)


### PR DESCRIPTION
## Summary
- **사이드바 인디케이터 버그 수정**: 문서 아코디언 열고 닫을 때 `docsOpen`이 `useLayoutEffect` 의존성에 없어 인디케이터 위치가 재계산되지 않던 문제 수정, 300ms transition 완료 후 재계산하는 `setTimeout(310ms)` 적용
- **SSH Key 등록 줄바꿈**: 사이드바에서 "SSH Key 등록"이 어색하게 잘리던 문제를 `label` 필드로 "SSH Key / 등록" 자연스럽게 줄바꿈 처리
- **advanced-resources 문의 방법**: 신청 방법 문단 줄바꿈 개선

## Test plan
- [ ] VM 선택 후 문서 아코디언 열기/닫기 시 인디케이터가 VM 위치를 따라가는지 확인
- [ ] 사이드바에서 SSH Key 등록 항목이 자연스럽게 2줄로 표시되는지 확인