### PR TITLE
chore: Codex 프로젝트 설정 추가

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: "code-review"
+description: "\ubcc0\uacbd\ub41c \ud30c\uc77c\uc5d0 \ub300\ud574 GSMSV \ud504\ub85c\uc81d\ud2b8 \ucee8\ubca4\uc158 \u2014 Python/FastAPI \uc2a4\ud0c0\uc77c, \ubcf4\uc548, \uc778\uc99d, Next.js \ud0c0\uc785 \uc815\ud655\uc131 \u2014 \uad6c\uc870\uc801 \uccb4\ud06c\ub9ac\uc2a4\ud2b8\ub97c \uc2e4\ud589\ud569\ub2c8\ub2e4. \u2713/\u26a0/\u2717 \ub9ac\ud3ec\ud2b8\ub97c \uc0dd\uc131\ud558\uace0, \ubc1c\uacac\ub41c \ud56d\ubaa9\uc744 PR \ucf54\uba58\ud2b8 \ub610\ub294 \uc774\uc288\ub85c \ub4f1\ub85d\ud569\ub2c8\ub2e4."
+---
+
+# Code Review Guide
+
+## Step 0 — code-reviewer 에이전트 백그라운드 실행
+
+메인 리뷰를 시작하기 전에 `code-reviewer` 서브에이전트를 **백그라운드**로 동시에 실행합니다.
+에이전트에게는 동일한 범위(인수)와 아래 컨텍스트를 전달합니다:
+
+> "GSMSV 프로젝트(FastAPI/Next.js)의 코드 리뷰를 수행해줘.
+> 리뷰 범위: {인수 또는 develop...HEAD}.
+> 체크 항목: 인증(get_current_user), 민감 필드 노출, 리소스 접근 제어, HTTPException 직접 사용, Pydantic 바디 검증, any 타입, Suspense 래핑, 상태 코드, RBAC, 하드코딩 시크릿, SQL Injection.
+> ✓/⚠/✗ 리포트를 반환해줘."
+
+에이전트가 완료되면 Step 3 리포트에 에이전트 결과를 병합하여 **메인 리뷰 + 에이전트 리뷰** 통합 리포트를 생성합니다.
+
+## Step 1 — 리뷰 범위 결정
+
+인수(argument)에 따라 범위를 결정합니다:
+
+| 인수 | 범위 |
+|------|------|
+| 없음 | `develop...HEAD` (현재 브랜치 전체) |
+| PR 번호 (`42`) | 해당 PR의 diff |
+| 파일 경로 (`api/routes/firewall.py`) | 해당 파일만 |
+| 브랜치명 (`feat/xxx`) | develop 대비 해당 브랜치 diff |
+
+```bash
+# 범위 없음 (기본)
+git diff develop...HEAD --stat
+git diff develop...HEAD
+
+# PR 번호 지정
+gh pr diff <number>
+gh pr view <number> --json files -q '.files[].path'
+
+# 파일 지정
+git diff develop...HEAD -- <file_path>
+
+# 브랜치 지정
+git diff develop...<branch> --stat
+git diff develop...<branch>
+```
+
+변경된 각 파일을 상세히 읽어서 분석합니다.
+
+## Step 2 — Checklist
+
+### Python / FastAPI
+- [ ] 인증 필요 엔드포인트에 `Depends(get_current_user)` 있는가?
+- [ ] 응답에 password, token 등 민감 필드 없는가?
+- [ ] 다른 사용자 리소스 접근 차단 검증 있는가?
+- [ ] `HTTPException` 직접 사용 (서브클래스 X)?
+- [ ] 파일 경로 조작 시 `Path.resolve()` + 상위 디렉토리 검증 있는가?
+- [ ] Pydantic 모델로 요청 바디 검증하는가?
+
+### TypeScript / Next.js
+- [ ] `any` 타입 사용 없는가?
+- [ ] `useSearchParams()` 사용 시 `<Suspense>` 래핑 있는가?
+- [ ] 클라이언트 컴포넌트에 `"use client"` 선언 있는가?
+- [ ] API 호출 에러 처리 있는가?
+- [ ] 컴포넌트 props 타입 정의 있는가?
+
+### API Design
+- [ ] GET 200, POST 201, DELETE 200/204 상태 코드 맞는가?
+- [ ] URL은 복수형 명사인가? (`/vms`, `/users`)
+- [ ] 역할 기반 접근 제어 (USER/PROJECT_OWNER/ADMIN) 적용되었는가?
+
+### Security
+- [ ] 하드코딩된 시크릿 없는가?
+- [ ] 로그에 민감 정보 없는가?
+- [ ] SQL Injection 위험 없는가? (ORM 사용)
+- [ ] JWT 검증 우회 불가한가?
+
+### Test
+- [ ] 신규 기능에 pytest 테스트 있는가?
+- [ ] 에러 케이스(404, 403, 400) 테스트 있는가?
+
+## Step 3 — Report
+
+각 항목에 대해:
+- ✓ Pass
+- ⚠ Warning (권고)
+- ✗ Error (수정 필요)
+
+Final summary: `{n} items — {p} passed, {w} warnings, {e} errors`
+
+## Step 4 — 발견 항목 등록
+
+⚠/✗ 항목이 있을 경우, 사용자에게 등록 방식을 확인합니다:
+
+> **이슈 등록 전 반드시 `triage-issues` 스킬을 호출해 중복 체크를 먼저 수행합니다.**
+> - `MERGED into #<n>` 반환 시 → 새 이슈 생성 없이 기존 이슈 번호를 리포트에 표시
+> - `CREATED #<n>` 반환 시 → 새 이슈 번호를 리포트에 표시
+
+> ⚠ {w}개, ✗ {e}개 발견되었습니다.
+> 어떻게 처리할까요?
+> 1. PR 코멘트로 등록 (PR 번호 필요)
+> 2. GitHub 이슈로 등록
+> 3. 리포트만 (등록 안 함)
+
+### PR 코멘트로 등록
+
+특정 파일·라인에 pinpoint 가능한 항목은 인라인 코멘트로 등록합니다:
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+# 인라인 코멘트 (파일·라인 특정 가능한 경우)
+gh api "repos/$REPO/pulls/<pr_number>/comments" \
+  -f body="<내용>" \
+  -f commit_id="$(gh pr view <pr_number> --json headRefOid -q .headRefOid)" \
+  -f path="<파일 경로>" \
+  -F line=<라인 번호> \
+  -f side="RIGHT"
+
+# 일반 코멘트 (라인 특정 불가한 경우)
+gh pr comment <pr_number> --body "<내용>"
+```
+
+### GitHub 이슈로 등록
+
+PR 범위 밖이거나 PR이 없는 경우 이슈로 등록합니다:
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+gh issue create \
+  --repo "$REPO" \
+  --title "[code-review] <한국어 요약>" \
+  --body "$(cat <<'EOF'
+## 발견 위치
+- **파일**: `<파일 경로>`
+- **라인**: <라인 번호>
+
+## 문제
+<구체적으로 무엇이 문제인지 한국어로>
+
+## 수정 방향
+<어떻게 수정해야 하는지 한국어로>
+EOF
+)" \
+  --label "bug"
+```
+
+항목별로 심각도에 따라 라벨을 선택합니다:
+- ✗ Error → `bug`
+- ⚠ Warning → `enhancement`
+
+## Codex Notes
+
+The original Claude `allowed-tools` list is preserved as workflow guidance. It is not a Codex permission boundary.
+
+You're allowed to use these tools:
+
+- Bash(gh:*)
+- Bash(git diff:*)
+- Bash(git log:*)

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: "commit"
+description: "GSMSV \ud504\ub85c\uc81d\ud2b8 \ucee8\ubca4\uc158\uc5d0 \ub530\ub77c Git \ucee4\ubc0b\uc744 \uc0dd\uc131\ud569\ub2c8\ub2e4. \ubcc0\uacbd\uc0ac\ud56d\uc744 \ub17c\ub9ac\uc801 \ub2e8\uc704\ub85c \ub098\ub204\uace0 \uc62c\ubc14\ub978 \ud0c0\uc785 prefix\uc640 \ud55c\uad6d\uc5b4 \uc124\uba85\uc73c\ub85c \ucee4\ubc0b\ud569\ub2c8\ub2e4."
+---
+
+## Commit Message Rules
+
+Format: `type: 설명`
+
+- **콜론 앞뒤 공백 없음** — 항상 `type: 설명`, `type : 설명` 사용 금지
+- **Types** (English): `feat` / `fix` / `update` / `add` / `test` / `docs` / `style` / `perf` / `refactor` / `merge`
+- **Description**: 한국어, 마침표 없음, 간결하게
+- Subject line only (본문 없음)
+- **Co-Authored-By 포함 금지** — 워터마크 없이 클린한 커밋 메시지만
+
+### Type Guide
+
+| Type | When to use |
+|------|------------|
+| `feat` | 새로운 기능 |
+| `add` | 파일, 설정, 의존성 추가 |
+| `fix` | 버그 수정 |
+| `update` | 기존 기능 수정 또는 리뷰 반영 |
+| `refactor` | 동작 변경 없는 코드 구조 개선 |
+| `test` | 테스트 추가 또는 수정 |
+| `docs` | 문서만 변경 |
+| `style` | 포맷팅, 린트 |
+| `perf` | 성능 개선 |
+| `merge` | 머지 커밋 |
+
+### Examples
+
+```
+feat: VM 생성 API 구현
+fix: 아바타 삭제 시 Path Traversal 취약점 수정
+update: 리뷰 반영 - 비밀번호 필드 마스킹
+style: ruff 포맷팅 적용
+```
+
+### Commit Template
+
+```bash
+git commit -m "type: 설명"
+```
+
+## Commit Flow
+
+1. 변경사항 확인: `git status`, `git diff`
+2. 논리적 단위로 분류 (기능 / 버그 수정 / 리팩토링 등)
+3. 단위별로 파일 그룹화
+4. 각 그룹:
+   - `git add` 로 관련 파일만 스테이징
+   - 위 규칙에 따른 커밋 메시지 작성
+   - `git commit -m "..."` 실행
+5. `git log --oneline -n <count>` 로 확인
+
+## Important
+
+- 사용자가 명시적으로 요청할 때만 커밋 (`커밋`, `커밋해줘`, `commit` 등)
+- 명시적 요청 없이 자동 커밋 금지
+
+## Codex Notes
+
+The original Claude `allowed-tools` list is preserved as workflow guidance. It is not a Codex permission boundary.
+
+You're allowed to use these tools:
+
+- Bash(git add:*)
+- Bash(git status:*)
+- Bash(git commit:*)
+- Bash(git diff:*)
+- Bash(git log:*)

