### PR TITLE
hotfix: CD 워크플로우 GLOBAL grep 빈 결과 시 exit code 1 버그 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,7 +77,7 @@ jobs:
             | grep -vE '^(backend|serverless|\.agents|\.claude|\.codex)/' \
             | grep -v '\.md$' \
             | grep -v '^\.gitignore$' \
-            | grep -v '^\.github/workflows/')
+            | grep -v '^\.github/workflows/' || true)
           if [ -n "$GLOBAL" ]; then
             echo "global=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary

**CD 워크플로우**의 `Detect Changed Areas` 잡에서 변경 파일이 전부 필터링될 경우 `grep`이 exit code `1`을 반환해 `bash -e` 모드에서 스크립트가 중단되는 버그를 수정합니다.

### 원인
`GLOBAL` 변수 계산 파이프라인의 마지막 `grep -v` 명령이 매칭 결과 없을 때 exit code `1` 반환 → `bash -e`에 의해 스크립트 강제 종료

### 변경 내용
`.github/workflows/cd.yml`의 `GLOBAL` 파이프라인 끝에 `|| true` 추가

```bash
# Before
GLOBAL=$(echo "$CHANGED"   | grep -vE '...'   | grep -v '\.md$'   | grep -v '^\.gitignore$'   | grep -v '^\.github/workflows/')

# After
GLOBAL=$(echo "$CHANGED"   | grep -vE '...'   | grep -v '\.md$'   | grep -v '^\.gitignore$'   | grep -v '^\.github/workflows/' || true)
```

## Test plan
- [ ] `main` 머지 후 CD 워크플로우 `Detect Changed Areas` 잡이 정상 통과하는지 확인
- [ ] `.md` 파일만 변경된 커밋에서 모든 deploy 잡이 skip되는지 확인