### PR TITLE
fix: Serverless fetch 샌드박스 DNS Rebinding(TOCTOU) 취약점 차단

### DIFF
--- a/serverless/src/engine/runtime.ts
+++ b/serverless/src/engine/runtime.ts
@@ -8,6 +8,8 @@ import ivm from "isolated-vm";
 import * as esbuild from "esbuild";
 import { lookup } from "dns/promises";
 import { isIPv4 } from "net";
+import * as http from "http";
+import * as https from "https";
 
 function isPrivateIP(ip: string): boolean {
   if (isIPv4(ip)) {
@@ -115,6 +117,9 @@ export async function executeFunction(
       } catch {
         throw new Error(`Invalid URL: ${url}`);
       }
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        throw new Error(`Blocked URL: ${url}`);
+      }
       const hostname = parsed.hostname;
       const host = hostname.startsWith("[") ? hostname.slice(1, -1) : hostname;
 
@@ -134,15 +139,63 @@ export async function executeFunction(
         throw new Error(`Blocked URL: ${url}`);
       }
 
-      const opts = options ? JSON.parse(options) : {};
-      const res = await fetch(url, opts);
-      const body = await res.text();
-      return JSON.stringify({
-        status: res.status,
-        statusText: res.statusText,
-        headers: Object.fromEntries(res.headers.entries()),
-        body,
+      // DNS Rebinding(TOCTOU) 방지: 검증한 IP로 직접 소켓 연결을 맺고,
+      // Host 헤더와 TLS SNI(servername)는 원래 호스트네임을 사용한다.
+      // fetch(url)를 그대로 호출하면 내부적으로 DNS가 재조회되어 검증을 우회할 수 있다.
+      const opts: { method?: string; headers?: Record<string, string>; body?: string } =
+        options ? JSON.parse(options) : {};
+      const isHttps = parsed.protocol === "https:";
+      const port = parsed.port ? Number(parsed.port) : (isHttps ? 443 : 80);
+      const reqHeaders: Record<string, string> = {};
+      for (const [k, v] of Object.entries(opts.headers ?? {})) {
+        if (k.toLowerCase() !== "host") reqHeaders[k] = v;
+      }
+      reqHeaders["Host"] = parsed.host;
+      const body = opts.body;
+      if (body !== undefined && body !== null && reqHeaders["Content-Length"] === undefined) {
+        reqHeaders["Content-Length"] = String(Buffer.byteLength(body));
+      }
+
+      const response = await new Promise<{
+        status: number;
+        statusText: string;
+        headers: Record<string, string>;
+        body: string;
+      }>((resolve, reject) => {
+        const mod = isHttps ? https : http;
+        const req = mod.request(
+          {
+            host: resolvedIP,
+            port,
+            method: opts.method ?? "GET",
+            path: parsed.pathname + parsed.search,
+            headers: reqHeaders,
+            servername: isHttps ? host : undefined,
+          },
+          (res) => {
+            const chunks: Buffer[] = [];
+            res.on("data", (chunk: Buffer) => chunks.push(chunk));
+            res.on("end", () => {
+              const respHeaders: Record<string, string> = {};
+              for (const [k, v] of Object.entries(res.headers)) {
+                if (v === undefined) continue;
+                respHeaders[k] = Array.isArray(v) ? v.join(", ") : String(v);
+              }
+              resolve({
+                status: res.statusCode ?? 0,
+                statusText: res.statusMessage ?? "",
+                headers: respHeaders,
+                body: Buffer.concat(chunks).toString("utf8"),
+              });
+            });
+          }
+        );
+        req.on("error", reject);
+        if (body !== undefined && body !== null) req.write(body);
+        req.end();
       });
+
+      return JSON.stringify(response);
     });
     await jail.set("__fetchRef", fetchCallback);
     await context.eval(`

--- a/serverless/src/engine/runtime.ts
+++ b/serverless/src/engine/runtime.ts
@@ -156,6 +156,7 @@ export async function executeFunction(
         reqHeaders["Content-Length"] = String(Buffer.byteLength(body));
       }
 
+      // 리다이렉트(3xx)는 의도적으로 차단: 새 URL에 대한 SSRF 재검증 없이 따라가면 우회 가능
       const response = await new Promise<{
         status: number;
         statusText: string;
@@ -171,6 +172,7 @@ export async function executeFunction(
             path: parsed.pathname + parsed.search,
             headers: reqHeaders,
             servername: isHttps ? host : undefined,
+            timeout: 10000,
           },
           (res) => {
             const chunks: Buffer[] = [];
@@ -181,16 +183,21 @@ export async function executeFunction(
                 if (v === undefined) continue;
                 respHeaders[k] = Array.isArray(v) ? v.join(", ") : String(v);
               }
+              const contentType = res.headers["content-type"] ?? "";
+              const charsetMatch = contentType.match(/charset=([^\s;]+)/i);
+              const encoding = (charsetMatch?.[1]?.toLowerCase() ?? "utf-8") as BufferEncoding;
+              const safeEncoding: BufferEncoding = Buffer.isEncoding(encoding) ? encoding : "utf8";
               resolve({
                 status: res.statusCode ?? 0,
                 statusText: res.statusMessage ?? "",
                 headers: respHeaders,
-                body: Buffer.concat(chunks).toString("utf8"),
+                body: Buffer.concat(chunks).toString(safeEncoding),
               });
             });
           }
         );
         req.on("error", reject);
+        req.on("timeout", () => req.destroy(new Error("Request timed out")));
         if (body !== undefined && body !== null) req.write(body);
         req.end();
       });


### PR DESCRIPTION
## Summary

- Serverless `fetch` 샌드박스에서 IP 검증 후 `fetch(url)`를 재호출하면 **DNS가 재조회**되어 검증을 우회하는 **TOCTOU/DNS Rebinding SSRF** 경로가 존재함
- 검증한 IP로 `http.request` / `https.request`를 통해 직접 소켓을 연결하고 `Host` 헤더·TLS `servername`(SNI)에는 원래 호스트네임을 사용하도록 변경
- `http`/`https` 외 프로토콜은 명시적으로 차단

PR #115 의 [gemini-code-assist 코멘트](https://github.com/GSMSV/GSM-SV/pull/115#discussion_r2570000) 반영.

## Test plan

- [ ] 공개 호스트로 `fetch("https://example.com")` 정상 응답 확인
- [ ] HTTPS 인증서 검증이 원래 호스트네임 기준으로 동작하는지 확인 (SNI)
- [ ] `fetch("http://127.0.0.1")` 차단 확인
- [ ] DNS Rebinding 시나리오(첫 조회 공개 IP → 두 번째 조회 내부 IP)에서도 내부망 요청 차단 확인
- [ ] POST/PUT body·헤더 전달 정상 동작 확인