### PR TITLE
fix: 모니터링 서버 통계 엔드포인트 역할 기반 접근 제어 적용

### DIFF
--- a/api/routes/monitoring.py
+++ b/api/routes/monitoring.py
@@ -26,7 +26,7 @@ async def get_system_stats(
             db.query(Vm.server_id)
             .filter(Vm.owner_id == current_user.id)
             .distinct()
-            .subquery()
+            .scalar_subquery()
         )
         query = query.filter(Server.id.in_(user_server_ids))
     servers = query.all()

--- a/api/routes/monitoring.py
+++ b/api/routes/monitoring.py
@@ -4,7 +4,8 @@ from sqlalchemy.orm import Session
 from services.proxmox_client import get_proxmox_for_server
 from core.database import get_db
 from models.server import Server
-from models.user import User
+from models.user import User, UserRole
+from models.vm import Vm
 from api.dependencies import get_current_user
 
 logger = logging.getLogger(__name__)
@@ -16,10 +17,23 @@ async def get_system_stats(
     current_user: User = Depends(get_current_user)
 ):
     """
-    플랫폼에 등록된 모든 활성 서버(Node)의 리소스 취합 조회 (USER/ADMIN 모두 가능)
-    VM 생성 전 사용자가 직접 노드별 사용률을 확인하기 위해 사용됩니다.
+    활성 서버(Node)의 리소스 취합 조회.
+    ADMIN: 전체 노드 조회 / USER: 본인 VM이 위치한 노드만 조회
     """
-    servers = db.query(Server).filter(Server.is_active == True).all()
+    if current_user.role == UserRole.ADMIN:
+        servers = db.query(Server).filter(Server.is_active == True).all()
+    else:
+        user_server_ids = (
+            db.query(Vm.server_id)
+            .filter(Vm.owner_id == current_user.id)
+            .distinct()
+            .subquery()
+        )
+        servers = (
+            db.query(Server)
+            .filter(Server.id.in_(user_server_ids), Server.is_active == True)
+            .all()
+        )
     if not servers:
         return {"message": "등록된 활성 서버가 없습니다.", "stats": {}}
         

--- a/api/routes/monitoring.py
+++ b/api/routes/monitoring.py
@@ -11,62 +11,58 @@ from api.dependencies import get_current_user
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
+
 @router.get("/nodes")
 async def get_system_stats(
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    db: Session = Depends(get_db), current_user: User = Depends(get_current_user)
 ):
     """
     활성 서버(Node)의 리소스 취합 조회.
-    ADMIN: 전체 노드 조회 / USER: 본인 VM이 위치한 노드만 조회
+    ADMIN/PROJECT_OWNER: 전체 노드 조회 / USER: 본인 VM이 위치한 노드만 조회
     """
-    if current_user.role == UserRole.ADMIN:
-        servers = db.query(Server).filter(Server.is_active == True).all()
-    else:
+    query = db.query(Server).filter(Server.is_active == True)
+    if current_user.role not in (UserRole.ADMIN, UserRole.PROJECT_OWNER):
         user_server_ids = (
             db.query(Vm.server_id)
             .filter(Vm.owner_id == current_user.id)
             .distinct()
             .subquery()
         )
-        servers = (
-            db.query(Server)
-            .filter(Server.id.in_(user_server_ids), Server.is_active == True)
-            .all()
-        )
+        query = query.filter(Server.id.in_(user_server_ids))
+    servers = query.all()
     if not servers:
         return {"message": "등록된 활성 서버가 없습니다.", "stats": {}}
-        
+
     all_stats = {}
-    
+
     for server in servers:
         try:
             proxmox = get_proxmox_for_server(server)
-            
+
             # 각 노드의 상태 조회
             node_status = proxmox.nodes(server.name).status.get()
-            
+
             # 데이터 가공
-            cpu_usage = node_status.get('cpu', 0) * 100 # 소수점(0.05)을 백분율(5%)로
-            
-            memory = node_status.get('memory', {})
-            total_ram_gb = memory.get('total', 0) / (1024**3)
-            used_ram_gb = memory.get('used', 0) / (1024**3)
+            cpu_usage = node_status.get("cpu", 0) * 100  # 소수점(0.05)을 백분율(5%)로
+
+            memory = node_status.get("memory", {})
+            total_ram_gb = memory.get("total", 0) / (1024**3)
+            used_ram_gb = memory.get("used", 0) / (1024**3)
             free_ram_gb = total_ram_gb - used_ram_gb
-            
+
             all_stats[server.name] = {
                 "status": "online",
                 "cpu_usage_percent": round(cpu_usage, 1),
                 "ram_total_gb": round(total_ram_gb, 1),
                 "ram_used_gb": round(used_ram_gb, 1),
                 "ram_free_gb": round(free_ram_gb, 1),
-                "uptime_seconds": node_status.get('uptime', 0)
+                "uptime_seconds": node_status.get("uptime", 0),
             }
         except Exception as e:
             logger.error(f"[monitoring] 노드 {server.name} 조회 실패: {e}")
             all_stats[server.name] = {
                 "status": "offline",
-                "error": "노드에 연결할 수 없습니다."
+                "error": "노드에 연결할 수 없습니다.",
             }
-            
+
     return {"stats": all_stats}

