### PR TITLE
fix: VMAction Literal 타입 적용, any 타입 수정, Proxmox 예외 세분화

### DIFF
--- a/api/routes/vmcontrol.py
+++ b/api/routes/vmcontrol.py
@@ -4,6 +4,7 @@ import logging
 import re
 from datetime import timedelta
 from core.timezone import now_kst
+from typing import Any
 from fastapi import APIRouter, HTTPException, status, Depends, Request
 from sqlalchemy.orm import Session
 from schemas.vm_schema import VMAction, VMCreate, VMResize
@@ -168,7 +169,7 @@ async def get_my_vms(
         server_vms[vm.server_id].append(vm)
 
     result = []
-    proxmox_cache: dict[int, any] = {}
+    proxmox_cache: dict[int, Any] = {}
 
     for vm in user_vms:
         info = {

--- a/schemas/vm_schema.py
+++ b/schemas/vm_schema.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Optional
+from typing import Literal, Optional
 from enum import Enum
 
 class VMTier(str, Enum):
@@ -16,7 +16,7 @@ class VMOs(str, Enum):
 
 class VMAction(BaseModel):
     """VM/컨테이너 제어 액션 모델"""
-    action: str  # "start", "stop", "shutdown", "reboot" 중 하나
+    action: Literal["start", "stop", "shutdown", "reboot"]
 
 class VMResize(BaseModel):
     """VM 사양 변경 요청 모델 (핫플러그)"""

--- a/services/proxmox_client.py
+++ b/services/proxmox_client.py
@@ -12,6 +12,26 @@ _cache_lock = threading.Lock()
 _CACHE_TTL = 300  # 5분
 
 
+def raise_proxmox_http_exception(e: Exception, context: str = "") -> None:
+    """
+    Proxmox API 호출 중 발생한 예외를 메시지 기반으로 분류하여 적절한 HTTPException을 발생시킵니다.
+    - "Permission denied" → 403
+    - "does not exist" / "not found" → 404
+    - 타임아웃 관련 → 503
+    - 그 외 → 500
+    """
+    msg = str(e).lower()
+    if context:
+        logger.error(f"[proxmox] {context}: {e}")
+    if "permission denied" in msg:
+        raise HTTPException(status_code=403, detail="Proxmox 권한이 없습니다.")
+    if "does not exist" in msg or "not found" in msg:
+        raise HTTPException(status_code=404, detail="요청한 리소스를 찾을 수 없습니다.")
+    if "timeout" in msg or "timed out" in msg or "connection timed out" in msg:
+        raise HTTPException(status_code=503, detail="Proxmox 서버 응답이 지연되고 있습니다. 잠시 후 다시 시도해주세요.")
+    raise HTTPException(status_code=500, detail="서버 오류가 발생했습니다.")
+
+
 def get_proxmox_for_server(server):
     """
     서버(Server) 모델 기반으로 Proxmox에 연결합니다.
@@ -39,6 +59,6 @@ def get_proxmox_for_server(server):
     except Exception as e:
         logger.error(f"Proxmox 연결 실패 ({server.name}): {e}")
         raise HTTPException(
-            status_code=500,
+            status_code=503,
             detail="서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요."
         )


### PR DESCRIPTION
## Summary
- **`VMAction.action`**을 `Literal["start","stop","shutdown","reboot"]`로 변경하여 스키마 레벨 검증 강화
- **`vmcontrol.py`**의 `dict[int, any]` → `dict[int, Any]`로 타입 힌트 수정 (`typing.Any` import)
- **`proxmox_client.py`** 예외를 메시지 기반으로 분류하여 적절한 HTTP 상태 코드 반환 (`raise_proxmox_http_exception` 헬퍼 추가, 연결 실패는 503으로 통일)

## Test plan
- [ ] 유효하지 않은 `action` 값 전송 시 422 Validation Error 반환 확인
- [ ] Proxmox 연결 불가 시 503 반환 확인
- [ ] `raise_proxmox_http_exception` 호출 시 "Permission denied" → 403, "does not exist" → 404, 타임아웃 → 503, 그 외 → 500 확인

Closes #60