### PR TITLE
feat: Serverless 함수 목록 페이지에 사용량 카드 추가

### DIFF
--- a/frontend/app/(dashboard)/serverless/page.tsx
+++ b/frontend/app/(dashboard)/serverless/page.tsx
@@ -14,12 +14,11 @@ export default function ServerlessPage() {
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    Promise.all([getFunctions(), getQuota()])
-      .then(([funcs, q]) => {
-        setFunctions(funcs)
-        setQuota(q)
+    Promise.allSettled([getFunctions(), getQuota()])
+      .then(([funcsResult, quotaResult]) => {
+        if (funcsResult.status === "fulfilled") setFunctions(funcsResult.value)
+        if (quotaResult.status === "fulfilled") setQuota(quotaResult.value)
       })
-      .catch(console.error)
       .finally(() => setLoading(false))
   }, [])
 
@@ -65,15 +64,15 @@ export default function ServerlessPage() {
           <div className="flex items-center justify-between mb-2">
             <span className="text-sm font-medium">함수 사용량</span>
             <span className="text-sm text-muted-foreground">
-              {quota.current} / {quota.max} 개
+              {functions.length} / {quota.max} 개
             </span>
           </div>
           <div className="w-full bg-muted rounded-full h-2">
             <div
               className={`h-2 rounded-full transition-all ${
-                quota.current >= quota.max ? "bg-destructive" : "bg-primary"
+                functions.length >= quota.max ? "bg-destructive" : "bg-primary"
               }`}
-              style={{ width: `${Math.min((quota.current / quota.max) * 100, 100)}%` }}
+              style={{ width: `${quota.max > 0 ? Math.min((functions.length / quota.max) * 100, 100) : 100}%` }}
             />
           </div>
         </div>

--- a/frontend/app/(dashboard)/serverless/page.tsx
+++ b/frontend/app/(dashboard)/serverless/page.tsx
@@ -4,21 +4,26 @@ import { useEffect, useState } from "react"
 import Link from "next/link"
 import { Plus, Zap } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { getFunctions, type ServerlessFunction } from "@/lib/serverless-api"
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip"
+import { getFunctions, getQuota, type ServerlessFunction, type FunctionQuota } from "@/lib/serverless-api"
 import FunctionList from "@/components/serverless/function-list"
-
-const MAX_FUNCTIONS = 5
 
 export default function ServerlessPage() {
   const [functions, setFunctions] = useState<ServerlessFunction[]>([])
+  const [quota, setQuota] = useState<FunctionQuota | null>(null)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    getFunctions()
-      .then(setFunctions)
+    Promise.all([getFunctions(), getQuota()])
+      .then(([funcs, q]) => {
+        setFunctions(funcs)
+        setQuota(q)
+      })
       .catch(console.error)
       .finally(() => setLoading(false))
   }, [])
+
+  const isAtLimit = !quota || functions.length >= quota.max
 
   return (
     <div className="space-y-6">
@@ -29,13 +34,50 @@ export default function ServerlessPage() {
             코드를 배포하고 HTTP 트리거 또는 Cron으로 실행하세요
           </p>
         </div>
-        <Button asChild disabled={functions.length >= MAX_FUNCTIONS}>
-          <Link href="/serverless/new">
-            <Plus className="w-4 h-4 mr-2" />
-            새 함수
-          </Link>
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span tabIndex={isAtLimit ? 0 : -1}>
+              <Button asChild={!isAtLimit} disabled={isAtLimit}>
+                {isAtLimit ? (
+                  <span className="flex items-center">
+                    <Plus className="w-4 h-4 mr-2" />
+                    새 함수
+                  </span>
+                ) : (
+                  <Link href="/serverless/new">
+                    <Plus className="w-4 h-4 mr-2" />
+                    새 함수
+                  </Link>
+                )}
+              </Button>
+            </span>
+          </TooltipTrigger>
+          {isAtLimit && quota && (
+            <TooltipContent>
+              함수 한도({quota.max}개)에 도달했습니다
+            </TooltipContent>
+          )}
+        </Tooltip>
       </div>
+
+      {quota && (
+        <div className="rounded-lg border bg-card p-4">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-sm font-medium">함수 사용량</span>
+            <span className="text-sm text-muted-foreground">
+              {quota.current} / {quota.max} 개
+            </span>
+          </div>
+          <div className="w-full bg-muted rounded-full h-2">
+            <div
+              className={`h-2 rounded-full transition-all ${
+                quota.current >= quota.max ? "bg-destructive" : "bg-primary"
+              }`}
+              style={{ width: `${Math.min((quota.current / quota.max) * 100, 100)}%` }}
+            />
+          </div>
+        </div>
+      )}
 
       {loading ? (
         <div className="text-muted-foreground text-sm">로딩 중...</div>

--- a/frontend/lib/serverless-api.ts
+++ b/frontend/lib/serverless-api.ts
@@ -121,3 +121,12 @@ export async function updateTrigger(funcId: string, triggerId: string, body: Par
 export async function deleteTrigger(funcId: string, triggerId: string): Promise<void> {
   return api<void>(`/serverless/functions/${funcId}/triggers/${triggerId}`, { method: "DELETE" });
 }
+
+export interface FunctionQuota {
+  current: number;
+  max: number;
+}
+
+export async function getQuota(): Promise<FunctionQuota> {
+  return api<FunctionQuota>("/serverless/functions/quota");
+}

--- a/serverless/src/routes/functions.ts
+++ b/serverless/src/routes/functions.ts
@@ -3,6 +3,7 @@ import { prisma } from "../db/prisma";
 import { requireAuth } from "../middleware/auth";
 import { checkFunctionLimit, assertOwnership } from "../services/functionService";
 import { compileTypeScript, compileJavaScript } from "../engine/runtime";
+import { config } from "../config";
 
 const router = Router();
 router.use(requireAuth);
@@ -48,6 +49,13 @@ router.get("/", async (req, res, next) => {
     const where = req.user!.role === "admin" ? {} : { ownerId: req.user!.userId };
     const functions = await prisma.function.findMany({ where, orderBy: { createdAt: "desc" } });
     res.json(functions.map(f => ({ ...f, envVars: JSON.parse(f.envVars) })));
+  } catch (err) { next(err); }
+});
+
+router.get("/quota", async (req, res, next) => {
+  try {
+    const current = await prisma.function.count({ where: { ownerId: req.user!.userId } });
+    res.json({ current, max: config.maxFunctionsPerUser });
   } catch (err) { next(err); }
 });
 


### PR DESCRIPTION
## Summary
- **`GET /functions/quota` 엔드포인트 추가**: `serverless/src/routes/functions.ts`에 사용자별 현재 함수 수(`current`)와 최대 한도(`max`) 반환 라우트 추가. `/:id` 라우트보다 앞에 등록해 충돌 방지
- **`FunctionQuota` 타입 및 `getQuota()` API 함수 추가**: `frontend/lib/serverless-api.ts`에 `/serverless/functions/quota` 호출 함수 추가
- **사용량 카드 UI 추가**: `frontend/app/(dashboard)/serverless/page.tsx` 목록 상단에 프로그레스 바 형태의 `N / M 개` 사용량 카드 표시. 한도 도달 시 바 색상 destructive로 전환
- **하드코딩 제거**: `const MAX_FUNCTIONS = 5` 제거 후 서버에서 내려받은 `quota.max` 사용
- **버튼 비활성화 + Tooltip**: 한도 도달 시 `+ 새 함수` 버튼 disabled 처리 및 "함수 한도(N개)에 도달했습니다" 툴팁 표시

## Test plan
- [x] `/functions/quota` 라우트가 `/:id` 보다 앞에 등록되어 라우트 충돌 없음
- [ ] 함수 0개 상태에서 `0 / 5 개` 사용량 카드 표시 확인
- [ ] 함수 생성 후 카드 수치 갱신 확인
- [ ] 한도(5개) 도달 시 프로그레스 바 빨강 전환 및 버튼 disabled 확인
- [ ] disabled 버튼 호버 시 툴팁 메시지 표시 확인
- [ ] Serverless 서비스 다운 상태에서 카드 미표시, 버튼 disabled(안전 처리) 확인