### PR TITLE
fix: CD 파이프라인 backend 이미지 빌드 실패 수정

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,7 +3,8 @@ FROM python:3.11-slim
 WORKDIR /app
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --timeout 120 -r requirements.txt
 
 COPY . .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
   backend:
     build:
       context: ./backend
+      network: host
     restart: always
     depends_on:
       db:


### PR DESCRIPTION
## Summary
- **Docker 빌드 네트워크**: `docker-compose.yml` backend build에 `network: host` 추가 — 브리지 네트워크에서 `pypi.org` 아웃바운드가 차단되어 발생한 `pip install` 타임아웃 해결
- **BuildKit 캐시 마운트**: `backend/Dockerfile` pip install에 `--mount=type=cache,target=/root/.cache/pip` 적용 — 재빌드 시 패키지 재다운로드 불필요
- **pip 타임아웃 증가**: `--timeout 120`으로 네트워크 지연 상황에서의 안정성 확보

## Test plan
- [x] `git diff` 로 변경 내용 확인
- [ ] CD 파이프라인 재실행 후 `Build all images` 단계 통과 확인
- [ ] 배포 후 backend 컨테이너 정상 기동 확인