### PR TITLE
fix: 이메일 인증 코드 재사용 취약점 수정

### DIFF
--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -483,14 +483,11 @@ async def resend_code(request: Request, body: ResendCodeRequest, db: Session = D
         expires_at=now_kst() + timedelta(minutes=settings.VERIFICATION_CODE_EXPIRE_MINUTES),
     )
     db.add(new_record)
-    db.flush()
+    db.commit()
 
     sent = await send_verification_email(body.email, new_code)
     if not sent:
-        db.rollback()
         raise HTTPException(status_code=500, detail="인증 이메일 발송에 실패했습니다.")
-
-    db.commit()
 
     return {
         "message": "새 인증 코드가 발송되었습니다.",

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -482,8 +482,12 @@ async def resend_code(request: Request, body: ResendCodeRequest, db: Session = D
         project_reason=project_reason,
         expires_at=now_kst() + timedelta(minutes=settings.VERIFICATION_CODE_EXPIRE_MINUTES),
     )
-    db.add(new_record)
-    db.commit()
+    try:
+        db.add(new_record)
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=400, detail="잠시 후 다시 시도해주세요.")
 
     sent = await send_verification_email(body.email, new_code)
     if not sent:

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -338,9 +338,9 @@ async def verify_email(request: Request, body: VerifyCodeRequest, db: Session = 
         project_name=record.project_name if is_project_owner else None,
         project_reason=record.project_reason if is_project_owner else None,
     )
-    db.delete(record)
-    db.add(new_user)
     try:
+        db.delete(record)
+        db.add(new_user)
         db.commit()
     except IntegrityError:
         db.rollback()
