### PR TITLE
fix: serverless Docker 빌드 네트워크를 host로 설정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
   serverless:
     build:
       context: ./serverless
+      network: host
     restart: always
     depends_on:
       db:


### PR DESCRIPTION
## Summary

- GitHub Actions CD에서 **serverless 이미지 빌드 실패** (`apt-get update` → `deb.debian.org` 연결 타임아웃, `openssl/python3/make` 패키지 설치 불가)
- 이전 PR #118에서 backend에만 적용했던 `network: host` 설정을 **serverless 서비스에도 동일하게 적용**
- 동일 원인 (러너에서 docker buildx 기본 네트워크가 데비안 미러로 외부 접근 불가)

실패 워크플로우: https://github.com/GSMSV/GSM-SV/actions/runs/26015606624/job/76464932836

## Test plan

- [ ] develop 머지 후 CD 워크플로우(`Deploy All Services`)가 정상적으로 두 이미지 빌드까지 통과하는지 확인
- [ ] `docker compose build serverless` 로컬 빌드 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)