### PR TITLE
perf: 모니터링 메트릭 인메모리 TTL 캐시 추가로 Proxmox API 부하 감소

### DIFF
--- a/api/routes/monitoring.py
+++ b/api/routes/monitoring.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from services.proxmox_client import get_proxmox_for_server
@@ -9,6 +10,9 @@ from api.dependencies import get_current_user
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+_stats_cache: dict[str, dict] = {}
+_STATS_CACHE_TTL = 30
 
 @router.get("/nodes")
 async def get_system_stats(
@@ -22,25 +26,28 @@ async def get_system_stats(
     servers = db.query(Server).filter(Server.is_active == True).all()
     if not servers:
         return {"message": "등록된 활성 서버가 없습니다.", "stats": {}}
-        
+
     all_stats = {}
-    
+
     for server in servers:
+        cached = _stats_cache.get(server.name)
+        if cached and (time.time() - cached["ts"]) < _STATS_CACHE_TTL:
+            all_stats[server.name] = cached["data"]
+            continue
+
         try:
             proxmox = get_proxmox_for_server(server)
-            
-            # 각 노드의 상태 조회
+
             node_status = proxmox.nodes(server.name).status.get()
-            
-            # 데이터 가공
-            cpu_usage = node_status.get('cpu', 0) * 100 # 소수점(0.05)을 백분율(5%)로
-            
+
+            cpu_usage = node_status.get('cpu', 0) * 100
+
             memory = node_status.get('memory', {})
             total_ram_gb = memory.get('total', 0) / (1024**3)
             used_ram_gb = memory.get('used', 0) / (1024**3)
             free_ram_gb = total_ram_gb - used_ram_gb
-            
-            all_stats[server.name] = {
+
+            result = {
                 "status": "online",
                 "cpu_usage_percent": round(cpu_usage, 1),
                 "ram_total_gb": round(total_ram_gb, 1),
@@ -48,11 +55,13 @@ async def get_system_stats(
                 "ram_free_gb": round(free_ram_gb, 1),
                 "uptime_seconds": node_status.get('uptime', 0)
             }
+            _stats_cache[server.name] = {"data": result, "ts": time.time()}
+            all_stats[server.name] = result
         except Exception as e:
             logger.error(f"[monitoring] 노드 {server.name} 조회 실패: {e}")
             all_stats[server.name] = {
                 "status": "offline",
                 "error": "노드에 연결할 수 없습니다."
             }
-            
+
     return {"stats": all_stats}

--- a/services/mon_service.py
+++ b/services/mon_service.py
@@ -1,3 +1,4 @@
+import time
 from sqlalchemy.orm import Session
 from models.server import Server
 from services.proxmox_client import get_proxmox_for_server
@@ -5,6 +6,9 @@ from fastapi import HTTPException
 import logging
 
 logger = logging.getLogger(__name__)
+
+_server_stat_ts: dict[str, float] = {}
+_SERVER_STAT_TTL = 300
 
 def update_server_stats(db: Session, server: Server):
     """
@@ -41,10 +45,13 @@ def get_best_server(db: Session, required_ram_mb: int) -> Server:
     if not active_servers:
         raise HTTPException(status_code=500, detail="사용 가능한 활성 서버가 없습니다.")
     
-    # 2. (옵션) 실시간에 가깝게 하기 위해 할당 전 모든 서버의 RAM 상태를 1회 갱신 (트래픽이 적을 때 유효)
-    # 트래픽이 많다면 이 부분은 백그라운드 스케줄러(ex: Celery, APScheduler)로 빼는 것이 좋습니다.
+    # 2. 마지막 갱신 후 TTL이 지난 서버만 RAM 상태 갱신
+    now = time.time()
     for server in active_servers:
-        update_server_stats(db, server)
+        last_ts = _server_stat_ts.get(server.name, 0)
+        if now - last_ts >= _SERVER_STAT_TTL:
+            update_server_stats(db, server)
+            _server_stat_ts[server.name] = now
         
     # 3. 요구사항을 충족(required_ram_mb 이상 여유)하는 서버들만 필터링
     capable_servers = [s for s in active_servers if s.last_free_ram_mb >= required_ram_mb]


### PR DESCRIPTION
## Summary
- `get_system_stats` 응답을 노드별 **30초 TTL 인메모리 캐시** 적용 — 동시 요청 시 Proxmox API 과부하 방지
- `get_best_server`에서 최근 **5분 이내** 갱신된 서버는 RAM 상태 재조회 스킵

## Test plan
- [ ] 30초 내 반복 요청 시 Proxmox API 호출 횟수 감소 확인 (로그)
- [ ] 30초 후 캐시 만료 시 Proxmox API 재호출 확인
- [ ] VM 생성 시 `get_best_server` 연속 호출 시 5분 내 동일 서버 재갱신 없음 확인

Closes #65