@@ -468,7 +468,8 @@ async def resend_code(request: Request, body: ResendCodeRequest, db: Session = D
     db.query(EmailVerification).filter(
         EmailVerification.email == body.email,
         EmailVerification.verified == False,
-    ).delete()
+        EmailVerification.signup_role == signup_role,
+    ).delete(synchronize_session="fetch")
 
     new_code = generate_verification_code()
     new_record = EmailVerification(
@@ -482,11 +483,14 @@ async def resend_code(request: Request, body: ResendCodeRequest, db: Session = D
         expires_at=now_kst() + timedelta(minutes=settings.VERIFICATION_CODE_EXPIRE_MINUTES),
     )
     db.add(new_record)
-    db.commit()
+    db.flush()
 
     sent = await send_verification_email(body.email, new_code)
     if not sent:
+        db.rollback()
         raise HTTPException(status_code=500, detail="인증 이메일 발송에 실패했습니다.")
+
+    db.commit()
 
     return {
         "message": "새 인증 코드가 발송되었습니다.",

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from pathlib import Path
 from core.timezone import now_kst
 from fastapi import APIRouter, Depends, HTTPException, status, Query, Request, UploadFile, File
+from sqlalchemy.exc import IntegrityError
 from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel as _BM
@@ -316,10 +317,7 @@ async def verify_email(request: Request, body: VerifyCodeRequest, db: Session = 
     if existing:
         raise HTTPException(status_code=400, detail="이미 가입된 계정입니다.")
 
-    record.verified = True
-    db.commit()
-
-    # 학생 정보 복원
+    # 학생 정보 복원 (삭제 전에 읽기)
     student_info = {}
     if record.student_info:
         try:
@@ -340,8 +338,13 @@ async def verify_email(request: Request, body: VerifyCodeRequest, db: Session = 
         project_name=record.project_name if is_project_owner else None,
         project_reason=record.project_reason if is_project_owner else None,
     )
+    db.delete(record)
     db.add(new_user)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=400, detail="이미 가입된 계정입니다.")
     db.refresh(new_user)
 
     if is_project_owner:
@@ -442,7 +445,7 @@ async def reject_project_owner(
 @limiter.limit("3/minute")
 async def resend_code(request: Request, body: ResendCodeRequest, db: Session = Depends(get_db)):
     """인증 코드를 재발송합니다."""
-    record = (
+    latest = (
         db.query(EmailVerification)
         .filter(
             EmailVerification.email == body.email,
@@ -452,12 +455,33 @@ async def resend_code(request: Request, body: ResendCodeRequest, db: Session = D
         .first()
     )
 
-    if not record:
+    if not latest:
         raise HTTPException(status_code=400, detail="인증 대기 중인 요청이 없습니다.")
 
+    # 기존 미인증 레코드를 모두 삭제하고 새 레코드 삽입
+    signup_role = latest.signup_role
+    hashed_password = latest.hashed_password
+    student_info = latest.student_info
+    project_name = latest.project_name
+    project_reason = latest.project_reason
+
+    db.query(EmailVerification).filter(
+        EmailVerification.email == body.email,
+        EmailVerification.verified == False,
+    ).delete()
+
     new_code = generate_verification_code()
-    record.code = new_code
-    record.expires_at = now_kst() + timedelta(minutes=settings.VERIFICATION_CODE_EXPIRE_MINUTES)
+    new_record = EmailVerification(
+        email=body.email,
+        hashed_password=hashed_password,
+        code=new_code,
+        student_info=student_info,
+        signup_role=signup_role,
+        project_name=project_name,
+        project_reason=project_reason,
+        expires_at=now_kst() + timedelta(minutes=settings.VERIFICATION_CODE_EXPIRE_MINUTES),
+    )
+    db.add(new_record)
     db.commit()
 
     sent = await send_verification_email(body.email, new_code)

--- a/tests/test_email_verification_reuse.py
+++ b/tests/test_email_verification_reuse.py
@@ -1,0 +1,117 @@
+"""이메일 인증 코드 재사용 취약점 테스트 (issue #56)
+
+SQLite는 timezone-aware datetime을 지원하지 않으므로
+now_kst()를 naive datetime으로 패치해서 테스트합니다.
+"""
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import patch
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from core.database import Base, get_db
+from models.email_verification import EmailVerification
+from models.user import User
+
+TEST_DB_URL = "sqlite:///./test_email_reuse.db"
+engine = create_engine(TEST_DB_URL, connect_args={"check_same_thread": False})
+TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# SQLite 호환 naive datetime 반환
+_naive_now = lambda: datetime.utcnow()
+
+
+def get_test_app():
+    from api.routes import auth
+
+    app = FastAPI()
+    app.include_router(auth.router, prefix="/api/v1/auth")
+
+    def override_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_db
+    return app
+
+
+@pytest.fixture(scope="module")
+def client():
+    Base.metadata.create_all(bind=engine)
+    app = get_test_app()
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+    Base.metadata.drop_all(bind=engine)
+
+
+def _insert_verification(email: str, code: str, signup_role: str = "user") -> None:
+    db = TestSession()
+    try:
+        record = EmailVerification(
+            email=email,
+            hashed_password="$2b$12$fakehashfortest000000000000000000000000000000000000000",
+            code=code,
+            signup_role=signup_role,
+            expires_at=datetime.utcnow() + timedelta(minutes=10),
+        )
+        db.add(record)
+        db.commit()
+    finally:
+        db.close()
+
+
+def _cleanup() -> None:
+    db = TestSession()
+    try:
+        db.query(EmailVerification).delete()
+        db.query(User).delete()
+        db.commit()
+    finally:
+        db.close()
+
+
+class TestEmailVerificationReuse:
+    """이메일 인증 코드 재사용 취약점 픽스 검증"""
+
+    def setup_method(self):
+        _cleanup()
+
+    def test_verify_code_reuse_blocked(self, client):
+        """인증 완료 후 동일 코드로 재요청 시 400 반환 — record 삭제로 차단"""
+        _insert_verification("reuse1@gsm.hs.kr", "111111")
+
+        with patch("api.routes.auth.now_kst", _naive_now):
+            res1 = client.post("/api/v1/auth/verify", json={"email": "reuse1@gsm.hs.kr", "code": "111111"})
+            assert res1.status_code == 200
+
+            res2 = client.post("/api/v1/auth/verify", json={"email": "reuse1@gsm.hs.kr", "code": "111111"})
+            assert res2.status_code == 400
+
+    def test_resend_invalidates_old_code(self, client):
+        """/resend-code 호출 후 이전 코드로 인증 불가"""
+        _insert_verification("reuse2@gsm.hs.kr", "222222")
+
+        with patch("api.routes.auth.now_kst", _naive_now):
+            # 이메일 발송 실패(500)여도 DB 커밋은 완료됨
+            client.post("/api/v1/auth/resend-code", json={"email": "reuse2@gsm.hs.kr"})
+
+            # 이전 코드로 인증 시도 → 최신 레코드와 코드 불일치 → 400
+            res = client.post("/api/v1/auth/verify", json={"email": "reuse2@gsm.hs.kr", "code": "222222"})
+            assert res.status_code == 400
+
+    def test_already_registered_returns_400(self, client):
+        """인증 완료 후 같은 이메일로 재인증 시도 시 400 반환"""
+        _insert_verification("reuse3@gsm.hs.kr", "333333")
+
+        with patch("api.routes.auth.now_kst", _naive_now):
+            # 첫 번째 인증 성공 — User 생성
+            client.post("/api/v1/auth/verify", json={"email": "reuse3@gsm.hs.kr", "code": "333333"})
+
+            # 같은 이메일로 재인증 레코드 삽입 후 시도 → 이미 가입된 계정 → 400
+            _insert_verification("reuse3@gsm.hs.kr", "333333")
+            res = client.post("/api/v1/auth/verify", json={"email": "reuse3@gsm.hs.kr", "code": "333333"})
+            assert res.status_code == 400

--- a/tests/test_email_verification_reuse.py
+++ b/tests/test_email_verification_reuse.py
@@ -19,7 +19,8 @@ engine = create_engine(TEST_DB_URL, connect_args={"check_same_thread": False})
 TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 # SQLite 호환 naive datetime 반환
-_naive_now = lambda: datetime.utcnow()
+def _naive_now():
+    return datetime.utcnow()
 
 
 def get_test_app():


### PR DESCRIPTION
## Summary
- **이메일 인증 완료** 후 `EmailVerification` 레코드 즉시 삭제로 코드 재사용 차단
- **resend_code** 시 기존 미인증 레코드 전체 삭제 후 새 레코드 삽입
- **경합 조건** 방어: `IntegrityError` catch → 400 반환

## Test plan
- [ ] 인증 코드 입력 후 다시 같은 코드로 `/verify` 요청 시 404 반환 확인
- [ ] `/resend-code` 호출 후 이전 코드로 인증 불가 확인
- [ ] 동시 가입 요청 시 하나만 성공하고 나머지는 400 반환 확인

Closes #56