### PR TITLE
update: VM cloud-init 기본 apt 미러 카카오로 변경

### DIFF
--- a/services/vm_service.py
+++ b/services/vm_service.py
@@ -122,6 +122,7 @@ runcmd:
   - echo "root:{root_password}" | chpasswd
   - printf "PasswordAuthentication yes\\nPermitRootLogin no\\nMaxAuthTries 5\\n" > /etc/ssh/sshd_config.d/99-gsmsv.conf
   - systemctl restart ssh
+  - sed -i 's|http://archive.ubuntu.com/ubuntu|http://mirror.kakao.com/ubuntu|g; s|http://security.ubuntu.com/ubuntu|http://mirror.kakao.com/ubuntu|g' /etc/apt/sources.list
   - apt update
   - apt install -y qemu-guest-agent
   - systemctl enable --now qemu-guest-agent


### PR DESCRIPTION
## Summary
- **apt 미러 변경**: VM cloud-init `runcmd`에서 `apt update` 전 `/etc/apt/sources.list`의 기본 미러를 `mirror.kakao.com`으로 교체해 국내 패키지 설치 속도 개선

## Test plan
- [ ] VM 생성 후 `/etc/apt/sources.list`에 카카오 미러가 적용됐는지 확인
- [ ] `apt update` 및 패키지 설치 정상 동작 확인