### PR TITLE
fix: 사이드바 인디케이터 rAF 루프로 트랜지션 실시간 추적

### DIFF
--- a/frontend/app/(dashboard)/docs/advanced-resources/page.tsx
+++ b/frontend/app/(dashboard)/docs/advanced-resources/page.tsx
@@ -39,7 +39,7 @@ export default function AdvancedResourcesPage() {
       <h2>신청 방법</h2>
       <p>
         관리자에게 직접 문의하면 사용 사유를 검토한 후 제공드립니다. <br />
-        Discord ming._.jun으로 연락해주시거나 웹 문의를 통해 신청해주시면 감사하겠습니다.
+        Discord <code>ming._.jun</code>으로 연락해주시거나 웹 문의를 통해 신청해주시면 감사하겠습니다.
       </p>
     </DocsLayout>
   )

--- a/frontend/components/dashboard/sidebar.tsx
+++ b/frontend/components/dashboard/sidebar.tsx
@@ -263,9 +263,20 @@ export function Sidebar() {
   }, [activeHref])
 
   useLayoutEffect(() => {
-    updateIndicator()
-    const timer = setTimeout(updateIndicator, 310)
-    return () => clearTimeout(timer)
+    let rafId: number
+    let startTime: number | null = null
+    const duration = 320
+
+    const loop = (time: number) => {
+      if (startTime === null) startTime = time
+      updateIndicator()
+      if (time - startTime < duration) {
+        rafId = requestAnimationFrame(loop)
+      }
+    }
+
+    rafId = requestAnimationFrame(loop)
+    return () => cancelAnimationFrame(rafId)
   }, [updateIndicator, pathname, vms, adminNodes, currentNode, expandedNodes, docsOpen])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- **사이드바 인디케이터 추적 개선**: `setTimeout` 방식 대신 `requestAnimationFrame` 루프(320ms)로 교체해 트랜지션 중 인디케이터가 실시간으로 따라가도록 개선 — 노드 펼치기/접기, docs 아코디언 모두 적용
- **advanced-resources 스타일**: Discord 아이디 `ming._.jun`을 `<code>` 태그로 강조

## Test plan
- [ ] VM 선택 후 docs 아코디언 열기/닫기 시 인디케이터가 부드럽게 따라가는지 확인
- [ ] 노드 펼쳤다가 접을 때 인디케이터가 정상적으로 이동하는지 확인