### PR TITLE
merge: develop 내용을 main에 반영

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ Proxmox VE 기반 VM 신청·관리 플랫폼 + Serverless 함수 실행 서비�
 | Proxmox `verify_ssl=False` | 내부망 + 자체 서명 인증서 |
 | Proxmox 180초 타임아웃 | VM 클론·스냅샷 장시간 작업 |
 | CORS `allow_headers=["*"]` | 동일 도메인 운영 |
+| 같은 이메일의 `USER` + `PROJECT_OWNER` 계정 공존 | 일반 사용자 계정과 프로젝트 오너 계정은 별개 계정 정책. OAuth/DataGSM 로그인은 `USER` row 기준으로 처리하며, `PROJECT_OWNER` row 존재만으로 차단하거나 병합하면 안 됨. 단, `ADMIN` row가 같은 이메일에 있으면 OAuth는 409로 차단 |
 
 ---
 

--- a/backend/api/routes/firewall.py
+++ b/backend/api/routes/firewall.py
@@ -153,15 +153,25 @@ async def add_custom_port(
 
     # iptables DNAT 추가 — 실패 시 DB 레코드 삭제
     if vm.internal_ip:
-        success = manage_custom_iptables(
-            server=server,
-            vm_ip=vm.internal_ip,
-            internal_port=body.internal_port,
-            external_port=external_port,
-            protocol=body.protocol,
-            action="ADD",
-            source_ip=body.source,
-        )
+        try:
+            success = manage_custom_iptables(
+                server=server,
+                vm_ip=vm.internal_ip,
+                internal_port=body.internal_port,
+                external_port=external_port,
+                protocol=body.protocol,
+                action="ADD",
+                source_ip=body.source,
+            )
+        except ValueError as e:
+            db.delete(vm_port)
+            db.commit()
+            raise HTTPException(status_code=400, detail=str(e))
+        except Exception as e:
+            db.delete(vm_port)
+            db.commit()
+            logger.error(f"[firewall] Gateway iptables 설정 중 예외 발생: {e}")
+            raise HTTPException(status_code=502, detail="Gateway 방화벽 규칙 설정에 실패했습니다.")
         if not success:
             db.delete(vm_port)
             db.commit()
@@ -255,19 +265,23 @@ async def delete_custom_port(
     # iptables 규칙 삭제 ("tcp/udp" 프로토콜은 두 번 호출)
     # 실패해도 DB 레코드는 삭제 — 삭제 실패 시 영구적으로 못 지우는 것이 더 위험
     if vm.internal_ip:
-        # ADD 시 source_ip와 동일한 값으로 DELETE — "0.0.0.0/0"은 플래그 없이 추가된 것이므로 None 처리
-        source_ip = vm_port.source if vm_port.source and vm_port.source != "0.0.0.0/0" else None
+        # source 정규화는 manage_custom_iptables 내부에서 처리합니다.
+        source_ip = vm_port.source
         protocols = ["tcp", "udp"] if vm_port.protocol == "tcp/udp" else [vm_port.protocol]
         for proto in protocols:
-            success = manage_custom_iptables(
-                server=server,
-                vm_ip=vm.internal_ip,
-                internal_port=vm_port.internal_port,
-                external_port=vm_port.external_port,
-                protocol=proto,
-                action="DELETE",
-                source_ip=source_ip,
-            )
+            try:
+                success = manage_custom_iptables(
+                    server=server,
+                    vm_ip=vm.internal_ip,
+                    internal_port=vm_port.internal_port,
+                    external_port=vm_port.external_port,
+                    protocol=proto,
+                    action="DELETE",
+                    source_ip=source_ip,
+                )
+            except Exception as e:
+                success = False
+                logger.error(f"[firewall] Gateway iptables 삭제 예외 — port {vm_port.external_port} ({proto}): {e}")
             if not success:
                 logger.error(f"[firewall] Gateway iptables 삭제 실패 — port {vm_port.external_port} ({proto}), DB 레코드는 삭제 진행")
 

--- a/backend/api/routes/oauth.py
+++ b/backend/api/routes/oauth.py
@@ -246,11 +246,12 @@ async def oauth_callback(
 
     # 7. 임시 코드 발급 → 프론트에서 POST /exchange로 교환
     temp_code = secrets.token_urlsafe(48)
-    _token_store[temp_code] = {
-        "access_token": our_access,
-        "refresh_token": our_refresh,
-        "expires": time.time() + 60,  # 1분 유효
-    }
+    with _store_lock:
+        _token_store[temp_code] = {
+            "access_token": our_access,
+            "refresh_token": our_refresh,
+            "expires": time.time() + 60,  # 1분 유효
+        }
 
     redirect_url = f"{settings.FRONTEND_URL}/auth/callback?code={temp_code}"
     return RedirectResponse(redirect_url)

--- a/backend/api/routes/oauth.py
+++ b/backend/api/routes/oauth.py
@@ -181,17 +181,20 @@ async def oauth_callback(
     if not email:
         raise HTTPException(status_code=400, detail="이메일 정보를 가져올 수 없습니다.")
 
-    # 5. 기존 유저 매칭 (이메일 기준)
-    # 복합 유니크 제약(email, role)으로 동일 이메일에 여러 역할 계정이 존재할 수 있으므로
-    # 관리자/오너 계정 존재 여부를 먼저 명시적으로 차단
-    if db.query(User).filter(User.email == email, User.role != UserRole.USER).first():
+    # 5. 기존 유저 매칭 (OAuth는 일반 USER 계정으로만 로그인)
+    # 동일 이메일의 PROJECT_OWNER 계정은 별도 계정으로 공존할 수 있습니다.
+    user = (
+        db.query(User).filter(User.email == email, User.role == UserRole.USER).first()
+    )
+
+    if not user and db.query(User).filter(
+        User.email == email,
+        User.role == UserRole.ADMIN,
+    ).first():
         raise HTTPException(
             status_code=409,
             detail="해당 이메일은 다른 권한 계정으로 이미 존재합니다.",
         )
-    user = (
-        db.query(User).filter(User.email == email, User.role == UserRole.USER).first()
-    )
 
     if user:
         # 기존 계정에 OAuth 연결

--- a/backend/api/routes/oauth.py
+++ b/backend/api/routes/oauth.py
@@ -9,6 +9,7 @@ import secrets
 import time
 import httpx
 import logging
+import threading
 from urllib.parse import urlencode
 
 from fastapi import APIRouter, HTTPException, Query, Depends, Request
@@ -30,6 +31,7 @@ router = APIRouter()
 # 임시 저장소 (프로덕션에서는 Redis 사용 권장)
 _pkce_store: dict[str, tuple[str, float]] = {}  # state → (code_verifier, expires_at)
 _token_store: dict[str, dict] = {}  # temp_code → {access, refresh, expires}
+_store_lock = threading.RLock()
 _STORE_TTL = 300  # 5분
 
 
@@ -45,15 +47,16 @@ def validate_oauth_store_mode():
 
 def _cleanup_stores():
     """만료된 항목 정리"""
-    now = time.time()
-    expired_pkce = [
-        k for k, v in _pkce_store.items() if isinstance(v, tuple) and v[1] < now
-    ]
-    for k in expired_pkce:
-        _pkce_store.pop(k, None)
-    expired_tokens = [k for k, v in _token_store.items() if v.get("expires", 0) < now]
-    for k in expired_tokens:
-        _token_store.pop(k, None)
+    with _store_lock:
+        now = time.time()
+        expired_pkce = [
+            k for k, v in _pkce_store.items() if isinstance(v, tuple) and v[1] < now
+        ]
+        for k in expired_pkce:
+            _pkce_store.pop(k, None)
+        expired_tokens = [k for k, v in _token_store.items() if v.get("expires", 0) < now]
+        for k in expired_tokens:
+            _token_store.pop(k, None)
 
 
 def _generate_pkce() -> tuple[str, str]:
@@ -76,11 +79,12 @@ async def oauth_authorize(request: Request):
 
     # state → (verifier, 만료시간) 저장
     _cleanup_stores()
-    if len(_pkce_store) > 1000:
-        raise HTTPException(
-            status_code=503, detail="서버가 바쁩니다. 잠시 후 다시 시도해주세요."
-        )
-    _pkce_store[state] = (verifier, time.time() + _STORE_TTL)
+    with _store_lock:
+        if len(_pkce_store) > 1000:
+            raise HTTPException(
+                status_code=503, detail="서버가 바쁩니다. 잠시 후 다시 시도해주세요."
+            )
+        _pkce_store[state] = (verifier, time.time() + _STORE_TTL)
 
     params = {
         "client_id": settings.DATAGSM_CLIENT_ID,
@@ -103,7 +107,8 @@ async def oauth_callback(
     """DataGSM 콜백 — code로 토큰 교환 → userinfo 조회 → 우리 JWT 발급"""
 
     # 1. PKCE verifier 꺼내기
-    entry = _pkce_store.pop(state, None)
+    with _store_lock:
+        entry = _pkce_store.pop(state, None)
     if not entry or (isinstance(entry, tuple) and entry[1] < time.time()):
         raise HTTPException(
             status_code=400,
@@ -187,7 +192,7 @@ async def oauth_callback(
         db.query(User).filter(User.email == email, User.role == UserRole.USER).first()
     )
 
-    if not user and db.query(User).filter(
+    if db.query(User).filter(
         User.email == email,
         User.role == UserRole.ADMIN,
     ).first():
@@ -258,7 +263,8 @@ class TokenExchangeRequest(BaseModel):
 @router.post("/exchange")
 async def exchange_temp_code(body: TokenExchangeRequest):
     """임시 코드를 JWT 토큰으로 교환 (1회용) — httpOnly 쿠키에 설정"""
-    entry = _token_store.pop(body.code, None)
+    with _store_lock:
+        entry = _token_store.pop(body.code, None)
     if not entry or entry["expires"] < time.time():
         raise HTTPException(
             status_code=400, detail="유효하지 않거나 만료된 코드입니다."

--- a/backend/services/network_service.py
+++ b/backend/services/network_service.py
@@ -24,11 +24,14 @@ PORT_OFFSETS = {
 
 def calculate_ports(base_port: int, vmid: int):
     """정책에 따라 포트 번호를 계산합니다."""
-    return {
+    ports = {
         "ssh": base_port + PORT_OFFSETS["ssh"] + vmid,
         "svc1": base_port + PORT_OFFSETS["svc1"] + vmid,
         "svc2": base_port + PORT_OFFSETS["svc2"] + vmid,
     }
+    for name, port in ports.items():
+        _validate_port(port, name)
+    return ports
 
 _IP_PATTERN = re.compile(r'^(\d{1,3}\.){3}\d{1,3}$')
 
@@ -45,7 +48,7 @@ def _validate_ip(ip: str) -> str:
 def _validate_port(port: int, name: str = "port") -> int:
     """iptables 명령에 사용할 포트 범위를 검증합니다."""
     if not isinstance(port, int) or not (1 <= port <= 65535):
-        raise ValueError(f"잘못된 {name} 범위: {port}")
+        raise ValueError(f"{name} 포트는 유효 범위(1~65535)여야 합니다: {port}")
     return port
 
 
@@ -74,6 +77,36 @@ def _iptables_command(table: Optional[str], chain: str, rule_args: str, action: 
     )
 
 
+def _run_iptables_commands(
+    ssh: paramiko.SSHClient,
+    commands: list[str],
+    rollback_commands: Optional[list[str]] = None,
+) -> bool:
+    """모든 iptables 명령을 실행하고 실패 시 가능한 rollback까지 시도합니다."""
+    success = True
+    for cmd in commands:
+        logger.info(f"Executing iptables command: {cmd}")
+        _, stdout_ch, stderr_ch = ssh.exec_command(cmd)
+        exit_status = stdout_ch.channel.recv_exit_status()
+        if exit_status != 0:
+            err = stderr_ch.read().decode()
+            logger.error(f"iptables command failed (exit {exit_status}): {err}")
+            success = False
+
+    if not success and rollback_commands:
+        for cmd in rollback_commands:
+            try:
+                logger.info(f"Rolling back iptables command: {cmd}")
+                _, stdout_ch, stderr_ch = ssh.exec_command(cmd)
+                exit_status = stdout_ch.channel.recv_exit_status()
+                if exit_status != 0:
+                    err = stderr_ch.read().decode()
+                    logger.error(f"iptables rollback failed (exit {exit_status}): {err}")
+            except Exception as e:
+                logger.error(f"iptables rollback error: {e}")
+    return success
+
+
 def manage_iptables(server: Server, vmid: int, vm_ip: str, action: str = "ADD"):
     """
     Router에 SSH로 접속하여 iptables DNAT 규칙을 추가하거나 삭제합니다.
@@ -94,6 +127,7 @@ def manage_iptables(server: Server, vmid: int, vm_ip: str, action: str = "ADD"):
     # iptables 명령어 생성 (예시: DNAT 설정)
     # -i {인터페이스} 는 환경에 따라 다를 수 있으므로 여기선 생략하거나 기본값 사용
     commands = []
+    rollback_commands = []
     
     # (공개포트, 내부포트, 프로토콜 목록)
     port_mapping = [
@@ -110,6 +144,9 @@ def manage_iptables(server: Server, vmid: int, vm_ip: str, action: str = "ADD"):
             forward_args = f"-p {proto} -d {vm_ip} --dport {internal_port} -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
             commands.append(_iptables_command("nat", "PREROUTING", dnat_args, action))
             commands.append(_iptables_command(None, "FORWARD", forward_args, action))
+            if action == "ADD":
+                rollback_commands.append(_iptables_command("nat", "PREROUTING", dnat_args, "DELETE"))
+                rollback_commands.append(_iptables_command(None, "FORWARD", forward_args, "DELETE"))
 
     ssh = paramiko.SSHClient()
     try:
@@ -121,19 +158,16 @@ def manage_iptables(server: Server, vmid: int, vm_ip: str, action: str = "ADD"):
             timeout=10
         )
 
-        for cmd in commands:
-            logger.info(f"Executing on {server.gateway_ip}: {cmd}")
-            _, stdout_ch, stderr_ch = ssh.exec_command(cmd)
-            exit_status = stdout_ch.channel.recv_exit_status()
-            if exit_status != 0:
-                err = stderr_ch.read().decode()
-                logger.error(f"iptables command failed (exit {exit_status}): {err}")
-                return False
+        success = _run_iptables_commands(
+            ssh,
+            commands,
+            rollback_commands if action == "ADD" else None,
+        )
 
         # iptables 백업 (변경 후 자동 저장)
         _backup_iptables(ssh, server.gateway_ip)
 
-        return True
+        return success
     except Exception as e:
         logger.error(f"Gateway SSH 접속 및 iptables 설정 실패: {e}")
         # 생성/삭제 핵심 로직을 멈추지는 않되 로그를 기록함
@@ -187,6 +221,10 @@ def manage_custom_iptables(
         _iptables_command("nat", "PREROUTING", dnat_args, action),
         _iptables_command(None, "FORWARD", forward_args, action),
     ]
+    rollback_commands = [
+        _iptables_command("nat", "PREROUTING", dnat_args, "DELETE"),
+        _iptables_command(None, "FORWARD", forward_args, "DELETE"),
+    ] if action == "ADD" else None
 
     ssh = paramiko.SSHClient()
     try:
@@ -197,16 +235,9 @@ def manage_custom_iptables(
             password=server.gateway_password or "",
             timeout=10,
         )
-        for cmd in commands:
-            logger.info(f"Executing on {server.gateway_ip}: {cmd}")
-            _, stdout_ch, stderr_ch = ssh.exec_command(cmd)
-            exit_status = stdout_ch.channel.recv_exit_status()
-            if exit_status != 0:
-                err = stderr_ch.read().decode()
-                logger.error(f"iptables command failed (exit {exit_status}): {err}")
-                return False
+        success = _run_iptables_commands(ssh, commands, rollback_commands)
         _backup_iptables(ssh, server.gateway_ip)
-        return True
+        return success
     except Exception as e:
         logger.error(f"Gateway SSH 접속 및 커스텀 iptables 설정 실패: {e}")
         return False

--- a/backend/services/network_service.py
+++ b/backend/services/network_service.py
@@ -2,6 +2,7 @@ import re
 import random
 import logging
 import paramiko
+import ipaddress
 from typing import Optional
 from datetime import datetime
 from pathlib import Path
@@ -40,6 +41,39 @@ def _validate_ip(ip: str) -> str:
         raise ValueError(f"잘못된 IP 범위: {ip}")
     return ip
 
+
+def _validate_port(port: int, name: str = "port") -> int:
+    """iptables 명령에 사용할 포트 범위를 검증합니다."""
+    if not isinstance(port, int) or not (1 <= port <= 65535):
+        raise ValueError(f"잘못된 {name} 범위: {port}")
+    return port
+
+
+def _normalize_source_ip(source_ip: Optional[str]) -> Optional[str]:
+    """source IP/CIDR을 검증하고 전체 허용 값은 iptables 인자에서 제외합니다."""
+    if source_ip in (None, "", "0.0.0.0/0", "0.0.0.0"):
+        return None
+    try:
+        ipaddress.ip_network(source_ip, strict=False)
+    except ValueError:
+        raise ValueError(f"잘못된 source IP/CIDR 형식: {source_ip}")
+    return source_ip
+
+
+def _iptables_command(table: Optional[str], chain: str, rule_args: str, action: str) -> str:
+    """ADD는 중복을 막고, DELETE는 같은 규칙을 모두 제거하는 명령을 만듭니다."""
+    if action not in {"ADD", "DELETE"}:
+        raise ValueError(f"유효하지 않은 iptables action: {action}")
+
+    base = f"sudo iptables {f'-t {table} ' if table else ''}"
+    if action == "ADD":
+        return f"{base}-C {chain} {rule_args} || {base}-A {chain} {rule_args}"
+    return (
+        f"{base}-L {chain} -n >/dev/null && "
+        f"while {base}-D {chain} {rule_args} 2>/dev/null; do :; done"
+    )
+
+
 def manage_iptables(server: Server, vmid: int, vm_ip: str, action: str = "ADD"):
     """
     Router에 SSH로 접속하여 iptables DNAT 규칙을 추가하거나 삭제합니다.
@@ -48,6 +82,8 @@ def manage_iptables(server: Server, vmid: int, vm_ip: str, action: str = "ADD"):
     # SSH 명령어 인젝션 방지: IP 형식 검증
     _validate_ip(vm_ip)
     _validate_ip(settings.GATEWAY_PUBLIC_IP)
+    if action not in {"ADD", "DELETE"}:
+        raise ValueError(f"유효하지 않은 iptables action: {action}")
 
     if not server.gateway_ip or not server.gateway_user:
         logger.warning(f"서버 {server.name}의 Gateway 정보가 설정되지 않아 iptables 설정을 건너뜁니다.")
@@ -67,13 +103,13 @@ def manage_iptables(server: Server, vmid: int, vm_ip: str, action: str = "ADD"):
     ]
 
     for public_port, internal_port, protocols in port_mapping:
+        _validate_port(public_port, "public_port")
+        _validate_port(internal_port, "internal_port")
         for proto in protocols:
-            if action == "ADD":
-                commands.append(f"sudo iptables -t nat -A PREROUTING -p {proto} -d {settings.GATEWAY_PUBLIC_IP} --dport {public_port} -j DNAT --to-destination {vm_ip}:{internal_port}")
-                commands.append(f"sudo iptables -A FORWARD -p {proto} -d {vm_ip} --dport {internal_port} -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT")
-            else:
-                commands.append(f"sudo iptables -t nat -D PREROUTING -p {proto} -d {settings.GATEWAY_PUBLIC_IP} --dport {public_port} -j DNAT --to-destination {vm_ip}:{internal_port}")
-                commands.append(f"sudo iptables -D FORWARD -p {proto} -d {vm_ip} --dport {internal_port} -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT")
+            dnat_args = f"-p {proto} -d {settings.GATEWAY_PUBLIC_IP} --dport {public_port} -j DNAT --to-destination {vm_ip}:{internal_port}"
+            forward_args = f"-p {proto} -d {vm_ip} --dport {internal_port} -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
+            commands.append(_iptables_command("nat", "PREROUTING", dnat_args, action))
+            commands.append(_iptables_command(None, "FORWARD", forward_args, action))
 
     ssh = paramiko.SSHClient()
     try:
@@ -92,6 +128,7 @@ def manage_iptables(server: Server, vmid: int, vm_ip: str, action: str = "ADD"):
             if exit_status != 0:
                 err = stderr_ch.read().decode()
                 logger.error(f"iptables command failed (exit {exit_status}): {err}")
+                return False
 
         # iptables 백업 (변경 후 자동 저장)
         _backup_iptables(ssh, server.gateway_ip)
@@ -133,18 +170,22 @@ def manage_custom_iptables(
         raise ValueError(f"유효하지 않은 프로토콜: {protocol}. tcp 또는 udp만 허용됩니다.")
     _validate_ip(vm_ip)
     _validate_ip(settings.GATEWAY_PUBLIC_IP)
+    _validate_port(internal_port, "internal_port")
+    _validate_port(external_port, "external_port")
+    if action not in {"ADD", "DELETE"}:
+        raise ValueError(f"유효하지 않은 iptables action: {action}")
 
     if not server.gateway_ip or not server.gateway_user:
         logger.warning(f"서버 {server.name}의 Gateway 정보가 설정되지 않아 iptables 설정을 건너뜁니다.")
         return False
 
-    flag = "-A" if action == "ADD" else "-D"
-    if source_ip in ("0.0.0.0/0", "0.0.0.0"):
-        source_ip = None
+    source_ip = _normalize_source_ip(source_ip)
     src = f"-s {source_ip} " if source_ip else ""
+    dnat_args = f"{src}-p {protocol} -d {settings.GATEWAY_PUBLIC_IP} --dport {external_port} -j DNAT --to-destination {vm_ip}:{internal_port}"
+    forward_args = f"{src}-p {protocol} -d {vm_ip} --dport {internal_port} -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT"
     commands = [
-        f"sudo iptables -t nat {flag} PREROUTING {src}-p {protocol} -d {settings.GATEWAY_PUBLIC_IP} --dport {external_port} -j DNAT --to-destination {vm_ip}:{internal_port}",
-        f"sudo iptables {flag} FORWARD {src}-p {protocol} -d {vm_ip} --dport {internal_port} -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT",
+        _iptables_command("nat", "PREROUTING", dnat_args, action),
+        _iptables_command(None, "FORWARD", forward_args, action),
     ]
 
     ssh = paramiko.SSHClient()

--- a/backend/services/network_service.py
+++ b/backend/services/network_service.py
@@ -165,7 +165,8 @@ def manage_iptables(server: Server, vmid: int, vm_ip: str, action: str = "ADD"):
         )
 
         # iptables 백업 (변경 후 자동 저장)
-        _backup_iptables(ssh, server.gateway_ip)
+        if success:
+            _backup_iptables(ssh, server.gateway_ip)
 
         return success
     except Exception as e:
@@ -236,7 +237,8 @@ def manage_custom_iptables(
             timeout=10,
         )
         success = _run_iptables_commands(ssh, commands, rollback_commands)
-        _backup_iptables(ssh, server.gateway_ip)
+        if success:
+            _backup_iptables(ssh, server.gateway_ip)
         return success
     except Exception as e:
         logger.error(f"Gateway SSH 접속 및 커스텀 iptables 설정 실패: {e}")

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -341,7 +341,7 @@ def create_vm(
     vm_name, vm_display_name = _generate_vm_name(current_user, tier.value, custom_name=name)
     vm_password = _generate_password()
     clone_started = False  # clone 시작 여부 추적
-    iptables_attempted = False
+    iptables_added = False
 
     try:
         # 5. 템플릿 Full Clone
@@ -395,9 +395,9 @@ def create_vm(
         )
 
         # 8. iptables 포트포워딩 등록
-        iptables_attempted = True
         if not manage_iptables(server, vmid, internal_ip, action="ADD"):
             raise RuntimeError("iptables 포트포워딩 등록에 실패했습니다.")
+        iptables_added = True
 
         # 9. VM 부팅
         proxmox.nodes(server.name).qemu(vmid).status.start.post()
@@ -493,7 +493,7 @@ def create_vm(
                 proxmox.nodes(server.name).qemu(vmid).delete(purge=1)
             except Exception:
                 logger.warning(f"VM {vmid} 생성 실패 후 정리 중 오류 (수동 확인 필요)")
-        if iptables_attempted:
+        if iptables_added:
             try:
                 manage_iptables(server, vmid, internal_ip, action="DELETE")
             except Exception as cleanup_error:

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -533,26 +533,29 @@ def delete_vm(
         delete_params = {"purge": 1} if purge else {}
         proxmox.nodes(server.name).qemu(vmid).delete(**delete_params)
 
-        # 커스텀 포트 iptables 규칙 제거
+        # VmPort에 저장된 실제 external_port 기준으로 iptables 규칙 제거
         if vm_record.internal_ip:
-            custom_ports = db.query(VmPort).filter(
-                VmPort.vm_id == vm_record.id,
-                VmPort.is_default.is_(False),
-            ).all()
-            for port in custom_ports:
+            vm_ports = db.query(VmPort).filter(VmPort.vm_id == vm_record.id).all()
+            for port in vm_ports:
+                source_ip = port.source if port.source and port.source != "0.0.0.0/0" else None
                 protocols = ["tcp", "udp"] if port.protocol == "tcp/udp" else [port.protocol]
                 for proto in protocols:
-                    manage_custom_iptables(
+                    success = manage_custom_iptables(
                         server=server,
                         vm_ip=vm_record.internal_ip,
                         internal_port=port.internal_port,
                         external_port=port.external_port,
                         protocol=proto,
                         action="DELETE",
+                        source_ip=source_ip,
                     )
+                    if not success:
+                        logger.error(
+                            f"VM {vmid} iptables 삭제 실패 - "
+                            f"port {port.external_port}->{port.internal_port} ({proto})"
+                        )
 
-        # 기본 포트 iptables 규칙 제거
-        if vm_record.internal_ip:
+            # 과거 데이터에 VmPort 기본 포트 레코드가 없을 수 있어 기존 계산식도 fallback으로 수행
             manage_iptables(server, vmid, vm_record.internal_ip, action="DELETE")
 
         # VmPort 레코드 일괄 삭제 (VM record 삭제 전 FK 제약 해소)

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -270,13 +270,11 @@ def create_vm(
         raise HTTPException(status_code=403, detail="프로젝트 커스텀 티어는 프로젝트 오너만 사용할 수 있습니다.")
 
     # 역할 기반 노드 접근 제어 (ADMIN은 모든 노드 허용)
-    if node_name and current_user.role == UserRole.USER:
-        project_node = settings.PROJECT_NODE_NAME
-        if node_name == project_node:
-            raise HTTPException(
-                status_code=403,
-                detail="일반 사용자는 프로젝트 전용 노드에 VM을 생성할 수 없습니다.",
-            )
+    if current_user.role == UserRole.USER and node_name == settings.PROJECT_NODE_NAME:
+        raise HTTPException(
+            status_code=403,
+            detail="일반 사용자는 프로젝트 전용 노드에 VM을 생성할 수 없습니다.",
+        )
 
     specs = TIER_SPECS.get(tier)
     if not specs:

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -537,7 +537,7 @@ def delete_vm(
         if vm_record.internal_ip:
             vm_ports = db.query(VmPort).filter(VmPort.vm_id == vm_record.id).all()
             for port in vm_ports:
-                source_ip = port.source if port.source and port.source != "0.0.0.0/0" else None
+                source_ip = port.source
                 protocols = ["tcp", "udp"] if port.protocol == "tcp/udp" else [port.protocol]
                 for proto in protocols:
                     success = manage_custom_iptables(

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -341,6 +341,7 @@ def create_vm(
     vm_name, vm_display_name = _generate_vm_name(current_user, tier.value, custom_name=name)
     vm_password = _generate_password()
     clone_started = False  # clone 시작 여부 추적
+    iptables_attempted = False
 
     try:
         # 5. 템플릿 Full Clone
@@ -394,7 +395,9 @@ def create_vm(
         )
 
         # 8. iptables 포트포워딩 등록
-        manage_iptables(server, vmid, internal_ip, action="ADD")
+        iptables_attempted = True
+        if not manage_iptables(server, vmid, internal_ip, action="ADD"):
+            raise RuntimeError("iptables 포트포워딩 등록에 실패했습니다.")
 
         # 9. VM 부팅
         proxmox.nodes(server.name).qemu(vmid).status.start.post()
@@ -490,6 +493,11 @@ def create_vm(
                 proxmox.nodes(server.name).qemu(vmid).delete(purge=1)
             except Exception:
                 logger.warning(f"VM {vmid} 생성 실패 후 정리 중 오류 (수동 확인 필요)")
+        if iptables_attempted:
+            try:
+                manage_iptables(server, vmid, internal_ip, action="DELETE")
+            except Exception as cleanup_error:
+                logger.warning(f"VM {vmid} 생성 실패 후 iptables 정리 중 오류: {cleanup_error}")
         try:
             _delete_snippet(server, f"user-data-{vmid}.yaml")
         except Exception:
@@ -536,6 +544,7 @@ def delete_vm(
         # VmPort에 저장된 실제 external_port 기준으로 iptables 규칙 제거
         if vm_record.internal_ip:
             vm_ports = db.query(VmPort).filter(VmPort.vm_id == vm_record.id).all()
+            has_default_ports = any(port.is_default for port in vm_ports)
             for port in vm_ports:
                 source_ip = port.source
                 protocols = ["tcp", "udp"] if port.protocol == "tcp/udp" else [port.protocol]
@@ -556,7 +565,8 @@ def delete_vm(
                         )
 
             # 과거 데이터에 VmPort 기본 포트 레코드가 없을 수 있어 기존 계산식도 fallback으로 수행
-            manage_iptables(server, vmid, vm_record.internal_ip, action="DELETE")
+            if not has_default_ports:
+                manage_iptables(server, vmid, vm_record.internal_ip, action="DELETE")
 
         # VmPort 레코드 일괄 삭제 (VM record 삭제 전 FK 제약 해소)
         db.query(VmPort).filter(VmPort.vm_id == vm_record.id).delete()

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -269,22 +269,13 @@ def create_vm(
     if tier == VMTierEnum.PROJECT_CUSTOM and current_user.role not in (UserRole.ADMIN, UserRole.PROJECT_OWNER):
         raise HTTPException(status_code=403, detail="프로젝트 커스텀 티어는 프로젝트 오너만 사용할 수 있습니다.")
 
-    # 프로젝트 커스텀 티어는 전용 노드 강제
-    if tier == VMTierEnum.PROJECT_CUSTOM:
-        node_name = settings.PROJECT_NODE_NAME
-
     # 역할 기반 노드 접근 제어 (ADMIN은 모든 노드 허용)
-    if node_name and current_user.role != UserRole.ADMIN:
+    if node_name and current_user.role == UserRole.USER:
         project_node = settings.PROJECT_NODE_NAME
-        if current_user.role == UserRole.USER and node_name == project_node:
+        if node_name == project_node:
             raise HTTPException(
                 status_code=403,
                 detail="일반 사용자는 프로젝트 전용 노드에 VM을 생성할 수 없습니다.",
-            )
-        if current_user.role == UserRole.PROJECT_OWNER and node_name != project_node:
-            raise HTTPException(
-                status_code=403,
-                detail=f"프로젝트 오너는 프로젝트 전용 노드({project_node})에서만 VM을 생성할 수 있습니다.",
             )
 
     specs = TIER_SPECS.get(tier)

--- a/backend/tests/test_external_services.py
+++ b/backend/tests/test_external_services.py
@@ -205,6 +205,29 @@ class TestOAuthRoleConflict:
         db.commit()
         assert self._call_callback(oauth_client, "admin@gsm.hs.kr") == 409
 
+    def test_admin_email_blocks_even_with_existing_user(self, db, oauth_client):
+        """ADMIN+USER 듀얼 row가 있으면 OAuth는 USER row가 있어도 409"""
+        db.add_all(
+            [
+                User(
+                    email="admin-dual@gsm.hs.kr",
+                    hashed_password=None,
+                    role=UserRole.USER,
+                    is_active=True,
+                    oauth_provider="datagsm",
+                    oauth_sub="old-sub",
+                ),
+                User(
+                    email="admin-dual@gsm.hs.kr",
+                    hashed_password="x",
+                    role=UserRole.ADMIN,
+                    is_active=True,
+                ),
+            ]
+        )
+        db.commit()
+        assert self._call_callback(oauth_client, "admin-dual@gsm.hs.kr") == 409
+
     def test_project_owner_email_can_create_user_account(self, db, oauth_client):
         """PROJECT_OWNER만 있는 이메일로 OAuth 시도 시 USER 계정을 별도로 생성"""
         db.add(

--- a/backend/tests/test_external_services.py
+++ b/backend/tests/test_external_services.py
@@ -133,11 +133,11 @@ class TestOAuthStoreConcurrency:
                 _pkce_store.pop(state, None)
 
 
-# ── EXT-TC-04: ADMIN/PROJECT_OWNER 이메일 OAuth 시도 시 409 ──
+# ── EXT-TC-04: OAuth는 일반 USER 계정 기준으로 처리 ──
 
 
 class TestOAuthRoleConflict:
-    """EXT-TC-04: 비USER 역할 이메일로 OAuth 콜백 시 409 반환"""
+    """EXT-TC-04: OAuth는 USER 계정으로 로그인하며 PO 계정과 공존 가능"""
 
     @pytest.fixture
     def oauth_client(self):
@@ -205,8 +205,8 @@ class TestOAuthRoleConflict:
         db.commit()
         assert self._call_callback(oauth_client, "admin@gsm.hs.kr") == 409
 
-    def test_project_owner_email_returns_409(self, db, oauth_client):
-        """PROJECT_OWNER 계정 이메일로 OAuth 시도 시 409"""
+    def test_project_owner_email_can_create_user_account(self, db, oauth_client):
+        """PROJECT_OWNER만 있는 이메일로 OAuth 시도 시 USER 계정을 별도로 생성"""
         db.add(
             User(
                 email="owner@gsm.hs.kr",
@@ -216,7 +216,39 @@ class TestOAuthRoleConflict:
             )
         )
         db.commit()
-        assert self._call_callback(oauth_client, "owner@gsm.hs.kr") == 409
+        status = self._call_callback(oauth_client, "owner@gsm.hs.kr")
+        assert status in (200, 302, 307)
+        assert (
+            db.query(User)
+            .filter(User.email == "owner@gsm.hs.kr", User.role == UserRole.USER)
+            .first()
+            is not None
+        )
+
+    def test_project_owner_email_does_not_block_existing_user(self, db, oauth_client):
+        """USER+PROJECT_OWNER 듀얼 계정이면 OAuth는 USER 계정으로 로그인"""
+        db.add_all(
+            [
+                User(
+                    email="dual@gsm.hs.kr",
+                    hashed_password=None,
+                    role=UserRole.USER,
+                    is_active=True,
+                    oauth_provider="datagsm",
+                    oauth_sub="old-sub",
+                ),
+                User(
+                    email="dual@gsm.hs.kr",
+                    hashed_password="x",
+                    role=UserRole.PROJECT_OWNER,
+                    is_active=True,
+                ),
+            ]
+        )
+        db.commit()
+        status = self._call_callback(oauth_client, "dual@gsm.hs.kr")
+        assert status in (200, 302, 307)
+        assert db.query(User).filter(User.email == "dual@gsm.hs.kr").count() == 2
 
     def test_user_role_does_not_block_oauth(self, db, oauth_client):
         """일반 USER 역할은 차단되지 않음 (409 아님)"""

--- a/backend/tests/test_firewall_iptables.py
+++ b/backend/tests/test_firewall_iptables.py
@@ -5,10 +5,17 @@
 - TestManageCustomIptables: manage_custom_iptables() 단위 테스트 (paramiko mock)
 - TestManageCustomIptablesManual: 실제 게이트웨이 + VM 연결 확인 (수동 실행)
 """
+import asyncio
 import socket
 import pytest
 from unittest.mock import MagicMock, patch
+from fastapi import HTTPException
+from models.server import Server
+from models.user import User, UserRole
+from models.vm import Vm
 from models.vm_port import VmPort
+from schemas.fw_schema import VmPortCreate
+from api.routes.firewall import add_custom_port
 from services.network_service import allocate_random_port, manage_custom_iptables
 
 
@@ -64,6 +71,15 @@ def _make_ssh_mock():
     stderr.read.return_value = b""
     ssh.exec_command.return_value = (MagicMock(), stdout, stderr)
     return ssh
+
+
+def _make_command_result(exit_status=0, stderr_text=""):
+    stdout = MagicMock()
+    stdout.channel.recv_exit_status.return_value = exit_status
+    stdout.read.return_value = b"# iptables rules\n"
+    stderr = MagicMock()
+    stderr.read.return_value = stderr_text.encode()
+    return MagicMock(), stdout, stderr
 
 
 class TestManageCustomIptables:
@@ -163,6 +179,87 @@ class TestManageCustomIptables:
                 protocol="tcp",
                 action="ADD",
             )
+
+    @patch("services.network_service.paramiko.SSHClient")
+    def test_add_failure_runs_remaining_commands_and_rollback(self, mock_ssh_cls):
+        ssh = MagicMock()
+        ssh.exec_command.side_effect = [
+            _make_command_result(1, "DNAT failed"),
+            _make_command_result(0),
+            _make_command_result(0),
+            _make_command_result(0),
+            _make_command_result(0),
+        ]
+        mock_ssh_cls.return_value = ssh
+        server = _make_server()
+
+        result = manage_custom_iptables(
+            server=server,
+            vm_ip="10.0.0.5",
+            internal_port=443,
+            external_port=31234,
+            protocol="tcp",
+            action="ADD",
+        )
+
+        assert result is False
+        executed_cmds = [c.args[0] for c in ssh.exec_command.call_args_list]
+        assert any("FORWARD" in c and "-A" in c for c in executed_cmds)
+        assert any("PREROUTING" in c and "-D" in c for c in executed_cmds)
+        assert any("FORWARD" in c and "-D" in c for c in executed_cmds)
+
+
+class TestAddCustomPortRollback:
+    """커스텀 포트 추가 실패 시 DB 선점 레코드 rollback"""
+
+    def _make_user_vm(self, db):
+        user = User(email="fw@gsm.hs.kr", hashed_password="h", role=UserRole.USER, is_active=True)
+        server = Server(
+            name="test-node",
+            ip_address="192.168.1.10",
+            port=8006,
+            api_user="root@pam",
+            api_password="password",
+            is_active=True,
+            gateway_ip="192.168.1.1",
+            gateway_user="admin",
+            gateway_password="gwpass",
+            base_port=21000,
+        )
+        db.add_all([user, server])
+        db.commit()
+        db.refresh(user)
+        db.refresh(server)
+        vm = Vm(
+            hypervisor_vmid=200,
+            name="test-vm",
+            server_id=server.id,
+            owner_id=user.id,
+            internal_ip="10.0.0.100",
+        )
+        db.add(vm)
+        db.commit()
+        db.refresh(vm)
+        return user
+
+    def test_value_error_removes_reserved_port(self, db):
+        user = self._make_user_vm(db)
+        body = VmPortCreate(
+            internal_port=8080,
+            protocol="tcp",
+            source="192.168.1.10/32",
+            description="test",
+        )
+
+        with patch("api.routes.firewall.allocate_random_port", return_value=33333), patch(
+            "api.routes.firewall.manage_custom_iptables",
+            side_effect=ValueError("잘못된 source IP/CIDR 형식"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(add_custom_port("test-node", 200, body, db=db, current_user=user))
+
+        assert exc_info.value.status_code == 400
+        assert db.query(VmPort).count() == 0
 
 
 # ── 수동 스모크 테스트 ─────────────────────────────────────────────────────────

--- a/backend/tests/test_vm_lifecycle.py
+++ b/backend/tests/test_vm_lifecycle.py
@@ -13,6 +13,7 @@ from core.database import Base
 from models.user import User, UserRole
 from models.server import Server
 from models.vm import Vm
+from models.vm_port import VmPort
 from models.notification import Notification
 from schemas.vm_schema import VMCreate, VMTier
 from services.vm_service import (
@@ -470,6 +471,53 @@ class TestVMDeletionHappyPath:
         # 알림 생성 확인
         notif = db.query(Notification).filter(Notification.user_id == user.id).first()
         assert notif is not None
+
+    @patch("services.vm_service.manage_custom_iptables", return_value=True)
+    @patch("services.vm_service.manage_iptables", return_value=True)
+    @patch("services.vm_service.get_proxmox_for_server")
+    def test_default_vm_ports_do_not_trigger_formula_fallback(
+        self, mock_proxmox_fn, mock_iptables, mock_custom_iptables, db, user, server
+    ):
+        """기본 VmPort가 있으면 계산식 fallback 삭제를 중복 실행하지 않는다."""
+        proxmox = _make_mock_proxmox()
+        mock_proxmox_fn.return_value = proxmox
+
+        vm = Vm(
+            hypervisor_vmid=200,
+            name="test-vm",
+            server_id=server.id,
+            owner_id=user.id,
+            internal_ip="10.0.0.100",
+        )
+        db.add(vm)
+        db.commit()
+        db.refresh(vm)
+        db.add_all(
+            [
+                VmPort(
+                    vm_id=vm.id,
+                    internal_port=22,
+                    external_port=21200,
+                    protocol="tcp",
+                    source="0.0.0.0/0",
+                    is_default=True,
+                ),
+                VmPort(
+                    vm_id=vm.id,
+                    internal_port=10000,
+                    external_port=23200,
+                    protocol="tcp/udp",
+                    source="0.0.0.0/0",
+                    is_default=True,
+                ),
+            ]
+        )
+        db.commit()
+
+        delete_vm(db, vm)
+
+        mock_iptables.assert_not_called()
+        assert mock_custom_iptables.call_count == 3
 
 
 # ── 포트 범위 검증 ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **OAuth 계정 공존 정책**: 동일 이메일의 `USER`/`PROJECT_OWNER` 계정 공존을 허용하고, `ADMIN` 계정 충돌은 차단하도록 반영
- **iptables 정리 안정화**: 기본/커스텀 포트포워딩 규칙 삭제 로직과 중복 규칙 처리 개선
- **PO VM 노드 정책**: 프로젝트 오너 VM 생성 가능 노드를 1, 2번 서버까지 허용
- **테스트 보강**: OAuth 역할 공존, firewall iptables, VM lifecycle 관련 테스트 추가/수정

## Test plan
- [ ] `backend/tests/test_external_services.py`
- [ ] `backend/tests/test_firewall_iptables.py`
- [ ] `backend/tests/test_vm_lifecycle.py`
- [ ] 배포 전 main 병합 diff 확인