### PR TITLE
fix: vmcontrol, firewall 엔드포인트 HTTP 상태 코드 명시

### DIFF
--- a/api/routes/firewall.py
+++ b/api/routes/firewall.py
@@ -1,5 +1,5 @@
 import logging
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException, Depends, status
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 from schemas.fw_schema import FirewallRule, VmPortCreate
@@ -33,7 +33,7 @@ async def get_firewall_rules(
         raise HTTPException(status_code=500, detail="방화벽 규칙 조회에 실패했습니다.")
 
 
-@router.post("/{vmid}/rules")
+@router.post("/{vmid}/rules", status_code=status.HTTP_201_CREATED)
 async def add_firewall_rule(
     vmid: int,
     rule: FirewallRule,
@@ -57,7 +57,7 @@ async def add_firewall_rule(
         raise HTTPException(status_code=500, detail="방화벽 규칙 추가에 실패했습니다.")
 
 
-@router.delete("/{vmid}/rules/{pos}")
+@router.delete("/{vmid}/rules/{pos}", status_code=status.HTTP_200_OK)
 async def delete_firewall_rule(
     vmid: int,
     pos: int,
@@ -236,7 +236,7 @@ async def restore_default_ports(
     return {"restored": len(missing)}
 
 
-@router.delete("/{node}/{vmid}/ports/{port_id}")
+@router.delete("/{node}/{vmid}/ports/{port_id}", status_code=status.HTTP_200_OK)
 async def delete_custom_port(
     node: str,
     vmid: int,

--- a/api/routes/vmcontrol.py
+++ b/api/routes/vmcontrol.py
@@ -484,7 +484,7 @@ async def list_snapshots(
         raise HTTPException(status_code=500, detail="서버 오류가 발생했습니다.")
 
 
-@router.post("/{node}/vms/{vmid}/snapshots")
+@router.post("/{node}/vms/{vmid}/snapshots", status_code=status.HTTP_200_OK)
 async def create_snapshot(
     node: str,
     vmid: int,
@@ -547,7 +547,7 @@ async def rollback_snapshot(
         raise HTTPException(status_code=500, detail="스냅샷 복원에 실패했습니다.")
 
 
-@router.delete("/{node}/vms/{vmid}/snapshots/{snapname}")
+@router.delete("/{node}/vms/{vmid}/snapshots/{snapname}", status_code=status.HTTP_200_OK)
 async def delete_snapshot(
     node: str,
     vmid: int,
@@ -593,7 +593,7 @@ async def toggle_auto_snapshot(
     return {"enabled": bool(vm_record.auto_snapshot)}
 
 
-@router.delete("/{node}/vms/{vmid}")
+@router.delete("/{node}/vms/{vmid}", status_code=status.HTTP_200_OK)
 @limiter.limit("5/minute")
 async def delete_vm_endpoint(
     request: Request,


### PR DESCRIPTION
## Summary
- `vmcontrol.py` DELETE 엔드포인트(스냅샷 삭제, VM 삭제)에 `status_code=HTTP_200_OK` 명시
- `vmcontrol.py` POST 스냅샷 생성 엔드포인트에 `status_code=HTTP_200_OK` 명시
- `firewall.py` POST(방화벽 규칙 추가 → 201), DELETE(규칙/포트 삭제 → 200) 상태 코드 명시
- `firewall.py`에 누락된 `from fastapi import status` 추가
- REST 컨벤션 준수 및 코드 의도 명확화

## Test plan
- [ ] DELETE /snapshots/{name} 응답 상태 코드 200 확인
- [ ] POST /snapshots 응답 상태 코드 200 확인
- [ ] DELETE /{node}/vms/{vmid} 응답 상태 코드 200 확인
- [ ] POST /rules 응답 상태 코드 201 확인
- [ ] DELETE /rules/{pos} 응답 상태 코드 200 확인
- [ ] DELETE /ports/{port_id} 응답 상태 코드 200 확인

Closes #61