### PR TITLE
merge: develop → main (#70, #81)

### DIFF
--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -483,14 +483,11 @@ async def resend_code(request: Request, body: ResendCodeRequest, db: Session = D
         expires_at=now_kst() + timedelta(minutes=settings.VERIFICATION_CODE_EXPIRE_MINUTES),
     )
     db.add(new_record)
-    db.flush()
+    db.commit()
 
     sent = await send_verification_email(body.email, new_code)
     if not sent:
-        db.rollback()
         raise HTTPException(status_code=500, detail="인증 이메일 발송에 실패했습니다.")
-
-    db.commit()
 
     return {
         "message": "새 인증 코드가 발송되었습니다.",

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -482,8 +482,12 @@ async def resend_code(request: Request, body: ResendCodeRequest, db: Session = D
         project_reason=project_reason,
         expires_at=now_kst() + timedelta(minutes=settings.VERIFICATION_CODE_EXPIRE_MINUTES),
     )
-    db.add(new_record)
-    db.commit()
+    try:
+        db.add(new_record)
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=400, detail="잠시 후 다시 시도해주세요.")
 
     sent = await send_verification_email(body.email, new_code)
     if not sent:

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -338,9 +338,9 @@ async def verify_email(request: Request, body: VerifyCodeRequest, db: Session = 
         project_name=record.project_name if is_project_owner else None,
         project_reason=record.project_reason if is_project_owner else None,
     )
-    db.delete(record)
-    db.add(new_user)
     try:
+        db.delete(record)
+        db.add(new_user)
         db.commit()
     except IntegrityError:
         db.rollback()
@@ -468,7 +468,8 @@ async def resend_code(request: Request, body: ResendCodeRequest, db: Session = D
     db.query(EmailVerification).filter(
         EmailVerification.email == body.email,
         EmailVerification.verified == False,
-    ).delete()
+        EmailVerification.signup_role == signup_role,
+    ).delete(synchronize_session="fetch")
 
     new_code = generate_verification_code()
     new_record = EmailVerification(
@@ -482,11 +483,14 @@ async def resend_code(request: Request, body: ResendCodeRequest, db: Session = D
         expires_at=now_kst() + timedelta(minutes=settings.VERIFICATION_CODE_EXPIRE_MINUTES),
     )
     db.add(new_record)
-    db.commit()
+    db.flush()
 
     sent = await send_verification_email(body.email, new_code)
     if not sent:
+        db.rollback()
         raise HTTPException(status_code=500, detail="인증 이메일 발송에 실패했습니다.")
+
+    db.commit()
 
     return {
         "message": "새 인증 코드가 발송되었습니다.",

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from pathlib import Path
 from core.timezone import now_kst
 from fastapi import APIRouter, Depends, HTTPException, status, Query, Request, UploadFile, File
+from sqlalchemy.exc import IntegrityError
 from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel as _BM
@@ -316,10 +317,7 @@ async def verify_email(request: Request, body: VerifyCodeRequest, db: Session = 
     if existing:
         raise HTTPException(status_code=400, detail="이미 가입된 계정입니다.")
 
-    record.verified = True
-    db.commit()
-
-    # 학생 정보 복원
+    # 학생 정보 복원 (삭제 전에 읽기)
     student_info = {}
     if record.student_info:
         try:
@@ -340,8 +338,13 @@ async def verify_email(request: Request, body: VerifyCodeRequest, db: Session = 
         project_name=record.project_name if is_project_owner else None,
         project_reason=record.project_reason if is_project_owner else None,
     )
+    db.delete(record)
     db.add(new_user)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=400, detail="이미 가입된 계정입니다.")
     db.refresh(new_user)
 
     if is_project_owner:
@@ -442,7 +445,7 @@ async def reject_project_owner(
 @limiter.limit("3/minute")
 async def resend_code(request: Request, body: ResendCodeRequest, db: Session = Depends(get_db)):
     """인증 코드를 재발송합니다."""
-    record = (
+    latest = (
         db.query(EmailVerification)
         .filter(
             EmailVerification.email == body.email,
@@ -452,12 +455,33 @@ async def resend_code(request: Request, body: ResendCodeRequest, db: Session = D
         .first()
     )
 
-    if not record:
+    if not latest:
         raise HTTPException(status_code=400, detail="인증 대기 중인 요청이 없습니다.")
 
+    # 기존 미인증 레코드를 모두 삭제하고 새 레코드 삽입
+    signup_role = latest.signup_role
+    hashed_password = latest.hashed_password
+    student_info = latest.student_info
+    project_name = latest.project_name
+    project_reason = latest.project_reason
+
+    db.query(EmailVerification).filter(
+        EmailVerification.email == body.email,
+        EmailVerification.verified == False,
+    ).delete()
+
     new_code = generate_verification_code()
-    record.code = new_code
-    record.expires_at = now_kst() + timedelta(minutes=settings.VERIFICATION_CODE_EXPIRE_MINUTES)
+    new_record = EmailVerification(
+        email=body.email,
+        hashed_password=hashed_password,
+        code=new_code,
+        student_info=student_info,
+        signup_role=signup_role,
+        project_name=project_name,
+        project_reason=project_reason,
+        expires_at=now_kst() + timedelta(minutes=settings.VERIFICATION_CODE_EXPIRE_MINUTES),
+    )
+    db.add(new_record)
     db.commit()
 
     sent = await send_verification_email(body.email, new_code)

--- a/api/routes/vmcontrol.py
+++ b/api/routes/vmcontrol.py
@@ -1,12 +1,11 @@
 import asyncio
 import base64
 import logging
-import re
 from datetime import timedelta
 from core.timezone import now_kst
 from fastapi import APIRouter, HTTPException, status, Depends, Request
 from sqlalchemy.orm import Session
-from schemas.vm_schema import VMAction, VMCreate, VMResize
+from schemas.vm_schema import VMAction, VMCreate, VMResize, SnapshotCreateRequest
 from services.proxmox_client import get_proxmox_for_server
 from models.server import Server
 from services.vm_service import create_vm, delete_vm
@@ -488,7 +487,7 @@ async def list_snapshots(
 async def create_snapshot(
     node: str,
     vmid: int,
-    body: dict,
+    body: SnapshotCreateRequest,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -497,13 +496,7 @@ async def create_snapshot(
     node = vm_record.server.name
     proxmox = get_proxmox_for_server(vm_record.server)
 
-    snap_name = body.get("name", "").strip()
-    if not snap_name:
-        raise HTTPException(status_code=400, detail="스냅샷 이름을 입력해주세요.")
-    if len(snap_name) > 40:
-        raise HTTPException(status_code=400, detail="스냅샷 이름은 40자 이내로 입력해주세요.")
-    if not re.match(r'^[a-zA-Z0-9가-힣_-]+$', snap_name):
-        raise HTTPException(status_code=400, detail="스냅샷 이름은 영문, 숫자, 한글, _, -만 사용할 수 있습니다.")
+    snap_name = body.name
 
     try:
         existing = proxmox.nodes(node).qemu(vmid).snapshot.get()
@@ -516,7 +509,7 @@ async def create_snapshot(
 
         result = proxmox.nodes(node).qemu(vmid).snapshot.post(
             snapname=snap_name,
-            description=body.get("description", ""),
+            description=body.description or "",
             vmstate=0,  # RAM 상태 저장 안 함 (디스크만)
         )
         return {"success": True, "message": f"스냅샷 '{snap_name}'이(가) 생성되었습니다.", "task": result}

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
 from api.routes import vmcontrol, firewall, auth, monitoring, network, notifications, oauth, faq
 from core.config import settings
+from sqlalchemy.orm import joinedload
 from core.database import Base, engine, SessionLocal
 from core.init_servers import sync_servers
 from models.vm import Vm
@@ -140,11 +141,28 @@ async def _iptables_weekly_backup_loop():
 AUTO_SNAP_PREFIX = "auto-daily"
 
 
+async def _wait_snap_delete(proxmox, node_name: str, upid: str, timeout: int = 120) -> None:
+    """스냅샷 삭제 UPID 완료를 비동기로 대기합니다."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        try:
+            task = await asyncio.to_thread(proxmox.nodes(node_name).tasks(upid).status.get)
+            if task.get("status") == "stopped":
+                if task.get("exitstatus") != "OK":
+                    logger.warning(f"[auto-snap] 삭제 태스크 비정상 종료: {upid} exitstatus={task.get('exitstatus')}")
+                return
+        except Exception as e:
+            logger.debug(f"[auto-snap] UPID {upid} 상태 조회 실패: {e}")
+        await asyncio.sleep(2)
+    logger.warning(f"[auto-snap] 삭제 UPID {upid} 타임아웃 ({timeout}초) — 생성 단계에서 충돌 가능")
+
+
 async def _daily_snapshot_loop():
     """
     매일 자동 스냅샷 (auto_snapshot=True인 VM만)
-    - 00:00 → 기존 auto-daily 스냅샷 삭제
-    - 00:10 → 새 auto-daily 스냅샷 생성
+    - 00:00 → 기존 auto-daily 스냅샷 삭제 (UPID 완료를 gather로 병렬 대기)
+    - 00:01 → 새 auto-daily 스냅샷 생성 (target_vms 재조회)
     """
     from services.proxmox_client import get_proxmox_for_server
 
@@ -159,39 +177,57 @@ async def _daily_snapshot_loop():
             logger.info("[auto-snap] 기존 자동 스냅샷 삭제 시작")
             db = SessionLocal()
             try:
-                target_vms = db.query(Vm).filter(Vm.auto_snapshot == True).all()
-
-                for vm in target_vms:
-                    try:
-                        proxmox = get_proxmox_for_server(vm.server)
-                        snapshots = proxmox.nodes(vm.server.name).qemu(vm.hypervisor_vmid).snapshot.get()
-                        for snap in snapshots:
-                            if snap.get("name", "").startswith(AUTO_SNAP_PREFIX):
-                                proxmox.nodes(vm.server.name).qemu(vm.hypervisor_vmid).snapshot(snap["name"]).delete()
-                                logger.info(f"[auto-snap] 삭제: {vm.name} / {snap['name']}")
-                    except Exception as e:
-                        logger.warning(f"[auto-snap] 삭제 실패 ({vm.name}): {e}")
-
-                # ── 00:10 — 새 스냅샷 생성 ──
-                await asyncio.sleep(600)
-
-                today_str = now_kst().strftime("%Y%m%d")
-                snap_name = f"{AUTO_SNAP_PREFIX}-{today_str}"
-                logger.info(f"[auto-snap] 자동 스냅샷 생성 시작: {snap_name}")
-
-                for vm in target_vms:
-                    try:
-                        proxmox = get_proxmox_for_server(vm.server)
-                        proxmox.nodes(vm.server.name).qemu(vm.hypervisor_vmid).snapshot.post(
-                            snapname=snap_name,
-                            description="자동 일일 스냅샷",
-                            vmstate=0,
-                        )
-                        logger.info(f"[auto-snap] 생성: {vm.name} / {snap_name}")
-                    except Exception as e:
-                        logger.warning(f"[auto-snap] 생성 실패 ({vm.name}): {e}")
+                vms = db.query(Vm).options(joinedload(Vm.server)).filter(Vm.auto_snapshot == True).all()
+                delete_targets = [(vm.name, vm.hypervisor_vmid, vm.server) for vm in vms]
+                db.expunge_all()
             finally:
                 db.close()
+
+            wait_tasks = []
+            for vm_name, vmid, server in delete_targets:
+                try:
+                    proxmox = get_proxmox_for_server(server)
+                    snapshots = proxmox.nodes(server.name).qemu(vmid).snapshot.get()
+                    for snap in snapshots:
+                        if snap.get("name", "").startswith(AUTO_SNAP_PREFIX):
+                            upid = proxmox.nodes(server.name).qemu(vmid).snapshot(snap["name"]).delete()
+                            logger.info(f"[auto-snap] 삭제 요청: {vm_name} / {snap['name']}")
+                            if isinstance(upid, str):
+                                wait_tasks.append(_wait_snap_delete(proxmox, server.name, upid))
+                except Exception as e:
+                    logger.warning(f"[auto-snap] 삭제 실패 ({vm_name}): {e}")
+
+            if wait_tasks:
+                await asyncio.gather(*wait_tasks, return_exceptions=True)
+
+            # ── 00:01 — 새 스냅샷 생성 ──
+            await asyncio.sleep(60)
+
+            today_str = now_kst().strftime("%Y%m%d")
+            snap_name = f"{AUTO_SNAP_PREFIX}-{today_str}"
+            logger.info(f"[auto-snap] 자동 스냅샷 생성 시작: {snap_name}")
+
+            # 생성 직전 재조회 — sleep 사이 auto_snapshot 변경분 반영
+            db = SessionLocal()
+            try:
+                vms = db.query(Vm).options(joinedload(Vm.server)).filter(Vm.auto_snapshot == True).all()
+                create_targets = [(vm.name, vm.hypervisor_vmid, vm.server) for vm in vms]
+                db.expunge_all()
+            finally:
+                db.close()
+
+            for vm_name, vmid, server in create_targets:
+                try:
+                    proxmox = get_proxmox_for_server(server)
+                    proxmox.nodes(server.name).qemu(vmid).snapshot.post(
+                        snapname=snap_name,
+                        description="자동 일일 스냅샷",
+                        vmstate=0,
+                    )
+                    logger.info(f"[auto-snap] 생성: {vm_name} / {snap_name}")
+                except Exception as e:
+                    logger.warning(f"[auto-snap] 생성 실패 ({vm_name}): {e}")
+
         except Exception as e:
             logger.error(f"[auto-snap] 백그라운드 태스크 오류: {e}")
             await asyncio.sleep(3600)

--- a/schemas/vm_schema.py
+++ b/schemas/vm_schema.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Optional
 from enum import Enum
 
@@ -22,6 +22,10 @@ class VMResize(BaseModel):
     """VM 사양 변경 요청 모델 (핫플러그)"""
     cores: Optional[int] = None    # vCPU 수
     memory: Optional[int] = None   # RAM (MB 단위)
+
+class SnapshotCreateRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=40, pattern=r"^[a-zA-Z][a-zA-Z0-9_-]*$")
+    description: str = ""
 
 class VMCreate(BaseModel):
     """VM 생성 요청 모델 — 사용자는 os, tier와 선택적으로 node_name만 입력"""

--- a/tests/test_email_verification_reuse.py
+++ b/tests/test_email_verification_reuse.py
@@ -1,0 +1,117 @@
+"""이메일 인증 코드 재사용 취약점 테스트 (issue #56)
+
+SQLite는 timezone-aware datetime을 지원하지 않으므로
+now_kst()를 naive datetime으로 패치해서 테스트합니다.
+"""
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import patch
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from core.database import Base, get_db
+from models.email_verification import EmailVerification
+from models.user import User
+
+TEST_DB_URL = "sqlite:///./test_email_reuse.db"
+engine = create_engine(TEST_DB_URL, connect_args={"check_same_thread": False})
+TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# SQLite 호환 naive datetime 반환
+_naive_now = lambda: datetime.utcnow()
+
+
+def get_test_app():
+    from api.routes import auth
+
+    app = FastAPI()
+    app.include_router(auth.router, prefix="/api/v1/auth")
+
+    def override_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_db
+    return app
+
+
+@pytest.fixture(scope="module")
+def client():
+    Base.metadata.create_all(bind=engine)
+    app = get_test_app()
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+    Base.metadata.drop_all(bind=engine)
+
+
+def _insert_verification(email: str, code: str, signup_role: str = "user") -> None:
+    db = TestSession()
+    try:
+        record = EmailVerification(
+            email=email,
+            hashed_password="$2b$12$fakehashfortest000000000000000000000000000000000000000",
+            code=code,
+            signup_role=signup_role,
+            expires_at=datetime.utcnow() + timedelta(minutes=10),
+        )
+        db.add(record)
+        db.commit()
+    finally:
+        db.close()
+
+
+def _cleanup() -> None:
+    db = TestSession()
+    try:
+        db.query(EmailVerification).delete()
+        db.query(User).delete()
+        db.commit()
+    finally:
+        db.close()
+
+
+class TestEmailVerificationReuse:
+    """이메일 인증 코드 재사용 취약점 픽스 검증"""
+
+    def setup_method(self):
+        _cleanup()
+
+    def test_verify_code_reuse_blocked(self, client):
+        """인증 완료 후 동일 코드로 재요청 시 400 반환 — record 삭제로 차단"""
+        _insert_verification("reuse1@gsm.hs.kr", "111111")
+
+        with patch("api.routes.auth.now_kst", _naive_now):
+            res1 = client.post("/api/v1/auth/verify", json={"email": "reuse1@gsm.hs.kr", "code": "111111"})
+            assert res1.status_code == 200
+
+            res2 = client.post("/api/v1/auth/verify", json={"email": "reuse1@gsm.hs.kr", "code": "111111"})
+            assert res2.status_code == 400
+
+    def test_resend_invalidates_old_code(self, client):
+        """/resend-code 호출 후 이전 코드로 인증 불가"""
+        _insert_verification("reuse2@gsm.hs.kr", "222222")
+
+        with patch("api.routes.auth.now_kst", _naive_now):
+            # 이메일 발송 실패(500)여도 DB 커밋은 완료됨
+            client.post("/api/v1/auth/resend-code", json={"email": "reuse2@gsm.hs.kr"})
+
+            # 이전 코드로 인증 시도 → 최신 레코드와 코드 불일치 → 400
+            res = client.post("/api/v1/auth/verify", json={"email": "reuse2@gsm.hs.kr", "code": "222222"})
+            assert res.status_code == 400
+
+    def test_already_registered_returns_400(self, client):
+        """인증 완료 후 같은 이메일로 재인증 시도 시 400 반환"""
+        _insert_verification("reuse3@gsm.hs.kr", "333333")
+
+        with patch("api.routes.auth.now_kst", _naive_now):
+            # 첫 번째 인증 성공 — User 생성
+            client.post("/api/v1/auth/verify", json={"email": "reuse3@gsm.hs.kr", "code": "333333"})
+
+            # 같은 이메일로 재인증 레코드 삽입 후 시도 → 이미 가입된 계정 → 400
+            _insert_verification("reuse3@gsm.hs.kr", "333333")
+            res = client.post("/api/v1/auth/verify", json={"email": "reuse3@gsm.hs.kr", "code": "333333"})
+            assert res.status_code == 400

--- a/tests/test_email_verification_reuse.py
+++ b/tests/test_email_verification_reuse.py
@@ -19,7 +19,8 @@ engine = create_engine(TEST_DB_URL, connect_args={"check_same_thread": False})
 TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 # SQLite 호환 naive datetime 반환
-_naive_now = lambda: datetime.utcnow()
+def _naive_now():
+    return datetime.utcnow()
 
 
 def get_test_app():

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -6,37 +6,44 @@ Domain 3: 입력 검증 & 스키마 테스트 (VAL-TC-01 ~ VAL-TC-12)
 import pytest
 from pydantic import ValidationError
 
-from schemas.vm_schema import VMAction, VMActionType
+from schemas.vm_schema import VMAction, VMActionType, SnapshotCreateRequest
 from schemas.fw_schema import FirewallRule
 
 
 # ── VAL-TC-01/02: 스냅샷 이름 검증 ──────────────────────────
 
 class TestSnapshotNameValidation:
-    """스냅샷 이름 정규식 검증 (vmcontrol.py에서 사용하는 패턴)"""
-
-    import re
-    SNAP_PATTERN = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9_-]*$')
+    """SnapshotCreateRequest 스키마 기반 스냅샷 이름 검증"""
 
     def test_korean_name_rejected(self):
         """VAL-TC-01: 한글 스냅샷 이름 거부"""
-        assert not self.SNAP_PATTERN.match("테스트스냅샷")
+        with pytest.raises(ValidationError):
+            SnapshotCreateRequest(name="테스트스냅샷")
 
     def test_valid_name_accepted(self):
         """VAL-TC-02: 정상 스냅샷 이름 통과"""
-        assert self.SNAP_PATTERN.match("valid-snap_1")
+        req = SnapshotCreateRequest(name="valid-snap")
+        assert req.name == "valid-snap"
 
     def test_path_traversal_rejected(self):
         """VAL-TC-03: 경로 순회 공격 거부"""
-        assert not self.SNAP_PATTERN.match("../../../etc/passwd")
+        with pytest.raises(ValidationError):
+            SnapshotCreateRequest(name="../../../etc/passwd")
 
     def test_dash_start_rejected(self):
         """대시로 시작 거부"""
-        assert not self.SNAP_PATTERN.match("-invalid")
+        with pytest.raises(ValidationError):
+            SnapshotCreateRequest(name="-invalid")
+
+    def test_number_start_rejected(self):
+        """숫자로 시작 거부 — Proxmox 식별자 규칙"""
+        with pytest.raises(ValidationError):
+            SnapshotCreateRequest(name="1snap")
 
     def test_auto_daily_prefix_accepted(self):
         """auto-daily 프리픽스 통과"""
-        assert self.SNAP_PATTERN.match("auto-daily-20260409")
+        req = SnapshotCreateRequest(name="auto-daily-20260409")
+        assert req.name == "auto-daily-20260409"
 
 
 # ── VAL-TC-04/05: VMAction Enum 검증 ─────────────────────────


### PR DESCRIPTION
## Summary

develop 브랜치 최신 변경사항을 main에 반영합니다.

주요 변경사항:
- **PR #70**: 이메일 인증 코드 재사용 취약점 수정
- **PR #81**: 자동 스냅샷 스케줄 개선 및 `create_snapshot` Pydantic 스키마 적용

---

### PR #70 — 이메일 인증 코드 재사용 취약점 수정

- **이메일 인증 완료** 후 `EmailVerification` 레코드 즉시 삭제로 코드 재사용 차단
- **resend_code** 시 기존 미인증 레코드 전체 삭제 후 새 레코드 삽입
- **경합 조건** 방어: `IntegrityError` catch → 400 반환

### PR #81 — 자동 스냅샷 스케줄 개선 및 `create_snapshot` Pydantic 스키마 적용

- `_daily_snapshot_loop`: **sleep 600초 → 60초** 단축 (00:10 → 00:01)
- 삭제 완료 후 DB 세션 즉시 닫기, 생성 단계에서 새 세션 오픈
- 스냅샷 `.delete()` 반환 **UPID 완료 대기** — 삭제 중 동일 이름 생성 요청 방지
- 생성 단계 직전 `target_vms` **재조회** — sleep 사이 `auto_snapshot` 변경분 반영
- `create_snapshot`: `body: dict` → **`SnapshotCreateRequest` Pydantic 스키마** 교체

## Test plan

- [ ] 인증 코드 입력 후 같은 코드로 재요청 시 404 반환 확인
- [ ] `/resend-code` 호출 후 이전 코드로 인증 불가 확인
- [ ] 자동 스냅샷 루프 삭제 완료 후 1분 뒤 생성 요청 확인 (로그)
- [ ] `POST /snapshots` 유효하지 않은 필드 전송 시 422 반환 확인