### PR TITLE
fix: FirewallRule 스키마 action/type/proto Literal 타입 제한 및 dport 검증

### DIFF
--- a/schemas/fw_schema.py
+++ b/schemas/fw_schema.py
@@ -1,6 +1,7 @@
 import ipaddress
+import re
 from pydantic import BaseModel, field_validator, Field
-from typing import Optional
+from typing import Literal, Optional
 
 
 class VmPortCreate(BaseModel):
@@ -30,11 +31,21 @@ class VmPortCreate(BaseModel):
 
 class FirewallRule(BaseModel):
     """방화벽 규칙 생성/수정 모델"""
-    action: str = "ACCEPT"  # ACCEPT, DROP, REJECT
-    type: str = "in"        # in (인바운드), out (아웃바운드)
-    proto: Optional[str] = "tcp" # tcp, udp, icmp 등
-    dport: Optional[str] = None  # 목적지 포트 (예: "80", "443", "22")
-    dest: Optional[str] = None   # 목적지 IP
-    source: Optional[str] = None # 출발지 IP (예: 192.168.1.0/24)
-    enable: int = 1         # 1: 활성, 0: 비활성
+    action: Literal["ACCEPT", "DROP", "REJECT"] = "ACCEPT"
+    type: Literal["in", "out"] = "in"
+    proto: Optional[Literal["tcp", "udp", "icmp"]] = "tcp"
+    dport: Optional[str] = None
+    dest: Optional[str] = None
+    source: Optional[str] = None
+    enable: int = 1
     comment: Optional[str] = None
+
+    @field_validator("dport")
+    @classmethod
+    def validate_dport(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        pattern = r"^\d{1,5}([:,]\d{1,5})*$"
+        if not re.match(pattern, v):
+            raise ValueError("포트는 숫자, 콤마, 콜론으로 구성된 형식만 허용됩니다")
+        return v


### PR DESCRIPTION
## Summary
- `FirewallRule.action`을 `Literal["ACCEPT","DROP","REJECT"]`로 제한
- `FirewallRule.type`을 `Literal["in","out"]`으로 제한
- `FirewallRule.proto`를 `Literal["tcp","udp","icmp"]`로 제한
- `dport` 필드에 포트 형식 `field_validator` 추가

## Test plan
- [ ] 허용되지 않는 action 값("ALLOW" 등) 전송 시 422 반환 확인
- [ ] 잘못된 dport 형식("abc") 전송 시 422 반환 확인

Closes #62