### PR TITLE
feat: VM 만료 임박 어드민 알림 백그라운드 태스크 추가

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -42,6 +42,19 @@ BACKGROUND_FAST_RETRY_SECONDS = 300
 EXPIRE_LOOP_INTERVAL_SECONDS = 3600
 IPTABLES_BACKUP_INTERVAL_SECONDS = 7 * 24 * 3600
 SNAPSHOT_CREATE_DELAY_SECONDS = 60
+NOTIFY_HOURS = [0, 6, 12, 18]  # KST 기준 어드민 VM 만료 알림 발송 시각
+
+
+def _next_notify_sleep_seconds(now, hours: list) -> float:
+    """now 기준 hours 중 다음 시각까지 초 반환 (KST aware datetime 전용)."""
+    today = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    sorted_hours = sorted(hours)
+    for h in sorted_hours:
+        candidate = today.replace(hour=h)
+        if candidate > now:
+            return (candidate - now).total_seconds()
+    first = (today + timedelta(days=1)).replace(hour=sorted_hours[0])
+    return (first - now).total_seconds()
 
 
 def _notify_admins_background_failure(task_name: str, consecutive_failures: int):
@@ -72,6 +85,45 @@ def _notify_admins_background_failure(task_name: str, consecutive_failures: int)
     finally:
         if db:
             db.close()
+
+
+def _send_admin_expiry_notifications(db, now) -> None:
+    """7일 이내 만료 VM 목록을 ADMIN 전체에 알림 1개씩 발송."""
+    soon_vms = (
+        db.query(Vm)
+        .filter(
+            Vm.expires_at.isnot(None),
+            Vm.expires_at > now,
+            Vm.expires_at <= now + timedelta(days=7),
+        )
+        .all()
+    )
+
+    if soon_vms:
+        parts = []
+        for vm in soon_vms:
+            delta = vm.expires_at - now
+            days = delta.days
+            hours = delta.seconds // 3600
+            parts.append(f"{vm.name}({days}일 {hours}시간)")
+        message = f"만료 임박 VM {len(soon_vms)}개: {', '.join(parts)}"
+    else:
+        message = "만료 임박 VM 없음"
+
+    admins = (
+        db.query(User)
+        .filter(User.role == UserRole.ADMIN, User.is_active == True)
+        .all()
+    )
+    for admin in admins:
+        db.add(
+            Notification(
+                user_id=admin.id,
+                type="info",
+                message=message,
+            )
+        )
+    db.commit()
 
 
 # Rate Limiter
@@ -434,6 +486,50 @@ async def _oauth_store_cleanup_loop():
         await asyncio.sleep(BACKGROUND_FAST_RETRY_SECONDS)  # 5분마다
 
 
+async def _admin_expiry_notify_loop():
+    """KST 06:00·12:00·18:00·00:00 마다 7일 이내 만료 VM 어드민 알림."""
+    consecutive_failures = 0
+    while True:
+        db = None
+        try:
+            if consecutive_failures == 0:
+                now = now_kst()
+                wait = _next_notify_sleep_seconds(now, NOTIFY_HOURS)
+                await asyncio.sleep(wait)
+
+            db = SessionLocal()
+            now = now_kst()
+            _send_admin_expiry_notifications(db, now)
+            logger.info("[expiry-notify] 어드민 VM 만료 임박 알림 발송 완료")
+            consecutive_failures = 0
+        except Exception as e:
+            if db:
+                db.rollback()
+            consecutive_failures += 1
+            logger.exception(
+                f"[expiry-notify] 백그라운드 태스크 오류 ({consecutive_failures}회 연속): {e}"
+            )
+            if consecutive_failures >= BACKGROUND_FAILURE_NOTIFY_THRESHOLD:
+                logger.critical(
+                    f"[expiry-notify] 연속 {consecutive_failures}회 실패 — 점검 필요"
+                )
+            if consecutive_failures == BACKGROUND_FAILURE_NOTIFY_THRESHOLD:
+                try:
+                    await asyncio.to_thread(
+                        _notify_admins_background_failure,
+                        "expiry-notify",
+                        consecutive_failures,
+                    )
+                except Exception as notify_err:
+                    logger.exception(f"[expiry-notify] 관리자 알림 발송 실패: {notify_err}")
+        finally:
+            if db:
+                db.close()
+
+        if consecutive_failures > 0:
+            await asyncio.sleep(BACKGROUND_FAST_RETRY_SECONDS)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # ── 시작 시 ──
@@ -454,6 +550,8 @@ async def lifespan(app: FastAPI):
     snapshot_task = asyncio.create_task(_daily_snapshot_loop())
     # OAuth PKCE/토큰 스토어 주기적 정리 (5분 간격)
     oauth_cleanup_task = asyncio.create_task(_oauth_store_cleanup_loop())