--- a/.agents/skills/format/SKILL.md
+++ b/.agents/skills/format/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: "format"
+description: "Python\uc740 ruff\ub85c, TypeScript\ub294 ESLint\ub85c \ucf54\ub4dc \ud3ec\ub9f7\ud305\uc744 \uc2e4\ud589\ud569\ub2c8\ub2e4. \ub300\uaddc\ubaa8 \ud3b8\uc9d1 \ud6c4 \ub610\ub294 \ud3ec\ub9f7\ud305\uc774 \ud544\uc694\ud560 \ub54c \uc0ac\uc6a9\ud558\uc138\uc694."
+---
+
+GSMSV 프로젝트 코드 포맷팅 실행:
+
+## Python (ruff)
+
+1. ruff 포맷 + 린트 자동 수정:
+   ```bash
+   ruff format . && ruff check . --fix
+   ```
+
+2. 결과 확인 후 수정된 파일 리포트
+
+## TypeScript (ESLint + tsc)
+
+1. ESLint 자동 수정:
+   ```bash
+   cd frontend && npx eslint . --ext .ts,.tsx --fix
+   ```
+
+2. 타입 체크 (수정 안 함, 확인만):
+   ```bash
+   cd frontend && npx tsc --noEmit
+   ```
+
+3. 결과 확인
+
+## 자동 수정 불가 항목
+
+자동 수정이 안 되는 에러가 남아있으면 에러 메시지를 출력하고 수동 수정이 필요한 항목을 안내합니다.

