### PR TITLE
add: 새 폴더 구조 기반 Dockerfile 및 docker-compose 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,3 +64,6 @@ NODE_3_USER=root@pam
 NODE_3_PASSWORD=
 NODE_3_SSH_PORT=10013
 NODE_3_BASE_PORT=23000
+
+# ── 데이터베이스 비밀번호 (docker-compose용) ─────────────────────
+DB_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -32,13 +32,6 @@ backups/
 # 업로드 파일 (아바타 등 사용자 콘텐츠)
 uploads/
 
-# Docker
-backend/Dockerfile
-frontend/Dockerfile
-docker-compose.yml
-backend/.dockerignore
-frontend/.dockerignore
-backend/nginx/
 
 # Claude (개인 설정만 제외, 팀 공통 설정은 추적)
 .claude/settings.local.json

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,13 @@
+__pycache__/
+**/__pycache__/
+*.pyc
+*.pyo
+.env
+.env.*
+!.env.example
+tests/
+*.log
+uploads/
+backups/
+ruff.toml
+*.md

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir psycopg2-binary && \
+    pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN mkdir -p uploads/avatars backups
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,12 +3,9 @@ FROM python:3.11-slim
 WORKDIR /app
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir psycopg2-binary && \
-    pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
-
-RUN mkdir -p uploads/avatars backups
 
 EXPOSE 8000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+services:
+  db:
+    image: postgres:16-alpine
+    restart: always
+    command: postgres -c log_connections=on -c log_disconnections=on
+    environment:
+      POSTGRES_USER: gsmsv
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: gsmsv
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U gsmsv"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  backend:
+    build:
+      context: ./backend
+    restart: always
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file: .env
+    environment:
+      DATABASE_URL: postgresql://gsmsv:${DB_PASSWORD}@db:5432/gsmsv
+    volumes:
+      - uploads:/app/uploads
+      - backups:/app/backups
+    ports:
+      - "127.0.0.1:8000:8000"
+
+  frontend:
+    build:
+      context: ./frontend
+      args:
+        NEXT_PUBLIC_DISCORD_URL: ${NEXT_PUBLIC_DISCORD_URL}
+        NEXT_PUBLIC_API_URL: http://backend:8000
+    restart: always
+    depends_on:
+      - backend
+    environment:
+      NEXT_PUBLIC_API_URL: http://backend:8000
+    ports:
+      - "127.0.0.1:3000:3000"
+
+volumes:
+  pgdata:
+  uploads:
+  backups:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         condition: service_healthy
     env_file: .env
     environment:
-      DATABASE_URL: postgresql://gsmsv:${DB_PASSWORD}@db:5432/gsmsv
+      DATABASE_URL: postgresql://${POSTGRES_USER:-gsmsv}:${DB_PASSWORD}@db:5432/${POSTGRES_DB:-gsmsv}
     volumes:
       - uploads:/app/uploads
       - backups:/app/backups
@@ -36,12 +36,12 @@ services:
       context: ./frontend
       args:
         NEXT_PUBLIC_DISCORD_URL: ${NEXT_PUBLIC_DISCORD_URL}
-        NEXT_PUBLIC_API_URL: http://backend:8000
+        API_URL: http://backend:8000
     restart: always
     depends_on:
       - backend
     environment:
-      NEXT_PUBLIC_API_URL: http://backend:8000
+      API_URL: http://backend:8000
     ports:
       - "127.0.0.1:3000:3000"
 

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,7 @@
+node_modules/
+.next/
+.env
+.env.*
+!.env.example
+*.log
+*.md

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,34 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+ARG NEXT_PUBLIC_API_URL=http://backend:8000
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+
+ARG NEXT_PUBLIC_DISCORD_URL
+ENV NEXT_PUBLIC_DISCORD_URL=$NEXT_PUBLIC_DISCORD_URL
+
+RUN pnpm build
+
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/next.config.mjs ./
+
+EXPOSE 3000
+
+CMD ["node_modules/.bin/next", "start"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,13 +9,13 @@ RUN pnpm install --frozen-lockfile
 
 COPY . .
 
-ARG NEXT_PUBLIC_API_URL=http://backend:8000
-ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+ARG API_URL=http://backend:8000
+ENV API_URL=$API_URL
 
 ARG NEXT_PUBLIC_DISCORD_URL
 ENV NEXT_PUBLIC_DISCORD_URL=$NEXT_PUBLIC_DISCORD_URL
 
-RUN pnpm build
+RUN pnpm build && pnpm prune --prod
 
 FROM node:20-alpine AS runner
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -23,7 +23,7 @@ const nextConfig = {
   },
   // FastAPI 백엔드로 API 프록시 — CORS 문제 없이 동일 도메인 호출
   async rewrites() {
-    const backendUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8765";
+    const backendUrl = process.env.API_URL || "http://localhost:8765";
     return [
       {
         source: "/api/:path*",


### PR DESCRIPTION
## Summary
- **폴더 구조 변경 반영**: PR #100으로 `backend/`로 이동된 구조에 맞게 `backend/Dockerfile`, `frontend/Dockerfile`, `docker-compose.yml` 신규 작성
- **build context 변경**: `docker-compose.yml`의 backend 서비스 build context를 `.`에서 `./backend`로 수정
- **패키지 매니저 전환**: `frontend/Dockerfile`에서 `npm ci` → `pnpm install --frozen-lockfile` (pnpm-lock.yaml 기반)
- **`.dockerignore` 추가**: `backend/`, `frontend/` 각각 불필요 파일(tests/, .env, node_modules/ 등) 제외
- **`.gitignore` 수정**: 기존에 Docker 파일을 추적 제외하던 항목 삭제, git 추적 허용
- **`.env.example` 보완**: docker-compose에서 사용하는 `DB_PASSWORD` 항목 추가

## Test plan
- [ ] 배포 VM에서 `docker compose build` 성공 확인
- [ ] `docker compose up -d` 후 3개 서비스(db, backend, frontend) 정상 기동 확인
- [ ] `curl http://localhost:8000` backend 응답 확인
- [ ] `curl http://localhost:3000` frontend 응답 확인
- [x] .gitignore에서 Docker 파일 추적 제외 항목 제거됨
- [x] .env.example에 DB_PASSWORD 항목 존재