### PR TITLE
fix: 노드 접힐 때 인디케이터 숨김 및 추적 속도 개선

### DIFF
--- a/frontend/components/dashboard/sidebar.tsx
+++ b/frontend/components/dashboard/sidebar.tsx
@@ -81,7 +81,7 @@ function SlidingIndicator({ style }: { style: IndicatorStyle }) {
       style={{
         top: style.top,
         height: style.height,
-        transition: "top 0.3s cubic-bezier(0.4, 0, 0.2, 1), height 0.25s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.2s ease",
+        transition: "top 0.15s cubic-bezier(0.4, 0, 0.2, 1), height 0.15s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.15s ease",
         opacity: style.visible ? 1 : 0,
         width: "calc(100% - 8px)",
         marginLeft: "8px",
@@ -243,6 +243,15 @@ export function Sidebar() {
       return
     }
 
+    // 접힌 노드 안의 VM이면 숨김
+    if (activeHref.includes(":/instances/")) {
+      const [node] = activeHref.split(":")
+      if (!expandedNodes.has(node)) {
+        setIndicator((prev) => ({ ...prev, visible: false }))
+        return
+      }
+    }
+
     const el = itemRefs.current.get(activeHref)
     if (!el) {
       setIndicator((prev) => ({ ...prev, visible: false }))
@@ -260,7 +269,7 @@ export function Sidebar() {
       height: elRect.height,
       visible: true,
     })
-  }, [activeHref])
+  }, [activeHref, expandedNodes])
 
   useLayoutEffect(() => {
     let rafId: number


### PR DESCRIPTION
## Summary
- **인디케이터 숨김 처리**: 선택된 VM이 속한 노드를 접으면 인디케이터가 자리를 못 찾는 문제 수정 — `expandedNodes`에 해당 노드가 없으면 즉시 숨김
- **transition 단축**: 인디케이터 이동 속도 `0.3s` → `0.15s`로 단축해 더 빠르게 반응하도록 개선

## Test plan
- [ ] VM 선택 후 해당 노드 접었을 때 인디케이터가 사라지는지 확인
- [ ] 노드 다시 펼치면 인디케이터가 VM 위치로 복귀하는지 확인
- [ ] 인디케이터 이동이 이전보다 빠르게 느껴지는지 확인