### PR TITLE
fix: 인스턴스 탭 setTimeout cleanup 추가 및 useEffect 의존성 최적화

### DIFF
--- a/frontend/components/instances/tabs/firewall-tab.tsx
+++ b/frontend/components/instances/tabs/firewall-tab.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useRef } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import {
@@ -26,6 +26,7 @@ export function FirewallTab({
   ports?: PortInfo[]
 }) {
   const [copiedId, setCopiedId] = useState<number | null>(null)
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [customPorts, setCustomPorts] = useState<VmPort[]>([])
   const [loading, setLoading] = useState(true)
   const [portsOpen, setPortsOpen] = useState(true)
@@ -59,11 +60,18 @@ export function FirewallTab({
     fetchPorts()
   }, [fetchPorts])
 
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
+    }
+  }, [])
+
   const handleCopy = async (text: string, id: number) => {
     try {
       await navigator.clipboard.writeText(text)
       setCopiedId(id)
-      setTimeout(() => setCopiedId(null), 1500)
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
+      copyTimerRef.current = setTimeout(() => setCopiedId(null), 1500)
     } catch {
       // 복사 실패 시 조용히 무시
     }

--- a/frontend/components/instances/tabs/metrics-tab.tsx
+++ b/frontend/components/instances/tabs/metrics-tab.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState, useCallback } from "react"
+import { useEffect, useState, useCallback, useRef } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   Select,
@@ -128,7 +128,7 @@ export function MetricsTab({ instance }: { instance: Instance }) {
   const [metrics, setMetrics] = useState<VmMetricPoint[]>([])
   const [error, setError] = useState<string | null>(null)
   const { addNotification } = useNotifications()
-  const [alertSent, setAlertSent] = useState<{ cpu: boolean; mem: boolean }>({ cpu: false, mem: false })
+  const alertSentRef = useRef<{ cpu: boolean; mem: boolean }>({ cpu: false, mem: false })
 
   const fetchMetrics = useCallback(async () => {
     if (!instance.node || !instance.vmid) return
@@ -147,24 +147,24 @@ export function MetricsTab({ instance }: { instance: Instance }) {
       // 리소스 90% 초과 경고
       const latest = filtered.length > 0 ? filtered[filtered.length - 1] : null
       if (latest) {
-        if (latest.cpu > 90 && !alertSent.cpu) {
+        if (latest.cpu > 90 && !alertSentRef.current.cpu) {
           addNotification("error", `${instance.name}: CPU 사용량이 ${latest.cpu}%에 도달했습니다.`)
-          setAlertSent((prev) => ({ ...prev, cpu: true }))
+          alertSentRef.current.cpu = true
         } else if (latest.cpu <= 90) {
-          setAlertSent((prev) => ({ ...prev, cpu: false }))
+          alertSentRef.current.cpu = false
         }
-        if (latest.mem_percent > 90 && !alertSent.mem) {
+        if (latest.mem_percent > 90 && !alertSentRef.current.mem) {
           addNotification("error", `${instance.name}: 메모리 사용량이 ${latest.mem_percent}%에 도달했습니다.`)
-          setAlertSent((prev) => ({ ...prev, mem: true }))
+          alertSentRef.current.mem = true
         } else if (latest.mem_percent <= 90) {
-          setAlertSent((prev) => ({ ...prev, mem: false }))
+          alertSentRef.current.mem = false
         }
       }
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : "메트릭 조회 실패"
       setError(msg)
     }
-  }, [instance.node, instance.vmid, range, alertSent, addNotification, instance.name])
+  }, [instance.node, instance.vmid, range, addNotification, instance.name])
 
   useEffect(() => {
     if (!isRunning) return

--- a/frontend/components/instances/tabs/overview-tab.tsx
+++ b/frontend/components/instances/tabs/overview-tab.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect, useRef } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Cpu, HardDrive, MemoryStick, Clock, Monitor, Calendar, User, Lock, Copy, Check, Key, Timer, Eye, EyeOff, Terminal } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -29,13 +29,19 @@ export function OverviewTab({
 }) {
   const [showPassword, setShowPassword] = useState(false)
   const [copiedField, setCopiedField] = useState<string | null>(null)
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
+    }
+  }, [])
 
   const handleCopy = (text: string, field: string) => {
     navigator.clipboard.writeText(text)
-    setTimeout(() => {
-      setCopiedField(field)
-      setTimeout(() => setCopiedField(null), 1500)
-    }, 100)
+    setCopiedField(field)
+    if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
+    copyTimerRef.current = setTimeout(() => setCopiedField(null), 1500)
   }
 
   const createdDate = instance.created


### PR DESCRIPTION
## Summary
- `firewall-tab`, `overview-tab`: 클립보드 복사 `setTimeout`을 `useRef`로 관리하여 언마운트 시 cleanup
- `metrics-tab`: `alertSent`를 `useRef`로 전환하여 `fetchMetrics` 불필요한 재생성 방지

## Test plan
- [ ] 인스턴스 탭 간 빠른 전환 시 React 언마운트 경고 없음 확인
- [ ] 메트릭 폴링 인터벌이 알림 전송 후 리셋되지 않음 확인

Closes #67