--- a/tests/test_monitoring_rbac.py
+++ b/tests/test_monitoring_rbac.py
@@ -1,0 +1,172 @@
+"""
+모니터링 RBAC 테스트 (MONITORING-TC-01 ~ 04)
+Proxmox 호출은 mock 처리, DB는 SQLite 인메모리 사용
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from core.database import Base, get_db
+from api.dependencies import get_current_user
+from models.user import User, UserRole
+from models.server import Server
+from models.vm import Vm
+
+TEST_DB_URL = "sqlite:///./test_monitoring.db"
+engine = create_engine(TEST_DB_URL, connect_args={"check_same_thread": False})
+TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+MOCK_NODE_STATUS = {
+    "cpu": 0.1,
+    "memory": {"total": 8 * 1024**3, "used": 2 * 1024**3},
+    "uptime": 3600,
+}
+
+
+def get_test_app():
+    from api.routes import monitoring
+
+    test_app = FastAPI()
+    test_app.include_router(monitoring.router, prefix="/api/v1/monitoring")
+
+    def override_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    test_app.dependency_overrides[get_db] = override_db
+    return test_app
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def db():
+    session = TestSession()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+
+
+@pytest.fixture
+def server1(db):
+    s = Server(
+        name="node1", ip_address="192.168.0.1", port=8006,
+        api_user="root@pam", api_password="pass", is_active=True,
+    )
+    db.add(s)
+    db.commit()
+    db.refresh(s)
+    return s
+
+
+@pytest.fixture
+def server2(db):
+    s = Server(
+        name="node2", ip_address="192.168.0.2", port=8006,
+        api_user="root@pam", api_password="pass", is_active=True,
+    )
+    db.add(s)
+    db.commit()
+    db.refresh(s)
+    return s
+
+
+@pytest.fixture
+def admin_user(db):
+    u = User(email="admin@gsm.hs.kr", hashed_password="h", role=UserRole.ADMIN, is_active=True)
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+@pytest.fixture
+def project_owner(db):
+    u = User(email="po@gsm.hs.kr", hashed_password="h", role=UserRole.PROJECT_OWNER, is_active=True)
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+@pytest.fixture
+def regular_user(db):
+    u = User(email="user@gsm.hs.kr", hashed_password="h", role=UserRole.USER, is_active=True)
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def make_client_with_user(user):
+    app = get_test_app()
+    app.dependency_overrides[get_current_user] = lambda: user
+    mock_px = MagicMock()
+    mock_px.nodes.return_value.status.get.return_value = MOCK_NODE_STATUS
+    return app, mock_px
+
+
+class TestMonitoringRBAC:
+    """MONITORING-TC-01~04: GET /monitoring/nodes RBAC 분기 검증"""
+
+    def test_admin_sees_all_nodes(self, db, server1, server2, admin_user):
+        """TC-01: ADMIN은 모든 활성 노드를 조회한다"""
+        app, mock_px = make_client_with_user(admin_user)
+        with patch("api.routes.monitoring.get_proxmox_for_server", return_value=mock_px):
+            with TestClient(app) as c:
+                res = c.get("/api/v1/monitoring/nodes")
+        assert res.status_code == 200
+        stats = res.json()["stats"]
+        assert "node1" in stats
+        assert "node2" in stats
+
+    def test_project_owner_sees_all_nodes(self, db, server1, server2, project_owner):
+        """TC-02: PROJECT_OWNER는 ADMIN과 동일하게 모든 활성 노드를 조회한다"""
+        app, mock_px = make_client_with_user(project_owner)
+        with patch("api.routes.monitoring.get_proxmox_for_server", return_value=mock_px):
+            with TestClient(app) as c:
+                res = c.get("/api/v1/monitoring/nodes")
+        assert res.status_code == 200
+        stats = res.json()["stats"]
+        assert "node1" in stats
+        assert "node2" in stats
+
+    def test_user_sees_only_own_vm_nodes(self, db, server1, server2, regular_user):
+        """TC-03: USER는 본인 VM이 위치한 노드만 조회된다"""
+        vm = Vm(
+            hypervisor_vmid=100, name="vm-test",
+            server_id=server1.id, owner_id=regular_user.id,
+        )
+        db.add(vm)
+        db.commit()
+
+        app, mock_px = make_client_with_user(regular_user)
+        with patch("api.routes.monitoring.get_proxmox_for_server", return_value=mock_px):
+            with TestClient(app) as c:
+                res = c.get("/api/v1/monitoring/nodes")
+        assert res.status_code == 200
+        stats = res.json()["stats"]
+        assert "node1" in stats
+        assert "node2" not in stats
+
+    def test_user_with_no_vms_gets_empty_stats(self, db, server1, server2, regular_user):
+        """TC-04: VM이 없는 USER 요청 시 빈 stats 반환"""
+        app, _ = make_client_with_user(regular_user)
+        with TestClient(app) as c:
+            res = c.get("/api/v1/monitoring/nodes")
+        assert res.status_code == 200
+        data = res.json()
+        assert data.get("stats") == {}


### PR DESCRIPTION
## Summary
- `GET /monitoring/nodes` 엔드포인트에 역할 기반 접근 제어 적용
- **ADMIN**: 전체 활성 노드 통계 조회
- **USER**: 본인 VM이 위치한 노드만 조회 (`Vm.owner_id` → `Vm.server_id` 서브쿼리)
- `UserRole`, `Vm` 모델 추가 임포트

## Test plan
- [ ] ADMIN 계정으로 `GET /monitoring/nodes` 요청 시 전체 노드 통계 반환 확인
- [ ] USER 계정으로 자신의 VM이 없는 노드 통계가 응답에서 제외되는지 확인
- [ ] USER 계정으로 자신의 VM이 있는 노드 통계는 정상 반환되는지 확인
- [ ] VM이 없는 USER가 요청 시 빈 stats(`{}`) 반환 확인

Closes #64