### PR TITLE
fix: VM cloud-init 완료 확인 로직을 agent exec 기반으로 개선

### DIFF
--- a/api/routes/vmcontrol.py
+++ b/api/routes/vmcontrol.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import time
 from datetime import datetime, timedelta, timezone
 from core.timezone import now_kst
 from fastapi import APIRouter, HTTPException, status, Depends, Request
@@ -218,12 +219,15 @@ async def get_vm_status(
         provisioning = False
         if vm_status.get("status") == "running":
             try:
-                proxmox.nodes(node).qemu(vmid).agent("file-read").get(
-                    file="/home/ubuntu/ok.txt"
+                result = proxmox.nodes(node).qemu(vmid).agent.exec.post(
+                    command="test -f /home/ubuntu/ok.txt && echo OK || echo NOTYET"
                 )
-                # 파일 있으면 설정 완료
+                pid = result.get("pid")
+                time.sleep(1)
+                out = proxmox.nodes(node).qemu(vmid).agent("exec-status").get(pid=pid)
+                stdout = out.get("out-data", "")
+                provisioning = "OK" not in stdout
             except Exception:
-                # agent 미응답 또는 파일 미존재 → 설정 중
                 provisioning = True
 
         # Proxmox 실시간 데이터 + DB 저장 데이터 통합

--- a/api/routes/vmcontrol.py
+++ b/api/routes/vmcontrol.py
@@ -216,16 +216,14 @@ async def get_vm_status(
 
         # cloud-init 완료 여부 확인 (running 상태일 때만)
         provisioning = False
-        uptime = vm_status.get("uptime", 0)
-        if vm_status.get("status") == "running" and 0 < uptime < 180:
-            # 부팅 10분 이내: guest agent로 ok.txt 확인 시도
+        if vm_status.get("status") == "running":
             try:
                 proxmox.nodes(node).qemu(vmid).agent("file-read").get(
                     file="/home/ubuntu/ok.txt"
                 )
                 # 파일 있으면 설정 완료
             except Exception:
-                # agent 미설치 또는 파일 미존재 → 설정 중
+                # agent 미응답 또는 파일 미존재 → 설정 중
                 provisioning = True
 
         # Proxmox 실시간 데이터 + DB 저장 데이터 통합

--- a/frontend/components/dashboard/sidebar.tsx
+++ b/frontend/components/dashboard/sidebar.tsx
@@ -140,8 +140,8 @@ function VmStatusDot({ status }: { status: string }) {
     status === "running"
       ? "bg-[var(--status-active-dot)]"
       : status === "stopped"
-      ? "bg-[var(--status-stopped-dot)]"
-      : "bg-[var(--status-pending-dot)]"
+        ? "bg-[var(--status-stopped-dot)]"
+        : "bg-[var(--status-pending-dot)]"
 
   return (
     <span


### PR DESCRIPTION
## Summary
- **cloud-init 완료 감지 개선**: 개별 VM 상태 조회 시 `uptime < 180` 시간 기반 판단 제거, `qemu-guest-agent exec`으로 `ok.txt` 존재 여부를 직접 확인하도록 변경
- **사이드바 린트 포맷팅**: `VmStatusDot` 삼항 연산자 들여쓰기 정렬

## Test plan
- [ ] VM 생성 후 cloud-init 완료 시 웹에서 설정중 상태가 정확히 종료되는지 확인
- [ ] guest-agent 미응답 시 설정중 상태 유지되는지 확인