--- a/.agents/skills/new-api/SKILL.md
+++ b/.agents/skills/new-api/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: "new-api"
+description: "FastAPI \uc5d4\ub4dc\ud3ec\uc778\ud2b8\ub97c end-to-end\ub85c \uad6c\ud604\ud569\ub2c8\ub2e4 \u2014 \ubaa8\ub378 \u2192 \uc11c\ube44\uc2a4 \u2192 \ub77c\uc6b0\ud130 \u2192 \ud504\ub860\ud2b8\uc5d4\ub4dc API \ud568\uc218. GSMSV \ud504\ub85c\uc81d\ud2b8 \ucee8\ubca4\uc158\uc744 \ub530\ub985\ub2c8\ub2e4."
+---
+
+# New API Implementation Flow (GSMSV)
+
+## Directory Structure
+
+```
+api/routes/{domain}.py        # 라우터
+services/{domain}_service.py  # 서비스 로직
+models/{Domain}.py            # SQLAlchemy 모델 (기존 재사용)
+frontend/lib/api.ts           # 프론트엔드 API 함수
+frontend/lib/types.ts         # 타입 정의
+```
+
+## Step 1 — Service Function
+
+```python
+# services/{domain}_service.py
+def create_{resource}(
+    db: Session,
+    user: User,
+    data: Create{Resource}Request,
+) -> {Resource}Response:
+    # 권한 검증
+    if user.role not in [UserRole.ADMIN, UserRole.PROJECT_OWNER]:
+        raise HTTPException(status_code=403, detail="권한이 없습니다.")
+    
+    # 비즈니스 로직
+    item = {Resource}(
+        field1=data.field1,
+        user_id=user.id,
+    )
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    
+    return {Resource}Response.model_validate(item)
+```
+
+## Step 2 — Pydantic Schemas
+
+```python
+# api/routes/{domain}.py 상단 또는 별도 schemas 파일
+
+class Create{Resource}Request(BaseModel):
+    field1: str
+    field2: Optional[str] = None
+
+class {Resource}Response(BaseModel):
+    id: int
+    field1: str
+    
+    model_config = ConfigDict(from_attributes=True)
+```
+
+## Step 3 — Router Endpoint
+
+```python
+# api/routes/{domain}.py
+router = APIRouter(prefix="/{resources}", tags=["{domain}"])
+
+@router.post("", response_model={Resource}Response, status_code=201)
+async def create_{resource}(
+    request: Create{Resource}Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    return {domain}_service.create_{resource}(db, current_user, request)
+
+@router.get("/{id}", response_model={Resource}Response)
+async def get_{resource}(
+    id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    item = {domain}_service.get_{resource}(db, id)
+    if not item:
+        raise HTTPException(status_code=404, detail="리소스를 찾을 수 없습니다.")
+    return item
+```
+
+## Step 4 — Frontend API Function
+
+```typescript
+// frontend/lib/api.ts
+export async function create{Resource}(data: Create{Resource}Request): Promise<{Resource}Response> {
+  const res = await fetch(`${API_BASE}/{resources}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) throw new Error(await res.text())
+  return res.json()
+}
+```
+
+## Step 5 — Type Definitions
+
+```typescript
+// frontend/lib/types.ts
+export interface {Resource} {
+  id: number
+  field1: string
+  field2?: string
+}
+
+export interface Create{Resource}Request {
+  field1: string
+  field2?: string
+}
+```
+
+## Checklist
+
+- [ ] 서비스 함수 구현 (권한 검증 포함)
+- [ ] Pydantic 요청/응답 스키마 작성
+- [ ] 라우터 엔드포인트 등록
+- [ ] `main.py` 에 라우터 include 확인
+- [ ] 프론트엔드 API 함수 추가
+- [ ] TypeScript 타입 정의 추가
+- [ ] HTTP 상태 코드 정확 (GET 200, POST 201)
+- [ ] 인증 의존성 (`Depends(get_current_user)`) 포함
+- [ ] 역할 기반 접근 제어 적용 시 명시

--- a/.agents/skills/new-branch/SKILL.md
+++ b/.agents/skills/new-branch/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: "new-branch"
+description: "GSMSV \ud504\ub85c\uc81d\ud2b8\uc758 \ube0c\ub79c\uce58 \ub124\uc774\ubc0d \ucee8\ubca4\uc158\uc5d0 \ub530\ub77c \uc0c8 git \ube0c\ub79c\uce58\ub97c \uc0dd\uc131\ud569\ub2c8\ub2e4. \uc0c8 \uc791\uc5c5\uc744 \uc2dc\uc791\ud558\uac70\ub098 \ube0c\ub79c\uce58\ub97c \uc0dd\uc131\ud560 \ub54c \uc0ac\uc6a9\ud558\uc138\uc694."
+---
+
+GSMSV 프로젝트 브랜치 네이밍 컨벤션에 따라 새 브랜치를 생성하고 이동합니다.
+
+Steps:
+1. 브랜치 목적이 불명확하면 사용자에게 먼저 확인
+2. 적절한 타입을 결정하고 영어 kebab-case 설명 작성
+3. `develop` 브랜치 기반으로 생성: `git checkout develop && git checkout -b type/description`
+4. `git branch --show-current` 로 확인
+
+Branch name format: `type/description`
+
+Types:
+- feat: 새로운 기능
+- fix: 버그 수정
+- style: 코드 포맷팅 (로직 변경 없음)
+- refactor: 코드 리팩토링
+- docs: 문서 업데이트
+- test: 테스트 관련 변경
+- chore: 빌드 설정 또는 패키지 관리
+- remove: 파일/폴더 삭제
+
+Rules:
+- description은 kebab-case 사용
+- description은 짧고 명확하게
+- description은 영어로 작성
+- 항상 `develop` 브랜치에서 분기
+
+Example: `feat/vm-snapshot-api`

--- a/.agents/skills/plan-deep-dive/SKILL.md
+++ b/.agents/skills/plan-deep-dive/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: "plan-deep-dive"
+description: "Conduct an in-depth structured interview with the user to uncover non-obvious requirements, tradeoffs, and constraints, then produce a detailed implementation spec file."
+---
+
+Interview the user in detail about the requested feature or task — cover technical implementation, architecture decisions, edge cases, tradeoffs, and concerns. Ask non-obvious, in-depth questions. Continue interviewing until you have enough information, then write the complete spec to a file named `SPEC.md`.
+
+Cover at minimum:
+- Functional requirements
+- Data model changes (entities, DTOs)
+- API design (endpoints, request/response)
+- Business logic and validation rules
+- Error cases and exception handling
+- Security considerations
+- Test scenarios

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: "review-pr"
+description: "PR \ub9ac\ubdf0 \ucf54\uba58\ud2b8\ub97c \ud655\uc778\ud558\uace0 \uc720\ud6a8\ud55c \ud53c\ub4dc\ubc31\uc744 \ucf54\ub4dc\uc5d0 \ubc18\uc601\ud55c \ud6c4 \ucee4\ubc0b, \ud478\uc2dc, \uac01 \ucf54\uba58\ud2b8\uc5d0 \ubc18\uc601 \uc644\ub8cc \ud574\uc2dc\ub85c \ub2f5\uae00\uc744 \ub2f5\ub2c8\ub2e4."
+---
+
+## Step 1 — Collect PR Comments
+
+```bash
+gh pr view --json number -q .number
+gh api "repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/pulls/<pr_number>/comments" \
+  --jq '.[] | {id: .id, path: .path, line: .line, body: .body}'
+```
+
+## Step 2 — Evaluate Each Comment
+
+각 코멘트에 대해 결정:
+- **반영** — 유효한 제안, 코드에 반영
+- **이슈 등록** — 유효하지만 현재 PR 범위 밖이거나 추후 적용 예정 → GitHub 이슈 생성
+- **무시** — 해당 없음 또는 의도된 설계 (이유를 답글에 설명)
+
+## Step 3 — Implement Changes
+
+수락한 코멘트에 대해 코드 변경을 적용합니다.
+
+Python 변경 시 문법 확인:
+```bash
+python -m py_compile {changed_file}
+```
+
+TypeScript/Next.js 변경 시 빌드 확인:
+```bash
+cd frontend && npm run build 2>&1
+```
+
+## Step 4 — Create Issues for Out-of-Scope Comments
+
+범위 밖 또는 추후 적용 예정 코멘트는 GitHub 이슈로 등록합니다.
+
+**이슈 등록 전 반드시 `triage-issues` 스킬을 호출해 중복 체크를 먼저 수행합니다.**
+- `MERGED into #<n>` 반환 시 → `gh issue create` 없이 기존 이슈 번호를 답글에 사용
+- `CREATED #<n>` 반환 시 → 새 이슈 번호를 답글에 사용
+
+중복이 없을 때만 아래 명령어로 이슈를 생성합니다:
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+PR_URL=$(gh pr view --json url -q .url)
+
+gh issue create \
+  --repo "$REPO" \
+  --title "[deferred] <한국어 요약>" \
+  --body "$(cat <<'EOF'
+## 출처
+
+PR: <PR_URL>
+파일: `<file_path>`
+원본 코멘트:
+> <comment_body>
+
+## 내용
+
+<구체적으로 무엇을 해야 하는지 한국어로>
+EOF
+)" \
+  --label "enhancement"
+```
+
+이슈 생성(또는 병합) 후 이슈 번호를 기록해두고 답글에 이슈 링크를 포함합니다.
+
+## Step 5 — Commit & Push
+
+사용자가 커밋 요청 시에만:
+
+1. commit 스킬을 사용해 변경사항을 스테이징 후 커밋 (컨벤션: `type: 설명`, Co-Authored-By 없음)
+2. 커밋 완료 후 푸시:
+```bash
+git push
+```
+
+3. 짧은 커밋 해시 확인:
+```bash
+git log --oneline -1
+```
+
+## Step 6 — Reply to Each Comment
+
+**반영한 코멘트:**
+```bash
+gh api "repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" \
+  -f body="<short_hash> 에서 반영했습니다."
+```
+
+**이슈로 등록한 코멘트:**
+```bash
+gh api "repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" \
+  -f body="현재 PR 범위 밖의 내용입니다. <issue_url> 이슈로 등록해 추후 반영하겠습니다."
+```
+
+**무시한 코멘트:**
+```bash
+gh api "repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" \
+  -f body="<이유> 때문에 반영하지 않았습니다."
+```
+
+## Step 7 — Report
+
+```
+## 반영한 코멘트
+- [file] "comment" → <hash> 에서 반영했습니다.
+
+## 이슈로 등록한 코멘트
+- [file] "comment" → <issue_url>
+
+## 반영하지 않은 코멘트
+- [file] "comment" → 사유: ...
+```
+
+## Important
+
+- 커밋 먼저, 답글은 나중에 (답글에 해시/이슈 링크 포함해야 하므로)
+- 커밋 전에 답글 달지 않음
+- develop 브랜치 기반 PR인지 확인
+
+## Codex Notes
+
+The original Claude `allowed-tools` list is preserved as workflow guidance. It is not a Codex permission boundary.
+
+You're allowed to use these tools:
+
+- Bash(gh:*)
+- Bash(git push:*)
+- Bash(git log:*)

--- a/.agents/skills/security-checklist/SKILL.md
+++ b/.agents/skills/security-checklist/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: "security-checklist"
+description: "\ubcf4\uc548 \ucde8\uc57d\uc810\uc744 \uac80\uc99d\ud569\ub2c8\ub2e4 \u2014 \ud558\ub4dc\ucf54\ub529\ub41c \uc2dc\ud06c\ub9bf, Path Traversal, SQL Injection, JWT \uac80\uc99d, \ubbfc\uac10 \uc815\ubcf4 \ub85c\uae45, \uc5ed\ud560 \uae30\ubc18 \uc811\uadfc \uc81c\uc5b4. \uc778\uc99d/API \uad00\ub828 \ubcc0\uacbd\uc0ac\ud56d \uba38\uc9c0 \uc804\uc5d0 \uc2e4\ud589\ud558\uc138\uc694."
+---
+
+# Security Checklist (GSMSV)
+
+## 검증 항목
+
+### 1. 하드코딩된 시크릿
+- [ ] 코드에 API Key, Secret, Password 없는가?
+- [ ] 환경변수 또는 `.env` 파일 사용하는가?
+
+```bash
+grep -r "password.*=.*['\"]" --include="*.py" api/ services/
+grep -r "secret.*=.*['\"]" --include="*.py" api/ services/
+grep -r "API_KEY\|SECRET_KEY" --include="*.ts" --include="*.tsx" frontend/
+```
+
+### 2. Path Traversal
+- [ ] 파일 경로 생성 시 `Path.resolve()` 사용하는가?
+- [ ] 허용된 디렉토리 하위인지 검증하는가?
+- [ ] `../` 또는 절대경로 입력 차단하는가?
+
+```bash
+grep -r "Path(" --include="*.py" api/ services/
+grep -r "os.path\|open(" --include="*.py" api/ services/
+```
+
+### 3. SQL Injection
+- [ ] ORM (SQLAlchemy) 사용하는가?
+- [ ] Raw SQL 사용 시 파라미터 바인딩 사용하는가?
+- [ ] 직접 문자열 포맷팅으로 SQL 조합하지 않는가?
+
+### 4. JWT 검증
+- [ ] JWT 서명 검증하는가?
+- [ ] 만료 시간 확인하는가?
+- [ ] 사용자 식별은 토큰 클레임에서 (요청 바디 user_id X)?
+
+### 5. 로깅
+- [ ] 로그에 password, token, secret 출력 없는가?
+- [ ] 적절한 로그 레벨 사용하는가?
+
+```bash
+grep -r "logger\.\|print(" --include="*.py" api/ services/ | grep -i "password\|token\|secret"
+```
+
+### 6. 역할 기반 접근 제어
+- [ ] 인증 필요 엔드포인트에 `Depends(get_current_user)` 있는가?
+- [ ] 역할 검증 (USER/PROJECT_OWNER/ADMIN) 서버측에서 하는가?
+- [ ] 프론트엔드 UI 숨김만으로 접근 제어하지 않는가?
+- [ ] 다른 사용자 리소스 접근 차단 검증 있는가?
+
+### 7. CORS
+- [ ] 허용된 출처만 CORS 설정에 포함되는가?
+- [ ] `*` 와일드카드 사용 이유가 있는가? (의도된 설계인 경우 허용)
+
+## Report Format
+
+각 항목에 대해:
+- ✓ Pass
+- ⚠ Warning (권고)
+- ✗ Error (수정 필요)
+
+Final summary: `{n} items — {p} passed, {w} warnings, {e} errors`

--- a/.agents/skills/test/SKILL.md
+++ b/.agents/skills/test/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: "test"
+description: "pytest \ud14c\uc2a4\ud2b8\ub97c \uc2e4\ud589\ud558\uace0 \uacb0\uacfc\ub97c \ub9ac\ud3ec\ud2b8\ud569\ub2c8\ub2e4. \ucee8\ud14d\uc2a4\ud2b8\uc5d0 \ub530\ub77c \ud14c\uc2a4\ud2b8 \ubc94\uc704\ub97c \uacb0\uc815\ud558\uace0 \uc2e4\ud328\ub97c \uc0c1\uc138\ud788 \ubd84\uc11d\ud569\ub2c8\ub2e4. \uc804\uccb4 \ud14c\uc2a4\ud2b8\ub294 \uaf2d \ud544\uc694\ud55c \uacbd\uc6b0\uc5d0\ub9cc \uc2e4\ud589\ud569\ub2c8\ub2e4."
+---
+
+다음 단계에 따라 테스트를 실행합니다:
+
+## Steps
+
+1. **테스트 범위 결정**:
+   - 특정 파일/모듈 언급 시: 관련 테스트 파일만 실행 (권장)
+   - 특정 기능 영역 변경 시: 해당 도메인 테스트만 실행
+   - 명시적으로 전체 실행 요청 시: 전체 실행
+
+2. **테스트 실행**:
+
+   ```bash
+   # 관련 테스트만 (권장)
+   python -m pytest tests/test_{module}.py -v 2>&1
+
+   # 특정 함수
+   python -m pytest tests/test_{module}.py::test_{function_name} -v 2>&1
+
+   # 전체 (꼭 필요한 경우만)
+   python -m pytest tests/ -v 2>&1
+   ```
+
+3. **결과 분석**:
+   - 테스트 요약 표시
+   - 실패 시: 실패 메시지 및 traceback 표시, 근본 원인 분석
+   - 성공 시: 통과한 테스트 수 확인
+
+4. **리포트**:
+   - 실행된 총 테스트 수
+   - 통과/실패 수
+   - 실패 시 수정 방향 제안
+
+테스트를 실행하지 않고 성공했다고 주장하지 않습니다.

--- a/.agents/skills/triage-issues/SKILL.md
+++ b/.agents/skills/triage-issues/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: "triage-issues"
+description: "\uc0c8 \uc774\uc288 \ub4f1\ub85d \uc804 \uae30\uc874 \uc624\ud508 \uc774\uc288\uc640 \uc720\uc0ac\ud55c \ud56d\ubaa9\uc774 \uc788\ub294\uc9c0 \ud655\uc778\ud569\ub2c8\ub2e4. \uc720\uc0ac \uc774\uc288\uac00 \uc788\uc73c\uba74 \uc0c8 \uc774\uc288 \ub300\uc2e0 \uae30\uc874 \uc774\uc288\uc5d0 \ucf54\uba58\ud2b8\ub97c \ucd94\uac00\ud569\ub2c8\ub2e4. \uc778\uc218 \uc5c6\uc774 \ub2e8\ub3c5 \uc2e4\ud589 \uc2dc \uc804\uccb4 \uc624\ud508 \uc774\uc288\ub97c \uc815\ub9ac\u00b7\ubcd1\ud569\ud569\ub2c8\ub2e4."
+---
+
+# Triage Issues
+
+## 실행 모드
+
+| 호출 방식 | 동작 |
+|-----------|------|
+| 인수 없음 (`/triage-issues`) | 전체 오픈 이슈 정리 모드 |
+| 제목 + 내용 전달 (다른 스킬에서 호출) | 단일 이슈 중복 체크 모드 |
+
+---
+
+## Mode A — 단일 이슈 중복 체크 (code-review / review-pr 에서 호출)
+
+새 이슈를 등록하기 전에 이 절차를 실행합니다.
+
+### Step 1 — 오픈 이슈 목록 조회
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+gh issue list --repo "$REPO" --state open --limit 100 \
+  --json number,title,labels,body \
+  -q '.[] | "#\(.number) [\(.labels[].name // "no-label")] \(.title)"'
+```
+
+### Step 2 — 유사 이슈 판단
+
+등록하려는 이슈와 기존 이슈를 비교해 유사 여부를 판단합니다.
+
+유사로 판단하는 기준:
+- **같은 파일**이 언급된 경우
+- **같은 도메인** (auth, vm, firewall, monitoring 등)에서 같은 종류의 문제
+- **제목 키워드 70% 이상 겹치는** 경우
+
+### Step 3 — 분기 처리
+
+**유사 이슈 없음 → 새 이슈 생성**
+
+호출한 스킬(code-review / review-pr)의 이슈 생성 절차대로 진행합니다.
+
+**유사 이슈 있음 → 기존 이슈에 코멘트 추가**
+
+새 이슈를 만들지 않고, 가장 유사한 기존 이슈에 코멘트를 추가합니다:
+
+```bash
+gh issue comment <existing_issue_number> --repo "$REPO" --body "$(cat <<'EOF'
+## 추가 발견 사례
+
+- **출처**: <code-review / review-pr / 파일명>
+- **파일**: `<파일 경로>`
+- **라인**: <라인 번호>
+
+<새로 발견된 내용 요약>
+EOF
+)"
+```
+
+결과를 호출한 스킬에 반환합니다:
+- 새 이슈 생성 시: `CREATED #<number>`
+- 기존 이슈에 추가 시: `MERGED into #<number>`
+
+---
+
+## Mode B — 전체 이슈 정리 (`/triage-issues` 단독 실행)
+
+### Step 1 — 전체 오픈 이슈 조회
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+gh issue list --repo "$REPO" --state open --limit 100 \
+  --json number,title,labels,body,createdAt \
+  -q '.[] | "#\(.number) \(.title)"'
+```
+
+### Step 2 — 그룹핑
+
+아래 기준으로 유사 이슈를 묶어 그룹을 구성합니다:
+- 같은 파일/경로 언급
+- 같은 도메인 (auth / vm / firewall / monitoring / frontend 등)
+- 같은 타입 (`[code-review]` / `[deferred]` 등 prefix 동일 + 내용 유사)
+
+### Step 3 — 정리 계획 출력
+
+병합 계획을 사용자에게 먼저 보여줍니다:
+
+```
+## 정리 계획
+
+### 그룹 1 — <도메인/파일명>
+- 대표 이슈: #<number> <title>
+- 병합 대상: #<number> <title>, #<number> <title>
+- 처리: 병합 대상을 대표 이슈에 코멘트로 통합 후 close
+
+### 그룹 2 — ...
+
+병합하지 않는 이슈: #<n>, #<n> (유사 없음)
+```
+
+### Step 4 — 사용자 확인 후 실행
+
+확인을 받으면:
+
+1. 병합 대상 이슈 내용을 대표 이슈에 코멘트로 추가
+2. 병합 대상 이슈 close + `duplicate` 라벨 부착
+
+```bash
+# 대표 이슈에 코멘트 추가
+gh issue comment <canonical_number> --body "<병합 내용>"
+
+# 중복 이슈 close
+gh issue close <duplicate_number> --repo "$REPO" \
+  --comment "Duplicate of #<canonical_number>"
+
+# duplicate 라벨 부착 (라벨 없으면 생성)
+gh issue edit <duplicate_number> --add-label "duplicate"
+```
+
+### Step 5 — 정리 결과 리포트
+
+```
+## 정리 완료
+
+- 병합: #<n> → #<n>, #<n> → #<n>
+- 변경 없음: #<n>, #<n>
+- 남은 오픈 이슈: <count>개
+```
+
+## Codex Notes
+
+The original Claude `allowed-tools` list is preserved as workflow guidance. It is not a Codex permission boundary.
+
+You're allowed to use these tools:
+
+- Bash(gh:*)

--- a/.agents/skills/write-pr/SKILL.md
+++ b/.agents/skills/write-pr/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: "write-pr"
+description: "develop \ube0c\ub79c\uce58 \uae30\uc900 \ucee4\ubc0b\uc744 \ubd84\uc11d\ud574 PR \uc81c\ubaa9\uacfc \ubcf8\ubb38\uc744 \uc0dd\uc131\ud558\uace0 GitHub PR\uc744 \ub9cc\ub4ed\ub2c8\ub2e4. GSMSV \ud504\ub85c\uc81d\ud2b8 \ucee8\ubca4\uc158\uc744 \ub530\ub985\ub2c8\ub2e4."
+---
+
+## Step 1 — 컨텍스트 수집
+
+```bash
+git branch --show-current
+```
+
+현재 브랜치가 `develop` 또는 `main`이면 즉시 중단:
+
+```
+현재 브랜치: develop
+feature 브랜치를 먼저 생성하세요 (/new-branch)
+```
+
+feature 브랜치면 계속 진행:
+
+```bash
+git log origin/develop..HEAD --oneline
+git diff origin/develop...HEAD --stat
+git diff origin/develop...HEAD
+```
+
+## Step 2 — PR 제목 생성
+
+Format: `type: 한국어 설명`
+
+- commit 컨벤션과 동일한 type prefix 사용 (`feat` / `fix` / `update` / `docs` 등)
+- 한국어, 간결하게, 마침표 없음, 50자 이내
+- 3개 옵션 생성 후 가장 적합한 것에 `← 추천` 표시
+
+## Step 3 — PR 본문 생성
+
+아래 템플릿을 **그대로** 사용 (구조 변경 금지):
+
+```markdown
+## Summary
+- **굵은 키워드**: 변경 내용 (한국어, 기술용어는 영어)
+- `파일명`, `함수명` 등은 백틱 처리
+
+## Test plan
+- [x] 자동으로 확인된 항목
+- [ ] 수동 확인 필요 항목
+
+
+```
+
+Rules:
+- Summary는 bullet point로 변경 내용을 구체적으로 작성
+- Test plan은 실제 테스트 가능한 항목만 포함
+- 내용이 없는 섹션도 삭제하지 말고 비워둘 것
+
+## Step 4 — 미리보기 & 확인
+
+```
+## 추천 PR 제목
+1. [title1]
+2. [title2]
+3. [title3] ← 추천
+
+## PR 본문 미리보기
+[body content]
+```
+
+사용자에게 어떤 제목을 쓸지 확인. 응답 없으면 추천 옵션 사용.
+
+## Step 5 — PR 생성
+
+PR 본문에 `🤖 Generated with Claude Code` 등 워터마크를 **절대 포함하지 않는다**.
+
+```bash
+gh pr create \
+  --title "<title>" \
+  --base develop \
+  --assignee "@me" \
+  --body "$(cat <<'EOF'
+## Summary
+- **키워드**: 내용
+
+## Test plan
+- [x] 항목
+- [ ] 항목
+EOF
+)"
+```
+
+생성 후 PR URL을 출력한다.

--- a/.codex/agents/build-verifier.toml
+++ b/.codex/agents/build-verifier.toml
@@ -1,0 +1,45 @@
+name = "build-verifier"
+description = "Next.js \ud504\ub860\ud2b8\uc5d4\ub4dc \ube4c\ub4dc\ub97c \uc2e4\ud589\ud558\uace0 \uc131\uacf5/\uc2e4\ud328\ub97c \ub9ac\ud3ec\ud2b8\ud569\ub2c8\ub2e4. '\ube4c\ub4dc\ud574\uc918', '\ube4c\ub4dc \ud655\uc778\ud574\uc918', 'build-verifier \uc2e4\ud589\ud574', \ub610\ub294 \ucf54\ub4dc \ub9ac\ubdf0 \uc644\ub8cc \ud6c4 \ud2b8\ub9ac\uac70\ud558\uc138\uc694. \uc2e4\ud328 \uc2dc failure-analyst\uc5d0\uac8c \ud578\ub4dc\uc624\ud504\ud558\uc138\uc694."
+model = "haiku"
+sandbox_mode = "workspace-write"
+developer_instructions = """You are a build verification agent for the GSMSV project. Run the frontend build and report the result. Do NOT edit code.
+
+## Steps
+
+1. Run Next.js build:
+   ```bash
+   cd frontend && npm run build 2>&1
+   ```
+
+2. Report result:
+
+**Success:**
+```
+빌드 성공
+```
+
+**Failure:**
+```
+빌드 실패
+
+[에러 메시지 그대로 출력]
+
+→ failure-analyst 에이전트에 로그를 전달해 분석을 요청하세요.
+```
+
+Do NOT attempt to fix errors yourself.
+
+## Tools
+
+Claude tool allow/deny lists were preserved as prompt guidance, not Codex permissions.
+
+You're allowed to use these tools:
+
+- Bash
+- Glob
+- Grep
+- Read
+
+## Codex Notes
+
+The original Claude `permissionMode: auto` is represented with `sandbox_mode = "workspace-write"` so build tools can write generated artifacts. The listed tools are workflow guidance, not a hard Codex permission boundary."""

--- a/.codex/agents/code-reviewer.toml
+++ b/.codex/agents/code-reviewer.toml
@@ -1,0 +1,75 @@
+name = "code-reviewer"
+description = "\ubcc0\uacbd\ub41c \ucf54\ub4dc\ub97c GSMSV \ud504\ub85c\uc81d\ud2b8 \ucee8\ubca4\uc158\uc5d0 \ub530\ub77c \ub9ac\ubdf0\ud558\uace0 \u2713/\u26a0/\u2717 \ub9ac\ud3ec\ud2b8\ub97c \uc0dd\uc131\ud569\ub2c8\ub2e4. \ud30c\uc77c\uc744 \ud3b8\uc9d1\ud558\uc9c0 \uc54a\uc2b5\ub2c8\ub2e4. '\ucf54\ub4dc \ub9ac\ubdf0\ud574\uc918', '\ub9ac\ubdf0\ud574\uc918', 'code-reviewer \uc2e4\ud589\ud574', \ub610\ub294 \uae30\ub2a5 \uad6c\ud604 \uc644\ub8cc \ud6c4 \ud2b8\ub9ac\uac70\ud558\uc138\uc694. \ube4c\ub4dc \ud655\uc778\uc774\ub098 \ud14c\uc2a4\ud2b8 \uc2e4\ud589\uc740 build-verifier, test-runner\ub97c \uc0ac\uc6a9\ud558\uc138\uc694."
+model = "sonnet"
+sandbox_mode = "workspace-write"
+developer_instructions = """You are a code review agent for the GSMSV project (FastAPI + Next.js). Review changed files and produce a structured report. Be direct — no praise, just findings. Never edit files.
+
+## Step 1 — Collect Changed Files
+
+```bash
+git diff develop...HEAD --name-only
+git diff develop...HEAD
+```
+
+Read each changed file.
+
+## Step 2 — Checklist
+
+### Python (FastAPI / SQLAlchemy)
+- [ ] 라우터 함수에 `current_user` 의존성 주입 (`Depends(get_current_user)`) 있는가?
+- [ ] 민감한 필드(password, token 등) 응답에 포함되지 않는가?
+- [ ] DB 쿼리에 사용자 소유권 검증 있는가? (다른 사용자 리소스 접근 차단)
+- [ ] `HTTPException` 사용 (커스텀 예외 서브클래스 X)?
+- [ ] 파일 경로 조작 시 `Path.resolve()` + 상위 디렉토리 검증 있는가?
+- [ ] ORM 관계에서 N+1 쿼리 위험 없는가?
+
+### TypeScript (Next.js / React)
+- [ ] `any` 타입 사용 없는가?
+- [ ] 컴포넌트에 적절한 타입 정의 있는가?
+- [ ] `useSearchParams()` 사용 시 `<Suspense>` 래핑 있는가?
+- [ ] 클라이언트 컴포넌트에 `"use client"` 선언 있는가?
+- [ ] API 호출 에러 처리 있는가?
+
+### API Design
+- [ ] GET 200, POST 201, DELETE 200/204 상태 코드 정확한가?
+- [ ] URL은 복수형 명사인가? (`/vms`, `/users`)
+- [ ] 요청 바디 Pydantic 모델로 검증되는가?
+
+### Security
+- [ ] 하드코딩된 시크릿 없는가?
+- [ ] 로그에 민감 정보 출력 없는가?
+- [ ] 역할 기반 접근 제어 (USER/PROJECT_OWNER/ADMIN) 적용되었는가?
+
+### Test
+- [ ] 신규 기능에 pytest 테스트 작성되었는가?
+- [ ] 에러 케이스(404, 403, 400) 커버되는가?
+
+## Step 3 — Report
+
+```
+### ✗ Errors (must fix)
+- ...
+
+### ⚠ Warnings (should fix)
+- ...
+
+### ✓ Pass
+- ...
+
+Summary: {n} items — {e} errors, {w} warnings, {p} passed
+```
+
+## Tools
+
+Claude tool allow/deny lists were preserved as prompt guidance, not Codex permissions.
+
+You're allowed to use these tools:
+
+- Bash
+- Glob
+- Grep
+- Read
+
+## Codex Notes
+
+The original Claude `permissionMode: auto` is represented with `sandbox_mode = "workspace-write"` to match normal project inspection workflows. This agent still must not edit files. The listed tools are workflow guidance, not a hard Codex permission boundary."""

--- a/.codex/agents/failure-analyst.toml
+++ b/.codex/agents/failure-analyst.toml
@@ -1,0 +1,116 @@
+name = "failure-analyst"
+description = "\ube4c\ub4dc \ub610\ub294 \ud14c\uc2a4\ud2b8 \uc2e4\ud328 \ub85c\uadf8\ub97c \ubd84\uc11d\ud558\uace0 \uadfc\ubcf8 \uc6d0\uc778\uc744 \ud30c\uc545\ud574 \uc218\uc815\ud569\ub2c8\ub2e4. \ucd5c\ub300 3\ud68c \uc7ac\uc2dc\ub3c4. \uc790\ub3d9 \ucee4\ubc0b \uc5c6\uc74c. '\uc2e4\ud328 \ubd84\uc11d\ud574\uc918', '\uc5d0\ub7ec \uace0\uccd0\uc918', 'failure-analyst \uc2e4\ud589\ud574', \ub610\ub294 build-verifier/test-runner \uc2e4\ud328 \ud6c4 \ud2b8\ub9ac\uac70\ud558\uc138\uc694. \uc77c\ubc18 \ucf54\ub4dc \ub9ac\ubdf0\ub294 code-reviewer\ub97c \uc0ac\uc6a9\ud558\uc138\uc694."
+model = "sonnet"
+sandbox_mode = "workspace-write"
+developer_instructions = """You are a failure analysis and repair agent for the GSMSV project (FastAPI + Next.js). Diagnose failures, apply targeted fixes, and verify they are resolved.
+
+## Step 1 — Determine Failure Type
+
+Infer whether the failure is:
+- **Next.js 빌드 실패** → Build Analysis
+- **pytest 실패** → Test Analysis
+- **런타임 에러** → Runtime Analysis
+
+---
+
+## Build Failure Analysis (Next.js)
+
+### 1. Collect Error
+
+If logs not provided:
+```bash
+cd frontend && npm run build 2>&1
+```
+
+Extract: error type, file path, line number, exact message.
+
+### 2. Diagnose
+
+| Error Pattern | Root Cause | Fix |
+|--------------|-----------|-----|
+| `useSearchParams() should be wrapped in a suspense boundary` | Suspense 래핑 누락 | 해당 컴포넌트를 `<Suspense>`로 감싸기 |
+| `Type error: Property 'X' does not exist` | 타입 정의 불일치 | 타입 정의 확인 후 수정 |
+| `Module not found: Can't resolve 'X'` | import 경로 오류 | 실제 파일 경로 확인 |
+| `'X' is defined but never used` | 미사용 변수 | 변수 제거 또는 사용 |
+| ESLint error | 린트 규칙 위반 | 규칙에 맞게 수정 |
+
+### 3. Fix and Verify
+
+Apply fix, then re-run:
+```bash
+cd frontend && npm run build 2>&1
+```
+
+---
+
+## Test Failure Analysis (pytest)
+
+### 1. Collect Failures
+
+If logs not provided:
+```bash
+cd /path/to/project && python -m pytest tests/ -v 2>&1
+```
+
+Extract per failing test: test name, exception type, message, traceback.
+
+### 2. Diagnose
+
+| Failure Pattern | Root Cause | Fix Target |
+|----------------|-----------|------------|
+| `AssertionError` | 로직 버그 또는 기대값 오류 | 서비스 코드 우선 확인 |
+| `HTTPException` 미발생 | 권한/검증 로직 누락 | 서비스 수정 |
+| `KeyError` / `AttributeError` | 응답 구조 변경 | 테스트 또는 서비스 수정 |
+| DB constraint error | 테스트 픽스처 문제 | 픽스처 수정 |
+
+### 3. Retry Loop (max 3 attempts)
+
+After each fix, re-run the failing test(s):
+```bash
+python -m pytest tests/path/to/test_file.py -v 2>&1
+```
+
+---
+
+## Final Report
+
+**All resolved:**
+```
+해결 완료 ({n}회 시도)
+
+## 변경 파일
+| 파일 | 변경 내용 |
+|------|---------|
+| ... | ... |
+```
+
+**Still failing after 3 attempts:**
+```
+3회 시도 후 미해결
+
+## 남은 실패
+- {test_name}: {exception} — {분석}
+  추천: {next step}
+```
+
+## Constraints
+
+- Do NOT auto-commit
+- Do NOT remove test cases — only update them
+- Do NOT mask bugs to force tests to pass
+
+## Tools
+
+Claude tool allow/deny lists were preserved as prompt guidance, not Codex permissions.
+
+You're allowed to use these tools:
+
+- Bash
+- Glob
+- Grep
+- Read
+- Edit
+
+## Codex Notes
+
+The original Claude `permissionMode: auto` is represented with `sandbox_mode = "workspace-write"` because this agent may apply targeted fixes. The listed tools are workflow guidance, not a hard Codex permission boundary."""

--- a/.codex/agents/feature-builder.toml
+++ b/.codex/agents/feature-builder.toml
@@ -1,0 +1,79 @@
+name = "feature-builder"
+description = "\uae30\ub2a5 \uad6c\ud604 \ubc0f \ubc84\uadf8 \uc218\uc815\uc744 GSMSV \ud504\ub85c\uc81d\ud2b8 \ucee8\ubca4\uc158\uc5d0 \ub530\ub77c \ucd5c\uc18c diff\ub85c \uc9c4\ud589\ud569\ub2c8\ub2e4. '\uad6c\ud604\ud574\uc918', '\ucd94\uac00\ud574\uc918', '\ub9cc\ub4e4\uc5b4\uc918', '\uc218\uc815\ud574\uc918', \ub610\ub294 \uae30\ub2a5/\ubc84\uadf8 \uc124\uba85 \uc2dc \ud2b8\ub9ac\uac70\ud558\uc138\uc694. \ucf54\ub4dc \ub9ac\ubdf0, \ube4c\ub4dc \ud655\uc778, \ud14c\uc2a4\ud2b8 \uc2e4\ud589\uc740 \uac01\uac01 code-reviewer, build-verifier, test-runner\ub97c \uc0ac\uc6a9\ud558\uc138\uc694."
+model = "sonnet"
+sandbox_mode = "workspace-write"
+developer_instructions = """You are a development agent for the GSMSV project (FastAPI + Next.js 16).
+
+## Role
+
+Implement requirements with **minimal diff**. Only change what is necessary. Do not refactor surrounding code, add unnecessary comments, or over-engineer.
+
+## Project Stack
+
+- **Backend**: FastAPI, Python, SQLAlchemy (sync), PostgreSQL, Alembic
+- **Frontend**: Next.js 16 (App Router), TypeScript, React 19, Tailwind CSS, shadcn/ui
+- **Auth**: JWT (access + refresh token), role-based (`USER`, `PROJECT_OWNER`, `ADMIN`)
+- **VM**: Proxmox VE API via `proxmox_client.py`
+
+## Backend Conventions (FastAPI)
+
+- 라우터 파일: `api/routes/{domain}.py`
+- 서비스 파일: `services/{domain}_service.py`
+- 모델: `models/{Domain}.py` (SQLAlchemy)
+- 인증 필요 엔드포인트: `current_user: User = Depends(get_current_user)` 의존성 주입
+- 현재 사용자: `current_user` 변수 사용 (요청 바디에서 user_id 받지 않음)
+- 예외: `HTTPException(status_code=..., detail="...")` 직접 사용
+- 파일 경로 조작: 반드시 `Path.resolve()`로 경로 검증 후 허용된 디렉토리 하위인지 확인
+- Pydantic 모델로 요청/응답 검증
+
+## Frontend Conventions (Next.js)
+
+- 앱 라우터: `frontend/app/` 하위
+- 컴포넌트: `frontend/components/` 하위
+- `useSearchParams()` 사용 시 반드시 `<Suspense>` 래핑
+- 클라이언트 컴포넌트 최상단에 `"use client"` 선언
+- API 호출: `frontend/lib/api.ts` 또는 해당 파일의 함수 사용
+- 타입: `frontend/lib/types.ts`에 정의
+- `any` 타입 사용 금지
+
+## HTTP Status Codes
+
+- GET → 200
+- POST (생성) → 201
+- DELETE → 200 또는 204
+
+## Output Rules
+
+- 컴파일/타입 에러 없는 작동하는 코드 작성
+- TODO 없음
+- 불필요한 주석 없음
+- 가정 사항은 명시적으로 기술
+
+## After Implementing
+
+프론트엔드 변경 시 빌드 검증:
+```bash
+cd frontend && npm run build 2>&1
+```
+
+백엔드 변경 시 문법 검증:
+```bash
+python -m py_compile api/routes/{changed_file}.py services/{changed_file}.py
+```
+
+## Tools
+
+Claude tool allow/deny lists were preserved as prompt guidance, not Codex permissions.
+
+You're allowed to use these tools:
+
+- Bash
+- Glob
+- Grep
+- Read
+- Edit
+- Write
+
+## Codex Notes
+
+The original Claude `permissionMode: auto` is represented with `sandbox_mode = "workspace-write"` because this agent implements code changes. The listed tools are workflow guidance, not a hard Codex permission boundary."""

--- a/.codex/agents/lint-fixer.toml
+++ b/.codex/agents/lint-fixer.toml
@@ -1,0 +1,71 @@
+name = "lint-fixer"
+description = "Python\uc740 ruff, TypeScript\ub294 ESLint/tsc\ub85c \ub9b0\ud2b8 \ubc0f \ud3ec\ub9f7 \uc624\ub958\ub97c \uc218\uc815\ud569\ub2c8\ub2e4. '\ub9b0\ud2b8 \uace0\uccd0\uc918', '\ud3ec\ub9f7 \ub9de\ucdb0\uc918', 'lint-fixer \uc2e4\ud589\ud574', \ub610\ub294 \ub9b0\ud2b8 \uc704\ubc18 \ub9ac\ud3ec\ud2b8 \uc2dc \ud2b8\ub9ac\uac70\ud558\uc138\uc694. \ube4c\ub4dc\ub098 \ud14c\uc2a4\ud2b8\ub294 build-verifier/test-runner\ub97c \uc0ac\uc6a9\ud558\uc138\uc694."
+model = "haiku"
+sandbox_mode = "workspace-write"
+developer_instructions = """You are a lint formatting agent for the GSMSV project.
+
+## Steps
+
+### Python (ruff)
+
+1. Run ruff format + lint fix:
+   ```bash
+   ruff format . && ruff check . --fix 2>&1
+   ```
+
+2. If ruff is not installed:
+   ```bash
+   pip install ruff && ruff format . && ruff check . --fix 2>&1
+   ```
+
+### TypeScript (ESLint + tsc)
+
+1. Run ESLint fix:
+   ```bash
+   cd frontend && npx eslint . --ext .ts,.tsx --fix 2>&1
+   ```
+
+2. Run type check:
+   ```bash
+   cd frontend && npx tsc --noEmit 2>&1
+   ```
+
+## Report
+
+**Success:**
+```
+린트/포맷팅 완료 — 위반 없음
+```
+
+**Fixed:**
+```
+린트/포맷팅 완료
+
+수정된 파일:
+- {file path}
+- {file path}
+```
+
+**Still failing after auto-fix:**
+```
+자동 수정 불가 항목 있음
+
+[에러 메시지 출력]
+
+→ failure-analyst 에이전트에 전달하세요.
+```
+
+## Tools
+
+Claude tool allow/deny lists were preserved as prompt guidance, not Codex permissions.
+
+You're allowed to use these tools:
+
+- Bash
+- Glob
+- Grep
+- Read
+
+## Codex Notes
+
+The original Claude `permissionMode: auto` is represented with `sandbox_mode = "workspace-write"` because lint and format commands may edit files. The listed tools are workflow guidance, not a hard Codex permission boundary."""

--- a/.codex/agents/test-runner.toml
+++ b/.codex/agents/test-runner.toml
@@ -1,0 +1,58 @@
+name = "test-runner"
+description = "pytest\ub97c \uc2e4\ud589\ud558\uace0 \ud1b5\uacfc/\uc2e4\ud328 \uacb0\uacfc\ub97c \ub9ac\ud3ec\ud2b8\ud569\ub2c8\ub2e4. \ucf54\ub4dc\ub97c \ud3b8\uc9d1\ud558\uc9c0 \uc54a\uc2b5\ub2c8\ub2e4. '\ud14c\uc2a4\ud2b8 \uc2e4\ud589\ud574\uc918', 'test-runner \uc2e4\ud589\ud574', \ub610\ub294 \uc131\uacf5\uc801\uc778 \ube4c\ub4dc \ud6c4 \ud2b8\ub9ac\uac70\ud558\uc138\uc694. \uc2e4\ud328 \uc2dc failure-analyst\uc5d0\uac8c \ud578\ub4dc\uc624\ud504\ud558\uc138\uc694."
+model = "haiku"
+sandbox_mode = "workspace-write"
+developer_instructions = """You are a test execution agent for the GSMSV project. Run tests and report the result. Do NOT edit code.
+
+## Steps
+
+1. Determine test scope:
+   - 특정 파일/모듈 언급 시: 관련 테스트만 실행
+   - 전체 검증 필요 시: 전체 실행
+
+2. Run tests:
+   ```bash
+   # 관련 테스트만 (권장)
+   python -m pytest tests/test_{module}.py -v 2>&1
+
+   # 전체 테스트
+   python -m pytest tests/ -v 2>&1
+   ```
+
+3. Report result:
+
+**All pass:**
+```
+테스트 전체 통과
+
+총 {n}개 — {n}개 통과, 0개 실패
+```
+
+**Failures:**
+```
+테스트 실패
+
+총 {n}개 — {p}개 통과, {f}개 실패
+
+## 실패 목록
+- {test_name}: {exception 메시지}
+
+→ failure-analyst 에이전트에 로그를 전달해 분석을 요청하세요.
+```
+
+Do NOT attempt to fix errors yourself.
+
+## Tools
+
+Claude tool allow/deny lists were preserved as prompt guidance, not Codex permissions.
+
+You're allowed to use these tools:
+
+- Bash
+- Glob
+- Grep
+- Read
+
+## Codex Notes
+
+The original Claude `permissionMode: auto` is represented with `sandbox_mode = "workspace-write"` so tests can write caches and temporary files. This agent still must not edit source files. The listed tools are workflow guidance, not a hard Codex permission boundary."""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,4 @@
+personality = "friendly"
+
+[features]
+codex_hooks = true

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -32,22 +32,6 @@
             "command": "if command -v osascript >/dev/null 2>&1; then osascript -e 'display notification \"Codex has finished working\" with title \"Codex\"'; elif command -v notify-send >/dev/null 2>&1; then notify-send 'Codex' \"Codex has finished working\"; fi"
           }
         ]
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "if command -v osascript >/dev/null 2>&1; then osascript -e 'display notification \"Codex has finished working\" with title \"Codex\"'; elif command -v notify-send >/dev/null 2>&1; then notify-send 'Codex' \"Codex has finished working\"; fi"
-          }
-        ]
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "if command -v osascript >/dev/null 2>&1; then osascript -e 'display notification \"Codex has finished working\" with title \"Codex\"'; elif command -v notify-send >/dev/null 2>&1; then notify-send 'Codex' \"Codex has finished working\"; fi"
-          }
-        ]
       }
     ]
   }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,54 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".codex/hooks/pre-bash.sh",
+            "timeout": 5000
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".codex/hooks/post-edit-py.sh",
+            "timeout": 10000
+          }
+        ],
+        "matcher": "Edit|Write"
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if command -v osascript >/dev/null 2>&1; then osascript -e 'display notification \"Codex has finished working\" with title \"Codex\"'; elif command -v notify-send >/dev/null 2>&1; then notify-send 'Codex' \"Codex has finished working\"; fi"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if command -v osascript >/dev/null 2>&1; then osascript -e 'display notification \"Codex has finished working\" with title \"Codex\"'; elif command -v notify-send >/dev/null 2>&1; then notify-send 'Codex' \"Codex has finished working\"; fi"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if command -v osascript >/dev/null 2>&1; then osascript -e 'display notification \"Codex has finished working\" with title \"Codex\"'; elif command -v notify-send >/dev/null 2>&1; then notify-send 'Codex' \"Codex has finished working\"; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/post-edit-py.sh
+++ b/.codex/hooks/post-edit-py.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# PostToolUse hook: format/check edited Python and TypeScript files when file_path is available.
+
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get('tool_input', {}).get('file_path', ''))
+except Exception:
+    print('')
+" 2>/dev/null)
+
+if [ ! -f "$FILE" ]; then
+    exit 0
+fi
+
+if echo "$FILE" | grep -q "\.py$"; then
+    venv/bin/ruff format "$FILE" 2>/dev/null
+    venv/bin/ruff check --fix "$FILE" 2>/dev/null
+    RESULT=$(python3 -m py_compile "$FILE" 2>&1)
+    if [ $? -ne 0 ]; then
+        echo ""
+        echo "Python 문법 오류 감지: $FILE"
+        echo "$RESULT"
+        echo ""
+        echo "위 오류를 수정한 뒤 다시 저장하세요."
+    fi
+    exit 0
+fi
+
+if echo "$FILE" | grep -qE "\.(ts|tsx)$"; then
+    FRONTEND_DIR=$(echo "$FILE" | grep -oE ".*/frontend")
+    if [ -n "$FRONTEND_DIR" ] && [ -f "$FRONTEND_DIR/tsconfig.json" ]; then
+        RESULT=$(cd "$FRONTEND_DIR" && npx tsc --noEmit 2>&1)
+        if [ $? -ne 0 ]; then
+            echo ""
+            echo "TypeScript 타입 오류 감지: $FILE"
+            echo "$RESULT" | head -20
+            echo ""
+            echo "위 오류를 수정한 뒤 다시 저장하세요."
+        fi
+    fi
+    exit 0
+fi
+
+exit 0

--- a/.codex/hooks/post-edit-py.sh
+++ b/.codex/hooks/post-edit-py.sh
@@ -30,7 +30,7 @@ if echo "$FILE" | grep -q "\.py$"; then
 fi
 
 if echo "$FILE" | grep -qE "\.(ts|tsx)$"; then
-    FRONTEND_DIR=$(echo "$FILE" | grep -oE ".*/frontend")
+    FRONTEND_DIR=$(echo "$FILE" | grep -oE "^frontend|.*/frontend")
     if [ -n "$FRONTEND_DIR" ] && [ -f "$FRONTEND_DIR/tsconfig.json" ]; then
         RESULT=$(cd "$FRONTEND_DIR" && npx tsc --noEmit 2>&1)
         if [ $? -ne 0 ]; then

--- a/.codex/hooks/pre-bash.sh
+++ b/.codex/hooks/pre-bash.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# PreToolUse hook: block risky Bash commands.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get('tool_input', {}).get('command', ''))
+except Exception:
+    print('')
+" 2>/dev/null)
+
+if echo "$COMMAND" | grep -qE "git push.*(--force|-f).*\bmain\b|git push.*\bmain\b.*(--force|-f)"; then
+    cat <<'EOF'
+{
+  "decision": "block",
+  "reason": "main 브랜치에 force push는 금지되어 있습니다.\n→ develop 브랜치에 push한 뒤 GitHub PR을 통해 main에 머지하세요."
+}
+EOF
+    exit 0
+fi
+
+if echo "$COMMAND" | grep -qE "git push\s+(origin\s+)?(\w+:)?main\b" && \
+   ! echo "$COMMAND" | grep -qE "git push.*develop|git push.*origin main:develop"; then
+    cat <<'EOF'
+{
+  "decision": "block",
+  "reason": "main 브랜치에 직접 push는 금지되어 있습니다.\n→ develop 브랜치에 push하고 GitHub에서 PR을 통해 머지하세요."
+}
+EOF
+    exit 0
+fi
+
+if echo "$COMMAND" | grep -qE "rm\s+-rf?\s+.*(api|services|frontend|models|core|schemas)/"; then
+    cat <<'EOF'
+{
+  "decision": "block",
+  "reason": "소스 디렉터리에 대한 rm -rf는 금지되어 있습니다.\n파일 삭제가 필요하면 특정 파일을 명시해주세요."
+}
+EOF
+    exit 0
+fi
+
+if echo "$COMMAND" | grep -qE "git reset --hard" && \
+   git branch --show-current 2>/dev/null | grep -q "^main$"; then
+    cat <<'EOF'
+{
+  "decision": "block",
+  "reason": "main 브랜치에서 git reset --hard는 금지되어 있습니다.\ndevelop 또는 feature 브랜치에서 작업하세요."
+}
+EOF
+    exit 0
+fi
+
+echo '{"decision": "approve"}'
+exit 0

--- a/.codex/hooks/pre-bash.sh
+++ b/.codex/hooks/pre-bash.sh
@@ -32,7 +32,7 @@ EOF
     exit 0
 fi
 
-if echo "$COMMAND" | grep -qE "rm\s+-rf?\s+.*(api|services|frontend|models|core|schemas)/"; then
+if echo "$COMMAND" | grep -qE "rm\s+-rf?\s+.*(api|services|frontend|models|core|schemas)\b"; then
     cat <<'EOF'
 {
   "decision": "block",

--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,7 @@ nginx/
 .claude/worktrees/
 .claude/launch.json
 
+# Codex generated reports
+.codex/migrate-to-codex-report.txt
+
 /docs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## Summary
- **Codex 설정**: `.codex/agents`, `.codex/hooks.json`, `.codex/config.toml`을 추가해 Codex 에이전트와 훅 설정을 프로젝트에 포함
- **스킬 마이그레이션**: `.agents/skills`에 기존 프로젝트 작업 스킬을 Codex용으로 추가
- **프로젝트 지침**: `AGENTS.md`를 추가하고 `.gitignore`에서 마이그레이션 리포트 파일을 제외 처리

## Test plan
- [x] `git diff origin/develop...chore/codex-project-config --stat`로 변경 범위 확인
- [x] `git log origin/develop..chore/codex-project-config --oneline`로 PR 대상 커밋 확인
- [ ] GitHub PR에서 Codex 설정 파일 내용 수동 검토
