### PR TITLE
feat: PO 계정 VM 생성 노드 제한 해제 (1, 2번 서버 허용)

### DIFF
--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -270,13 +270,11 @@ def create_vm(
         raise HTTPException(status_code=403, detail="프로젝트 커스텀 티어는 프로젝트 오너만 사용할 수 있습니다.")
 
     # 역할 기반 노드 접근 제어 (ADMIN은 모든 노드 허용)
-    if node_name and current_user.role == UserRole.USER:
-        project_node = settings.PROJECT_NODE_NAME
-        if node_name == project_node:
-            raise HTTPException(
-                status_code=403,
-                detail="일반 사용자는 프로젝트 전용 노드에 VM을 생성할 수 없습니다.",
-            )
+    if current_user.role == UserRole.USER and node_name == settings.PROJECT_NODE_NAME:
+        raise HTTPException(
+            status_code=403,
+            detail="일반 사용자는 프로젝트 전용 노드에 VM을 생성할 수 없습니다.",
+        )
 
     specs = TIER_SPECS.get(tier)
     if not specs:

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -269,22 +269,13 @@ def create_vm(
     if tier == VMTierEnum.PROJECT_CUSTOM and current_user.role not in (UserRole.ADMIN, UserRole.PROJECT_OWNER):
         raise HTTPException(status_code=403, detail="프로젝트 커스텀 티어는 프로젝트 오너만 사용할 수 있습니다.")
 
-    # 프로젝트 커스텀 티어는 전용 노드 강제
-    if tier == VMTierEnum.PROJECT_CUSTOM:
-        node_name = settings.PROJECT_NODE_NAME
-
     # 역할 기반 노드 접근 제어 (ADMIN은 모든 노드 허용)
-    if node_name and current_user.role != UserRole.ADMIN:
+    if node_name and current_user.role == UserRole.USER:
         project_node = settings.PROJECT_NODE_NAME
-        if current_user.role == UserRole.USER and node_name == project_node:
+        if node_name == project_node:
             raise HTTPException(
                 status_code=403,
                 detail="일반 사용자는 프로젝트 전용 노드에 VM을 생성할 수 없습니다.",
-            )
-        if current_user.role == UserRole.PROJECT_OWNER and node_name != project_node:
-            raise HTTPException(
-                status_code=403,
-                detail=f"프로젝트 오너는 프로젝트 전용 노드({project_node})에서만 VM을 생성할 수 있습니다.",
             )
 
     specs = TIER_SPECS.get(tier)


### PR DESCRIPTION
## Summary

- **PROJECT_OWNER** 계정의 노드 생성 제한 해제 — 기존 `gsmgpu3` 전용에서 전체 노드(1, 2, 3)로 확장
- **PROJECT_CUSTOM** 티어의 `gsmgpu3` 강제 배정 로직 제거 — 노드 자유 선택 가능
- `USER` 역할의 `gsmgpu3` 접근 차단은 그대로 유지

## Test plan

- [ ] PO 계정으로 `gsmgpu1`, `gsmgpu2`에 VM 생성 성공 확인
- [ ] PO 계정으로 `PROJECT_CUSTOM` 티어 + `gsmgpu1`/`gsmgpu2` 생성 후 resize 작동 확인 (hotplug 활성화됨)
- [ ] 일반 USER 계정으로 `gsmgpu3` 접근 시 403 유지 확인