### PR TITLE
fix: serverless Docker 빌드 네트워크를 host로 설정하고 backend 포트 바인딩 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - uploads:/app/uploads
       - backups:/app/backups
     ports:
-      - "127.0.0.1:8000:8000"
+      - "8000:8000"
     networks:
       - internal-net
       - serverless-net
@@ -42,6 +42,7 @@ services:
   serverless:
     build:
       context: ./serverless
+      network: host
     restart: always
     depends_on:
       db:


### PR DESCRIPTION
## Summary
- **Docker 빌드 설정**: serverless 서비스 빌드에 `network: host` 추가
- **포트 바인딩**: backend 서비스를 모든 인터페이스에서 접근 가능하도록 변경 (`127.0.0.1:8000:8000` → `8000:8000`)

## Test plan
- [x] Docker Compose 파일 유효성 확인
- [ ] 로컬 환경에서 `docker compose up` 실행 및 서비스 정상 작동 확인