### PR TITLE
test: resend-code 테스트 send_verification_email mock 추가

### DIFF
--- a/tests/test_email_verification_reuse.py
+++ b/tests/test_email_verification_reuse.py
@@ -96,8 +96,8 @@ class TestEmailVerificationReuse:
         """/resend-code 호출 후 이전 코드로 인증 불가"""
         _insert_verification("reuse2@gsm.hs.kr", "222222")
 
-        with patch("api.routes.auth.now_kst", _naive_now):
-            # 이메일 발송 실패(500)여도 DB 커밋은 완료됨
+        with patch("api.routes.auth.now_kst", _naive_now), \
+             patch("api.routes.auth.send_verification_email", return_value=True):
             client.post("/api/v1/auth/resend-code", json={"email": "reuse2@gsm.hs.kr"})
 
             # 이전 코드로 인증 시도 → 최신 레코드와 코드 불일치 → 400


### PR DESCRIPTION
## Summary

- `test_resend_invalidates_old_code`에서 `send_verification_email`을 mock 없이 호출하여 **실제 SMTP 발송을 시도**하던 문제 수정
- `patch("api.routes.auth.send_verification_email", return_value=True)` 추가로 테스트 환경에서 외부 의존성 차단

## Test plan

- [x] `pytest tests/test_email_verification_reuse.py` 3 passed 확인