### PR TITLE
fix: ok.txt 확인 실패 시 uptime 3분 이상이면 provisioning 해제

### DIFF
--- a/api/routes/vmcontrol.py
+++ b/api/routes/vmcontrol.py
@@ -218,6 +218,7 @@ async def get_vm_status(
         # cloud-init 완료 여부 확인 (running 상태일 때만)
         provisioning = False
         if vm_status.get("status") == "running":
+            uptime = vm_status.get("uptime", 0)
             try:
                 result = proxmox.nodes(node).qemu(vmid).agent.exec.post(
                     command="test -f /home/ubuntu/ok.txt && echo OK || echo NOTYET"
@@ -228,7 +229,7 @@ async def get_vm_status(
                 stdout = out.get("out-data", "")
                 provisioning = "OK" not in stdout
             except Exception:
-                provisioning = True
+                provisioning = uptime < 180
 
         # Proxmox 실시간 데이터 + DB 저장 데이터 통합
         return {


### PR DESCRIPTION
## Summary
- **cloud-init provisioning 폴백**: `ok.txt` 확인 실패(Guest Agent 미응답 등) 시 uptime 180초 미만일 때만 설정 중으로 표시, 이상이면 완료로 처리 (`vmcontrol.py`)

## Test plan
- [ ] VM uptime 3분 이상 + Guest Agent 미응답 상태에서 provisioning 미표시 확인
- [ ] 정상 부팅 VM에서 ok.txt 확인 성공 시 기존 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)