+    # 어드민 VM 만료 임박 알림 (KST 06/12/18/00시)
+    expiry_notify_task = asyncio.create_task(_admin_expiry_notify_loop())
 
     yield
     # ── 종료 시 ──
@@ -461,6 +559,7 @@ async def lifespan(app: FastAPI):
     iptables_task.cancel()
     snapshot_task.cancel()
     oauth_cleanup_task.cancel()
+    expiry_notify_task.cancel()
     await serverless._http_client.aclose()
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -99,16 +99,16 @@ def _send_admin_expiry_notifications(db, now) -> None:
         .all()
     )
 
-    if soon_vms:
-        parts = []
-        for vm in soon_vms:
-            delta = vm.expires_at - now
-            days = delta.days
-            hours = delta.seconds // 3600
-            parts.append(f"{vm.name}({days}일 {hours}시간)")
-        message = f"만료 임박 VM {len(soon_vms)}개: {', '.join(parts)}"
-    else:
-        message = "만료 임박 VM 없음"
+    if not soon_vms:
+        return
+
+    parts = []
+    for vm in soon_vms:
+        delta = vm.expires_at - now
+        days = delta.days
+        hours = delta.seconds // 3600
+        parts.append(f"{vm.name}({days}일 {hours}시간)")
+    message = f"만료 임박 VM {len(soon_vms)}개: {', '.join(parts)}"
 
     admins = (
         db.query(User)

--- a/backend/tests/test_background_tasks.py
+++ b/backend/tests/test_background_tasks.py
@@ -112,3 +112,143 @@ class TestNotifyAdminsBackgroundFailure:
             _notify_admins_background_failure("expire", 5)
 
         assert db.query(Notification).count() == 0
+
+
+from datetime import datetime, timezone, timedelta
+
+KST = timezone(timedelta(hours=9))
+
+
+class TestNextNotifySleepSeconds:
+    """_next_notify_sleep_seconds 순수 함수 단위 테스트."""
+
+    def _now(self, hour, minute=0):
+        return datetime(2026, 5, 26, hour, minute, 0, tzinfo=KST)
+
+    def test_next_hour_today(self):
+        """현재 05:30 → 다음 06:00까지 30분."""
+        from main import _next_notify_sleep_seconds
+        now = self._now(5, 30)
+        secs = _next_notify_sleep_seconds(now, [0, 6, 12, 18])
+        assert secs == 30 * 60
+
+    def test_next_is_tomorrow(self):
+        """현재 19:00 → 다음 00:00(익일)까지 5시간."""
+        from main import _next_notify_sleep_seconds
+        now = self._now(19, 0)
+        secs = _next_notify_sleep_seconds(now, [0, 6, 12, 18])
+        assert secs == 5 * 3600
+
+    def test_exact_boundary_skipped(self):
+        """현재 정확히 06:00 → 다음 12:00까지 6시간."""
+        from main import _next_notify_sleep_seconds
+        now = self._now(6, 0)
+        secs = _next_notify_sleep_seconds(now, [0, 6, 12, 18])
+        assert secs == 6 * 3600
+
+
+from models.vm import Vm
+from models.server import Server
+
+
+def _make_server(db):
+    s = Server(name="pve-test", ip_address="10.0.0.1", port=8006, api_user="root")
+    s.api_password = "pw"
+    db.add(s)
+    db.flush()
+    return s
+
+
+def _make_admin(db, email):
+    u = User(email=email, hashed_password=get_password_hash("Pass1!aa"),
+             role=UserRole.ADMIN, is_active=True)
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _make_vm(db, name, server, expires_at):
+    v = Vm(hypervisor_vmid=100, name=name, server_id=server.id,
+           allocated_ram_mb=2048, allocated_cores=2, expires_at=expires_at)
+    db.add(v)
+    db.flush()
+    return v
+
+
+class TestSendAdminExpiryNotifications:
+    """_send_admin_expiry_notifications 단위 테스트."""
+
+    def test_vms_within_7_days_sends_list(self, db):
+        """7일 이내 만료 VM 있으면 목록 포함 메시지 발송."""
+        from main import _send_admin_expiry_notifications
+        now = datetime(2026, 5, 26, 12, 0, 0)
+        server = _make_server(db)
+        admin = _make_admin(db, "admin@gsm.hs.kr")
+        _make_vm(db, "vm-alpha", server, now + timedelta(days=3, hours=4))
+        db.commit()
+
+        _send_admin_expiry_notifications(db, now)
+
+        db.expire_all()
+        notifs = db.query(Notification).filter(Notification.user_id == admin.id).all()
+        assert len(notifs) == 1
+        assert "만료 임박 VM 1개" in notifs[0].message
+        assert "vm-alpha(3일 4시간)" in notifs[0].message
+        assert notifs[0].type == "info"
+
+    def test_no_vms_sends_empty_message(self, db):
+        """7일 이내 만료 VM 없으면 '만료 임박 VM 없음' 발송."""
+        from main import _send_admin_expiry_notifications
+        now = datetime(2026, 5, 26, 12, 0, 0)
+        admin = _make_admin(db, "admin2@gsm.hs.kr")
+        db.commit()
+
+        _send_admin_expiry_notifications(db, now)
+
+        db.expire_all()
+        notifs = db.query(Notification).filter(Notification.user_id == admin.id).all()
+        assert len(notifs) == 1
+        assert notifs[0].message == "만료 임박 VM 없음"
+
+    def test_expired_vm_excluded(self, db):
+        """이미 만료된 VM(expires_at <= now)은 포함 안 됨."""
+        from main import _send_admin_expiry_notifications
+        now = datetime(2026, 5, 26, 12, 0, 0)
+        server = _make_server(db)
+        admin = _make_admin(db, "admin3@gsm.hs.kr")
+        _make_vm(db, "expired-vm", server, now - timedelta(hours=1))
+        db.commit()
+
+        _send_admin_expiry_notifications(db, now)
+
+        db.expire_all()
+        notif = db.query(Notification).filter(Notification.user_id == admin.id).first()
+        assert notif.message == "만료 임박 VM 없음"
+
+    def test_vm_beyond_7_days_excluded(self, db):
+        """8일 후 만료 VM은 포함 안 됨."""
+        from main import _send_admin_expiry_notifications
+        now = datetime(2026, 5, 26, 12, 0, 0)
+        server = _make_server(db)
+        admin = _make_admin(db, "admin4@gsm.hs.kr")
+        _make_vm(db, "far-vm", server, now + timedelta(days=8))
+        db.commit()
+
+        _send_admin_expiry_notifications(db, now)
+
+        db.expire_all()
+        notif = db.query(Notification).filter(Notification.user_id == admin.id).first()
+        assert notif.message == "만료 임박 VM 없음"
+
+    def test_multiple_admins_each_get_one_notification(self, db):
+        """ADMIN 2명이면 각자 알림 1개씩."""
+        from main import _send_admin_expiry_notifications
+        now = datetime(2026, 5, 26, 12, 0, 0)
+        _make_admin(db, "a1@gsm.hs.kr")
+        _make_admin(db, "a2@gsm.hs.kr")
+        db.commit()
+
+        _send_admin_expiry_notifications(db, now)
+
+        db.expire_all()
+        assert db.query(Notification).count() == 2

--- a/backend/tests/test_background_tasks.py
+++ b/backend/tests/test_background_tasks.py
@@ -1,14 +1,17 @@
 """_notify_admins_background_failure 단위 테스트."""
 
 import pytest
+from datetime import datetime, timezone, timedelta
 from unittest.mock import patch
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from core.database import Base
 from core.security import get_password_hash
-from models.user import User, UserRole
 from models.notification import Notification
+from models.server import Server
+from models.user import User, UserRole
+from models.vm import Vm
 
 TEST_DB_URL = "sqlite:///./test_background_tasks.db"
 engine = create_engine(TEST_DB_URL, connect_args={"check_same_thread": False})
@@ -114,8 +117,6 @@ class TestNotifyAdminsBackgroundFailure:
         assert db.query(Notification).count() == 0
 
 
-from datetime import datetime, timezone, timedelta
-
 KST = timezone(timedelta(hours=9))
 
 
@@ -145,10 +146,6 @@ class TestNextNotifySleepSeconds:
         now = self._now(6, 0)
         secs = _next_notify_sleep_seconds(now, [0, 6, 12, 18])
         assert secs == 6 * 3600
-
-
-from models.vm import Vm
-from models.server import Server
 
 
 def _make_server(db):

--- a/backend/tests/test_background_tasks.py
+++ b/backend/tests/test_background_tasks.py
@@ -1,13 +1,14 @@
 """_notify_admins_background_failure 단위 테스트."""
 
 import pytest
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
 from unittest.mock import patch
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from core.database import Base
 from core.security import get_password_hash
+from core.timezone import KST
 from models.notification import Notification
 from models.server import Server
 from models.user import User, UserRole
@@ -117,9 +118,6 @@ class TestNotifyAdminsBackgroundFailure:
         assert db.query(Notification).count() == 0
 
 
-KST = timezone(timedelta(hours=9))
-
-
 class TestNextNotifySleepSeconds:
     """_next_notify_sleep_seconds 순수 함수 단위 테스트."""
 
@@ -193,8 +191,8 @@ class TestSendAdminExpiryNotifications:
         assert "vm-alpha(3일 4시간)" in notifs[0].message
         assert notifs[0].type == "info"
 
-    def test_no_vms_sends_empty_message(self, db):
-        """7일 이내 만료 VM 없으면 '만료 임박 VM 없음' 발송."""
+    def test_no_vms_sends_no_notification(self, db):
+        """7일 이내 만료 VM 없으면 알림 발송 안 함."""
         from main import _send_admin_expiry_notifications
         now = datetime(2026, 5, 26, 12, 0, 0)
         admin = _make_admin(db, "admin2@gsm.hs.kr")
@@ -203,9 +201,7 @@ class TestSendAdminExpiryNotifications:
         _send_admin_expiry_notifications(db, now)
 
         db.expire_all()
-        notifs = db.query(Notification).filter(Notification.user_id == admin.id).all()
-        assert len(notifs) == 1
-        assert notifs[0].message == "만료 임박 VM 없음"
+        assert db.query(Notification).filter(Notification.user_id == admin.id).count() == 0
 
     def test_expired_vm_excluded(self, db):
         """이미 만료된 VM(expires_at <= now)은 포함 안 됨."""
@@ -219,8 +215,7 @@ class TestSendAdminExpiryNotifications:
         _send_admin_expiry_notifications(db, now)
 
         db.expire_all()
-        notif = db.query(Notification).filter(Notification.user_id == admin.id).first()
-        assert notif.message == "만료 임박 VM 없음"
+        assert db.query(Notification).filter(Notification.user_id == admin.id).count() == 0
 
     def test_vm_beyond_7_days_excluded(self, db):
         """8일 후 만료 VM은 포함 안 됨."""
@@ -234,15 +229,16 @@ class TestSendAdminExpiryNotifications:
         _send_admin_expiry_notifications(db, now)
 
         db.expire_all()
-        notif = db.query(Notification).filter(Notification.user_id == admin.id).first()
-        assert notif.message == "만료 임박 VM 없음"
+        assert db.query(Notification).filter(Notification.user_id == admin.id).count() == 0
 
     def test_multiple_admins_each_get_one_notification(self, db):
         """ADMIN 2명이면 각자 알림 1개씩."""
         from main import _send_admin_expiry_notifications
         now = datetime(2026, 5, 26, 12, 0, 0)
+        server = _make_server(db)
         _make_admin(db, "a1@gsm.hs.kr")
         _make_admin(db, "a2@gsm.hs.kr")
+        _make_vm(db, "vm-soon", server, now + timedelta(days=3))
         db.commit()
 
         _send_admin_expiry_notifications(db, now)


### PR DESCRIPTION
## Summary
- **어드민 VM 만료 임박 알림**: KST 00:00·06:00·12:00·18:00 하루 4회, 7일 이내 만료 VM 목록을 `ADMIN` 유저에게 Notification으로 발송
- `_admin_expiry_notify_loop()`: `_expire_vms_loop`와 동일한 패턴의 독립 async 루프, lifespan에 등록
- `_send_admin_expiry_notifications(db, now)`: VM 쿼리·메시지 빌드·Notification 삽입 sync 헬퍼
- `_next_notify_sleep_seconds(now, hours)`: 다음 알림 시각까지 초 계산 순수 함수
- 메시지 형식: `만료 임박 VM N개: VM-A(3일 4시간), VM-B(6일 2시간)` / VM 없음 시 `만료 임박 VM 없음`

## Test plan
- [x] `TestNextNotifySleepSeconds` — 다음 시각 계산 (당일·익일·경계 3케이스)
- [x] `TestSendAdminExpiryNotifications` — VM 목록 발송·빈 메시지·만료 제외·8일 제외·멀티 어드민 (5케이스)
- [ ] 프로덕션 배포 후 KST 알림 시각 수신 확인