### PR TITLE
fix: legacy 이슈 즉시 반영

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -15,7 +15,7 @@ from fastapi import (
     UploadFile,
     File,
 )
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
@@ -748,34 +748,44 @@ async def request_password_reset(
         await _pad_password_reset_response(started_at)
         return _password_reset_request_response(body.email)
 
-    sr = _reset_signup_role(body.login_role)
-    # 기존 미인증 비밀번호 재설정 레코드 삭제 (같은 role만)
-    db.query(EmailVerification).filter(
-        EmailVerification.email == body.email,
-        EmailVerification.signup_role == sr,
-        EmailVerification.verified == False,
-    ).delete()
-    db.commit()
+    try:
+        sr = _reset_signup_role(body.login_role)
+        # 기존 미인증 비밀번호 재설정 레코드 삭제 (같은 role만)
+        db.query(EmailVerification).filter(
+            EmailVerification.email == body.email,
+            EmailVerification.signup_role == sr,
+            EmailVerification.verified == False,
+        ).delete()
+        db.commit()
 
-    code = generate_verification_code()
-    verification = EmailVerification(
-        email=body.email,
-        hashed_password="",  # 재설정이므로 기존 비밀번호 불필요
-        code=code,
-        signup_role=sr,
-        expires_at=now_kst()
-        + timedelta(minutes=settings.VERIFICATION_CODE_EXPIRE_MINUTES),
-    )
-    db.add(verification)
-    db.commit()
+        code = generate_verification_code()
+        verification = EmailVerification(
+            email=body.email,
+            hashed_password="",  # 재설정이므로 기존 비밀번호 불필요
+            code=code,
+            signup_role=sr,
+            expires_at=now_kst()
+            + timedelta(minutes=settings.VERIFICATION_CODE_EXPIRE_MINUTES),
+        )
+        db.add(verification)
+        db.commit()
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.exception("[password-reset] DB 처리 실패: %s", e)
+        await _pad_password_reset_response(started_at)
+        raise HTTPException(status_code=503, detail="요청을 처리할 수 없습니다. 잠시 후 다시 시도해주세요.")
 
     sent = await send_verification_email(body.email, code)
     if not sent:
         logger.warning("[password-reset] 인증 이메일 발송 실패: %s", body.email)
-        db.delete(verification)
-        db.commit()
+        try:
+            db.delete(verification)
+            db.commit()
+        except SQLAlchemyError as e:
+            db.rollback()
+            logger.exception("[password-reset] 실패 레코드 정리 실패: %s", e)
         await _pad_password_reset_response(started_at)
-        return _password_reset_request_response(body.email)
+        raise HTTPException(status_code=503, detail="이메일 발송에 실패했습니다. 잠시 후 다시 시도해주세요.")
 
     await _pad_password_reset_response(started_at)
     return _password_reset_request_response(body.email)

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import time
 from datetime import timedelta
 from pathlib import Path
@@ -48,6 +49,7 @@ from slowapi import Limiter
 from slowapi.util import get_remote_address
 
 limiter = Limiter(key_func=get_remote_address)
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -769,7 +771,11 @@ async def request_password_reset(
 
     sent = await send_verification_email(body.email, code)
     if not sent:
-        raise HTTPException(status_code=500, detail="인증 이메일 발송에 실패했습니다.")
+        logger.warning("[password-reset] 인증 이메일 발송 실패: %s", body.email)
+        db.delete(verification)
+        db.commit()
+        await _pad_password_reset_response(started_at)
+        return _password_reset_request_response(body.email)
 
     await _pad_password_reset_response(started_at)
     return _password_reset_request_response(body.email)

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import time
 from datetime import timedelta
@@ -689,6 +690,17 @@ async def read_users_me(current_user: User = Depends(get_current_user)):
 
 
 _RESET_ROLE_MAP = {"user": UserRole.USER, "project_owner": UserRole.PROJECT_OWNER}
+_PASSWORD_RESET_MIN_RESPONSE_SECONDS = 0.5
+
+
+async def _pad_password_reset_response(started_at: float) -> None:
+    remaining = _PASSWORD_RESET_MIN_RESPONSE_SECONDS - (time.monotonic() - started_at)
+    if remaining > 0:
+        await asyncio.sleep(remaining)
+
+
+def _password_reset_request_response(email: str) -> dict[str, str]:
+    return {"message": "등록된 이메일이라면 인증 코드가 발송됩니다.", "email": email}
 
 
 def _reset_signup_role(login_role: str) -> str:
@@ -702,6 +714,7 @@ async def request_password_reset(
     request: Request, body: PasswordResetRequest, db: Session = Depends(get_db)
 ):
     """비밀번호 재설정 1단계: 이메일+role로 인증 코드를 발송합니다."""
+    started_at = time.monotonic()
     target_role = _RESET_ROLE_MAP[body.login_role]
     # 해당 이메일+role의 활성 계정이 있는지 확인
     user = (
@@ -726,10 +739,12 @@ async def request_password_reset(
         )
     if not user:
         # 보안상 존재하지 않는 이메일이어도 같은 메시지 반환
-        return {
-            "message": "등록된 이메일이라면 인증 코드가 발송됩니다.",
-            "email": body.email,
-        }
+        await _pad_password_reset_response(started_at)
+        return _password_reset_request_response(body.email)
+
+    if not user.hashed_password:
+        await _pad_password_reset_response(started_at)
+        return _password_reset_request_response(body.email)
 
     sr = _reset_signup_role(body.login_role)
     # 기존 미인증 비밀번호 재설정 레코드 삭제 (같은 role만)
@@ -756,10 +771,8 @@ async def request_password_reset(
     if not sent:
         raise HTTPException(status_code=500, detail="인증 이메일 발송에 실패했습니다.")
 
-    return {
-        "message": "등록된 이메일이라면 인증 코드가 발송됩니다.",
-        "email": body.email,
-    }
+    await _pad_password_reset_response(started_at)
+    return _password_reset_request_response(body.email)
 
 
 @router.post("/password-reset/confirm")

--- a/backend/api/routes/firewall.py
+++ b/backend/api/routes/firewall.py
@@ -1,9 +1,9 @@
 import logging
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException, Depends, status
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 from schemas.fw_schema import FirewallRule, VmPortCreate
-from services.proxmox_client import get_proxmox_for_server
+from services.proxmox_client import get_proxmox_for_server, raise_proxmox_http_exception
 from services.network_service import allocate_random_port, manage_custom_iptables, calculate_ports
 from core.database import get_db
 from models.user import User
@@ -14,14 +14,15 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.get("/{vmid}/rules")
+@router.get("/{node}/{vmid}/rules")
 async def get_firewall_rules(
+    node: str,
     vmid: int,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     """특정 VM의 방화벽 규칙 목록 조회 (소유자 또는 관리자)"""
-    vm = get_vm_with_owner_check(db, vmid, current_user)
+    vm = get_vm_with_owner_check(db, vmid, current_user, node=node)
     server = vm.server
     proxmox = get_proxmox_for_server(server)
 
@@ -30,18 +31,19 @@ async def get_firewall_rules(
         return {"vmid": vmid, "node": server.name, "rules": rules}
     except Exception as e:
         logger.error(f"[firewall] 규칙 조회 실패: {e}")
-        raise HTTPException(status_code=500, detail="방화벽 규칙 조회에 실패했습니다.")
+        raise_proxmox_http_exception(e, default_detail="방화벽 규칙 조회에 실패했습니다.")
 
 
-@router.post("/{vmid}/rules")
+@router.post("/{node}/{vmid}/rules", status_code=status.HTTP_201_CREATED)
 async def add_firewall_rule(
+    node: str,
     vmid: int,
     rule: FirewallRule,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     """특정 VM에 방화벽 규칙 추가 (소유자 또는 관리자)"""
-    vm = get_vm_with_owner_check(db, vmid, current_user)
+    vm = get_vm_with_owner_check(db, vmid, current_user, node=node)
     server = vm.server
     proxmox = get_proxmox_for_server(server)
 
@@ -54,18 +56,19 @@ async def add_firewall_rule(
         return {"success": True, "message": f"VM {vmid} 방화벽 규칙 추가 완료", "rule": rule_data}
     except Exception as e:
         logger.error(f"[firewall] 규칙 추가 실패: {e}")
-        raise HTTPException(status_code=500, detail="방화벽 규칙 추가에 실패했습니다.")
+        raise_proxmox_http_exception(e, default_detail="방화벽 규칙 추가에 실패했습니다.")
 
 
-@router.delete("/{vmid}/rules/{pos}")
+@router.delete("/{node}/{vmid}/rules/{pos}", status_code=status.HTTP_200_OK)
 async def delete_firewall_rule(
+    node: str,
     vmid: int,
     pos: int,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     """특정 VM의 방화벽 규칙 삭제 (소유자 또는 관리자)"""
-    vm = get_vm_with_owner_check(db, vmid, current_user)
+    vm = get_vm_with_owner_check(db, vmid, current_user, node=node)
     server = vm.server
     proxmox = get_proxmox_for_server(server)
 
@@ -74,7 +77,7 @@ async def delete_firewall_rule(
         return {"success": True, "message": f"VM {vmid} 방화벽 규칙({pos}번) 삭제 완료"}
     except Exception as e:
         logger.error(f"[firewall] 규칙 삭제 실패: {e}")
-        raise HTTPException(status_code=500, detail="방화벽 규칙 삭제에 실패했습니다.")
+        raise_proxmox_http_exception(e, default_detail="방화벽 규칙 삭제에 실패했습니다.")
 
 
 # ── 커스텀 포트 할당 (30000~39999) ───────────────────────────────────────────
@@ -108,7 +111,7 @@ async def get_custom_ports(
     }
 
 
-@router.post("/{node}/{vmid}/ports", status_code=201)
+@router.post("/{node}/{vmid}/ports", status_code=status.HTTP_201_CREATED)
 async def add_custom_port(
     node: str,
     vmid: int,
@@ -246,7 +249,7 @@ async def restore_default_ports(
     return {"restored": len(missing)}
 
 
-@router.delete("/{node}/{vmid}/ports/{port_id}")
+@router.delete("/{node}/{vmid}/ports/{port_id}", status_code=status.HTTP_200_OK)
 async def delete_custom_port(
     node: str,
     vmid: int,

--- a/backend/api/routes/monitoring.py
+++ b/backend/api/routes/monitoring.py
@@ -7,12 +7,13 @@ from models.server import Server
 from models.user import User, UserRole
 from models.vm import Vm
 from api.dependencies import get_current_user
+from schemas.monitoring_schema import NodeStatsResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.get("/nodes")
+@router.get("/nodes", response_model=NodeStatsResponse)
 async def get_system_stats(
     db: Session = Depends(get_db), current_user: User = Depends(get_current_user)
 ):

--- a/backend/api/routes/vmcontrol.py
+++ b/backend/api/routes/vmcontrol.py
@@ -21,6 +21,13 @@ from slowapi.util import get_remote_address
 limiter = Limiter(key_func=get_remote_address)
 logger = logging.getLogger(__name__)
 router = APIRouter()
+_snapshot_create_locks: dict[tuple[str, int], asyncio.Lock] = {}
+_snapshot_create_locks_guard = asyncio.Lock()
+
+
+async def _get_snapshot_create_lock(node: str, vmid: int) -> asyncio.Lock:
+    async with _snapshot_create_locks_guard:
+        return _snapshot_create_locks.setdefault((node, vmid), asyncio.Lock())
 
 
 @router.get("/nodes")
@@ -509,24 +516,26 @@ async def create_snapshot(
     snap_name = body.name
 
     try:
-        existing = proxmox.nodes(node).qemu(vmid).snapshot.get()
-        real_snaps = [s for s in existing if s.get("name") != "current"]
-        if any(s.get("name") == snap_name for s in real_snaps):
-            raise HTTPException(status_code=400, detail="이미 존재하는 스냅샷 이름입니다.")
-        manual_snaps = [
-            s for s in real_snaps
-            if not (s.get("name") or "").startswith(AUTO_SNAP_PREFIX)
-        ]
-        if manual_snaps and len(manual_snaps) >= 2:
-            raise HTTPException(status_code=400, detail="수동 스냅샷은 최대 2개까지 생성할 수 있습니다.")
-        if len(real_snaps) >= 3:
-            raise HTTPException(status_code=400, detail="스냅샷은 최대 3개까지 생성할 수 있습니다.")
+        lock = await _get_snapshot_create_lock(node, vmid)
+        async with lock:
+            existing = proxmox.nodes(node).qemu(vmid).snapshot.get()
+            real_snaps = [s for s in existing if s.get("name") != "current"]
+            if any(s.get("name") == snap_name for s in real_snaps):
+                raise HTTPException(status_code=400, detail="이미 존재하는 스냅샷 이름입니다.")
+            manual_snaps = [
+                s for s in real_snaps
+                if not (s.get("name") or "").startswith(AUTO_SNAP_PREFIX)
+            ]
+            if manual_snaps and len(manual_snaps) >= 2:
+                raise HTTPException(status_code=400, detail="수동 스냅샷은 최대 2개까지 생성할 수 있습니다.")
+            if len(real_snaps) >= 3:
+                raise HTTPException(status_code=400, detail="스냅샷은 최대 3개까지 생성할 수 있습니다.")
 
-        result = proxmox.nodes(node).qemu(vmid).snapshot.post(
-            snapname=snap_name,
-            description=body.description or "",
-            vmstate=0,  # RAM 상태 저장 안 함 (디스크만)
-        )
+            result = proxmox.nodes(node).qemu(vmid).snapshot.post(
+                snapname=snap_name,
+                description=body.description or "",
+                vmstate=0,  # RAM 상태 저장 안 함 (디스크만)
+            )
         return {"success": True, "message": f"스냅샷 '{snap_name}'이(가) 생성되었습니다.", "task": result}
     except HTTPException:
         raise

--- a/backend/api/routes/vmcontrol.py
+++ b/backend/api/routes/vmcontrol.py
@@ -1,12 +1,14 @@
 import asyncio
 import base64
 import logging
+from typing import Any
 from datetime import timedelta
 from core.timezone import now_kst
 from fastapi import APIRouter, HTTPException, status, Depends, Request
 from sqlalchemy.orm import Session
 from schemas.vm_schema import VMAction, VMCreate, VMResize, SnapshotCreateRequest
-from services.proxmox_client import get_proxmox_for_server
+from core.constants import AUTO_SNAP_PREFIX, PROVISIONING_UPTIME_THRESHOLD_SECONDS
+from services.proxmox_client import get_proxmox_for_server, raise_proxmox_http_exception
 from models.server import Server
 from services.vm_service import create_vm, delete_vm
 from core.database import get_db
@@ -105,7 +107,7 @@ async def get_vms(
         return {"vms": filtered_vms}
     except Exception as e:
         logger.error(f"[vm] VM 목록 조회 실패: {e}")
-        raise HTTPException(status_code=500, detail="서버 오류가 발생했습니다.")
+        raise_proxmox_http_exception(e, default_detail="서버 오류가 발생했습니다.")
 
 
 @router.get("/admin/all-vms")
@@ -167,7 +169,7 @@ async def get_my_vms(
         server_vms[vm.server_id].append(vm)
 
     result = []
-    proxmox_cache: dict[int, any] = {}
+    proxmox_cache: dict[int, Any] = {}
 
     for vm in user_vms:
         info = {
@@ -192,7 +194,8 @@ async def get_my_vms(
             info["uptime"] = vm_status.get("uptime", 0)
             uptime = vm_status.get("uptime", 0)
             info["provisioning"] = (
-                vm_status.get("status") == "running" and 0 < uptime < 180
+                vm_status.get("status") == "running"
+                and 0 < uptime < PROVISIONING_UPTIME_THRESHOLD_SECONDS
             )
         except Exception:
             pass
@@ -227,9 +230,12 @@ async def get_vm_status(
                 await asyncio.sleep(1)
                 out = proxmox.nodes(node).qemu(vmid).agent("exec-status").get(pid=pid)
                 stdout = base64.b64decode(out.get("out-data", "")).decode(errors="ignore")
-                provisioning = "OK" not in stdout and 0 < uptime < 180
+                provisioning = (
+                    "OK" not in stdout
+                    and 0 < uptime < PROVISIONING_UPTIME_THRESHOLD_SECONDS
+                )
             except Exception:
-                provisioning = 0 < uptime < 180
+                provisioning = 0 < uptime < PROVISIONING_UPTIME_THRESHOLD_SECONDS
 
         # Proxmox 실시간 데이터 + DB 저장 데이터 통합
         return {
@@ -252,7 +258,7 @@ async def get_vm_status(
         }
     except Exception as e:
         logger.error(f"[vm] VM 상태 조회 실패: {e}")
-        raise HTTPException(status_code=500, detail="서버 오류가 발생했습니다.")
+        raise_proxmox_http_exception(e, default_detail="서버 오류가 발생했습니다.")
 
 
 @router.get("/{node}/vms/{vmid}/metrics")
@@ -306,7 +312,7 @@ async def get_vm_metrics(
         return {"vmid": vmid, "timeframe": timeframe, "data": data_points}
     except Exception as e:
         logger.error(f"[vm] 메트릭 조회 실패: {e}")
-        raise HTTPException(status_code=500, detail="서버 오류가 발생했습니다.")
+        raise_proxmox_http_exception(e, default_detail="서버 오류가 발생했습니다.")
 
 
 @router.put("/{node}/vms/{vmid}/resize")
@@ -368,7 +374,7 @@ async def resize_vm(
     except Exception as e:
         db.rollback()
         logger.error(f"[vm] 사양 변경 실패: {e}")
-        raise HTTPException(status_code=500, detail="사양 변경에 실패했습니다.")
+        raise_proxmox_http_exception(e, default_detail="사양 변경에 실패했습니다.")
 
 
 @router.post("/{node}/vms/{vmid}/extend")
@@ -435,7 +441,7 @@ async def control_vm(
         raise
     except Exception as e:
         logger.error(f"[vm] 전원 제어 실패: {e}")
-        raise HTTPException(status_code=500, detail="서버 오류가 발생했습니다.")
+        raise_proxmox_http_exception(e, default_detail="서버 오류가 발생했습니다.")
 
 
 @router.post("/create", status_code=status.HTTP_201_CREATED)
@@ -477,10 +483,14 @@ async def list_snapshots(
     try:
         snapshots = proxmox.nodes(node).qemu(vmid).snapshot.get()
         # 'current' 항목(현재 상태)은 제외
-        return [s for s in snapshots if s.get("name") != "current"]
+        return [
+            {**s, "is_auto": s.get("name", "").startswith(AUTO_SNAP_PREFIX)}
+            for s in snapshots
+            if s.get("name") != "current"
+        ]
     except Exception as e:
         logger.error(f"[vm] 스냅샷 목록 조회 실패: {e}")
-        raise HTTPException(status_code=500, detail="서버 오류가 발생했습니다.")
+        raise_proxmox_http_exception(e, default_detail="서버 오류가 발생했습니다.")
 
 
 @router.post("/{node}/vms/{vmid}/snapshots")
@@ -501,7 +511,9 @@ async def create_snapshot(
     try:
         existing = proxmox.nodes(node).qemu(vmid).snapshot.get()
         real_snaps = [s for s in existing if s.get("name") != "current"]
-        manual_snaps = [s for s in real_snaps if not s.get("name", "").startswith("auto-daily")]
+        if any(s.get("name") == snap_name for s in real_snaps):
+            raise HTTPException(status_code=400, detail="이미 존재하는 스냅샷 이름입니다.")
+        manual_snaps = [s for s in real_snaps if not s.get("name", "").startswith(AUTO_SNAP_PREFIX)]
         if manual_snaps and len(manual_snaps) >= 2:
             raise HTTPException(status_code=400, detail="수동 스냅샷은 최대 2개까지 생성할 수 있습니다.")
         if len(real_snaps) >= 3:
@@ -517,7 +529,7 @@ async def create_snapshot(
         raise
     except Exception as e:
         logger.error(f"[vm] 스냅샷 생성 실패: {e}")
-        raise HTTPException(status_code=500, detail="스냅샷 생성에 실패했습니다.")
+        raise_proxmox_http_exception(e, default_detail="스냅샷 생성에 실패했습니다.")
 
 
 @router.post("/{node}/vms/{vmid}/snapshots/{snapname}/rollback")
@@ -537,10 +549,10 @@ async def rollback_snapshot(
         return {"success": True, "message": f"스냅샷 '{snapname}'으로 복원되었습니다.", "task": result}
     except Exception as e:
         logger.error(f"[vm] 스냅샷 복원 실패: {e}")
-        raise HTTPException(status_code=500, detail="스냅샷 복원에 실패했습니다.")
+        raise_proxmox_http_exception(e, default_detail="스냅샷 복원에 실패했습니다.")
 
 
-@router.delete("/{node}/vms/{vmid}/snapshots/{snapname}")
+@router.delete("/{node}/vms/{vmid}/snapshots/{snapname}", status_code=status.HTTP_200_OK)
 async def delete_snapshot(
     node: str,
     vmid: int,
@@ -557,7 +569,7 @@ async def delete_snapshot(
         return {"success": True, "message": f"스냅샷 '{snapname}'이(가) 삭제되었습니다.", "task": result}
     except Exception as e:
         logger.error(f"[vm] 스냅샷 삭제 실패: {e}")
-        raise HTTPException(status_code=500, detail="스냅샷 삭제에 실패했습니다.")
+        raise_proxmox_http_exception(e, default_detail="스냅샷 삭제에 실패했습니다.")
 
 
 @router.get("/{node}/vms/{vmid}/auto-snapshot")
@@ -586,7 +598,7 @@ async def toggle_auto_snapshot(
     return {"enabled": bool(vm_record.auto_snapshot)}
 
 
-@router.delete("/{node}/vms/{vmid}")
+@router.delete("/{node}/vms/{vmid}", status_code=status.HTTP_200_OK)
 @limiter.limit("5/minute")
 async def delete_vm_endpoint(
     request: Request,

--- a/backend/api/routes/vmcontrol.py
+++ b/backend/api/routes/vmcontrol.py
@@ -1,10 +1,13 @@
 import asyncio
 import base64
+import hashlib
 import logging
+from contextlib import asynccontextmanager
 from typing import Any
 from datetime import timedelta
 from core.timezone import now_kst
 from fastapi import APIRouter, HTTPException, status, Depends, Request
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 from schemas.vm_schema import VMAction, VMCreate, VMResize, SnapshotCreateRequest
 from core.constants import AUTO_SNAP_PREFIX, PROVISIONING_UPTIME_THRESHOLD_SECONDS
@@ -28,6 +31,26 @@ _snapshot_create_locks_guard = asyncio.Lock()
 async def _get_snapshot_create_lock(node: str, vmid: int) -> asyncio.Lock:
     async with _snapshot_create_locks_guard:
         return _snapshot_create_locks.setdefault((node, vmid), asyncio.Lock())
+
+
+def _snapshot_advisory_lock_key(node: str, vmid: int) -> int:
+    digest = hashlib.blake2b(f"{node}:{vmid}".encode(), digest_size=8).digest()
+    return int.from_bytes(digest, "big", signed=True)
+
+
+@asynccontextmanager
+async def _snapshot_create_guard(db: Session, node: str, vmid: int):
+    if db.get_bind().dialect.name == "postgresql":
+        db.execute(
+            text("SELECT pg_advisory_xact_lock(:lock_key)"),
+            {"lock_key": _snapshot_advisory_lock_key(node, vmid)},
+        )
+        yield
+        return
+
+    lock = await _get_snapshot_create_lock(node, vmid)
+    async with lock:
+        yield
 
 
 @router.get("/nodes")
@@ -516,8 +539,7 @@ async def create_snapshot(
     snap_name = body.name
 
     try:
-        lock = await _get_snapshot_create_lock(node, vmid)
-        async with lock:
+        async with _snapshot_create_guard(db, node, vmid):
             existing = proxmox.nodes(node).qemu(vmid).snapshot.get()
             real_snaps = [s for s in existing if s.get("name") != "current"]
             if any(s.get("name") == snap_name for s in real_snaps):

--- a/backend/api/routes/vmcontrol.py
+++ b/backend/api/routes/vmcontrol.py
@@ -484,7 +484,7 @@ async def list_snapshots(
         snapshots = proxmox.nodes(node).qemu(vmid).snapshot.get()
         # 'current' 항목(현재 상태)은 제외
         return [
-            {**s, "is_auto": s.get("name", "").startswith(AUTO_SNAP_PREFIX)}
+            {**s, "is_auto": (s.get("name") or "").startswith(AUTO_SNAP_PREFIX)}
             for s in snapshots
             if s.get("name") != "current"
         ]
@@ -513,7 +513,10 @@ async def create_snapshot(
         real_snaps = [s for s in existing if s.get("name") != "current"]
         if any(s.get("name") == snap_name for s in real_snaps):
             raise HTTPException(status_code=400, detail="이미 존재하는 스냅샷 이름입니다.")
-        manual_snaps = [s for s in real_snaps if not s.get("name", "").startswith(AUTO_SNAP_PREFIX)]
+        manual_snaps = [
+            s for s in real_snaps
+            if not (s.get("name") or "").startswith(AUTO_SNAP_PREFIX)
+        ]
         if manual_snaps and len(manual_snaps) >= 2:
             raise HTTPException(status_code=400, detail="수동 스냅샷은 최대 2개까지 생성할 수 있습니다.")
         if len(real_snaps) >= 3:

--- a/backend/core/constants.py
+++ b/backend/core/constants.py
@@ -9,3 +9,6 @@ TIER_SPECS = {
     # 프로젝트 오너 전용 (최대 8 vCPU, 32GB RAM, 70GB SSD)
     VMTier.PROJECT_CUSTOM: {"memory": 32768, "cores": 8, "disk": 70},
 }
+
+AUTO_SNAP_PREFIX = "auto-daily"
+PROVISIONING_UPTIME_THRESHOLD_SECONDS = 180

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,7 @@ from api.routes import (
 )
 from api.routes.oauth import validate_oauth_store_mode
 from core.config import settings
+from core.constants import AUTO_SNAP_PREFIX
 from sqlalchemy.orm import joinedload
 from core.database import Base, engine, SessionLocal
 from core.init_servers import sync_servers
@@ -314,9 +315,6 @@ async def _iptables_weekly_backup_loop():
             await asyncio.sleep(BACKGROUND_FAST_RETRY_SECONDS)
         else:
             await asyncio.sleep(IPTABLES_BACKUP_INTERVAL_SECONDS)
-
-
-AUTO_SNAP_PREFIX = "auto-daily"
 
 
 async def _wait_snap_delete(

--- a/backend/schemas/monitoring_schema.py
+++ b/backend/schemas/monitoring_schema.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+
+
+class NodeStats(BaseModel):
+    status: str
+    cpu_usage_percent: float | None = None
+    ram_total_gb: float | None = None
+    ram_used_gb: float | None = None
+    ram_free_gb: float | None = None
+    uptime_seconds: int | None = None
+    error: str | None = None
+
+
+class NodeStatsResponse(BaseModel):
+    stats: dict[str, NodeStats]
+    message: str | None = None

--- a/backend/services/mon_service.py
+++ b/backend/services/mon_service.py
@@ -59,7 +59,7 @@ def get_best_server(
     active_servers = query.all()
     
     if not active_servers:
-        if allowed_nodes is not None:
+        if allowed_nodes is not None or excluded_nodes is not None:
             raise HTTPException(status_code=503, detail="요청 가능한 활성 서버가 없습니다.")
         raise HTTPException(status_code=500, detail="사용 가능한 활성 서버가 없습니다.")
     

--- a/backend/services/mon_service.py
+++ b/backend/services/mon_service.py
@@ -59,6 +59,8 @@ def get_best_server(
     active_servers = query.all()
     
     if not active_servers:
+        if allowed_nodes is not None:
+            raise HTTPException(status_code=503, detail="요청 가능한 활성 서버가 없습니다.")
         raise HTTPException(status_code=500, detail="사용 가능한 활성 서버가 없습니다.")
     
     # 2. (옵션) 실시간에 가깝게 하기 위해 할당 전 모든 서버의 RAM 상태를 1회 갱신 (트래픽이 적을 때 유효)

--- a/backend/services/mon_service.py
+++ b/backend/services/mon_service.py
@@ -3,6 +3,7 @@ from models.server import Server
 from services.proxmox_client import get_proxmox_for_server
 from fastapi import HTTPException
 import logging
+from typing import Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -32,13 +33,24 @@ def update_server_stats(db: Session, server: Server):
         db.commit()
         return None
 
-def get_best_server(db: Session, required_ram_mb: int) -> Server:
+def get_best_server(
+    db: Session,
+    required_ram_mb: int,
+    *,
+    allowed_nodes: Iterable[str] | None = None,
+    excluded_nodes: Iterable[str] | None = None,
+) -> Server:
     """
     요구되는 RAM(MB)를 감당할 수 있으면서, 가장 여유 자원이 많은 서버를 찾습니다.
     (Resource-Based Auto Provisioning)
     """
     # 1. 활성화된 모든 서버 목록 가져오기
-    active_servers = db.query(Server).filter(Server.is_active == True).all()
+    query = db.query(Server).filter(Server.is_active == True)
+    if allowed_nodes:
+        query = query.filter(Server.name.in_(set(allowed_nodes)))
+    if excluded_nodes:
+        query = query.filter(~Server.name.in_(set(excluded_nodes)))
+    active_servers = query.all()
     
     if not active_servers:
         raise HTTPException(status_code=500, detail="사용 가능한 활성 서버가 없습니다.")

--- a/backend/services/mon_service.py
+++ b/backend/services/mon_service.py
@@ -46,10 +46,16 @@ def get_best_server(
     """
     # 1. 활성화된 모든 서버 목록 가져오기
     query = db.query(Server).filter(Server.is_active == True)
-    if allowed_nodes:
-        query = query.filter(Server.name.in_(set(allowed_nodes)))
-    if excluded_nodes:
-        query = query.filter(~Server.name.in_(set(excluded_nodes)))
+    if allowed_nodes is not None:
+        allowed_set = {node for node in allowed_nodes if node is not None}
+        if allowed_set:
+            query = query.filter(Server.name.in_(allowed_set))
+        else:
+            query = query.filter(Server.id == -1)
+    if excluded_nodes is not None:
+        excluded_set = {node for node in excluded_nodes if node is not None}
+        if excluded_set:
+            query = query.filter(~Server.name.in_(excluded_set))
     active_servers = query.all()
     
     if not active_servers:

--- a/backend/services/proxmox_client.py
+++ b/backend/services/proxmox_client.py
@@ -1,7 +1,9 @@
 import logging
+import requests
 import threading
 import time
 from proxmoxer import ProxmoxAPI
+from proxmoxer.core import ResourceException
 from fastapi import HTTPException
 
 logger = logging.getLogger(__name__)
@@ -10,6 +12,53 @@ logger = logging.getLogger(__name__)
 _connection_cache: dict[int, tuple[object, float]] = {}  # server_id → (proxmox, expires_at)
 _cache_lock = threading.Lock()
 _CACHE_TTL = 300  # 5분
+
+
+def proxmox_http_exception(
+    exc: Exception,
+    *,
+    default_detail: str = "서버 오류가 발생했습니다.",
+) -> HTTPException:
+    if isinstance(exc, HTTPException):
+        return exc
+
+    if isinstance(exc, (TimeoutError, requests.exceptions.Timeout)):
+        return HTTPException(
+            status_code=503,
+            detail="Proxmox 응답이 지연되고 있습니다. 잠시 후 다시 시도해주세요.",
+        )
+
+    if isinstance(exc, requests.exceptions.ConnectionError):
+        return HTTPException(
+            status_code=503,
+            detail="Proxmox 서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.",
+        )
+
+    if isinstance(exc, ResourceException):
+        content = f"{exc.content} {exc.errors or ''}".lower()
+        if exc.status_code in (401, 403):
+            return HTTPException(status_code=401, detail="Proxmox 인증에 실패했습니다.")
+        if exc.status_code == 404:
+            return HTTPException(status_code=404, detail="Proxmox 리소스를 찾을 수 없습니다.")
+        if exc.status_code == 409:
+            return HTTPException(status_code=409, detail="Proxmox 리소스가 현재 작업 중입니다.")
+        if exc.status_code == 507 or any(
+            marker in content
+            for marker in ("insufficient", "not enough", "no space", "resource")
+        ):
+            return HTTPException(status_code=507, detail="Proxmox 노드의 리소스가 부족합니다.")
+        if exc.status_code >= 500:
+            return HTTPException(status_code=502, detail="Proxmox 서버 오류가 발생했습니다.")
+
+    return HTTPException(status_code=500, detail=default_detail)
+
+
+def raise_proxmox_http_exception(
+    exc: Exception,
+    *,
+    default_detail: str = "서버 오류가 발생했습니다.",
+) -> None:
+    raise proxmox_http_exception(exc, default_detail=default_detail)
 
 
 def get_proxmox_for_server(server):
@@ -38,7 +87,7 @@ def get_proxmox_for_server(server):
         return proxmox
     except Exception as e:
         logger.error(f"Proxmox 연결 실패 ({server.name}): {e}")
-        raise HTTPException(
-            status_code=500,
-            detail="서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요."
+        raise_proxmox_http_exception(
+            e,
+            default_detail="서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.",
         )

--- a/backend/services/proxmox_client.py
+++ b/backend/services/proxmox_client.py
@@ -40,10 +40,14 @@ def proxmox_http_exception(
             return HTTPException(status_code=401, detail="Proxmox 인증에 실패했습니다.")
         if exc.status_code == 403:
             return HTTPException(status_code=403, detail="Proxmox 작업 권한이 없습니다.")
+        if exc.status_code == 400:
+            return HTTPException(status_code=400, detail="Proxmox 요청이 올바르지 않습니다.")
         if exc.status_code == 404:
             return HTTPException(status_code=404, detail="Proxmox 리소스를 찾을 수 없습니다.")
         if exc.status_code == 409:
             return HTTPException(status_code=409, detail="Proxmox 리소스가 현재 작업 중입니다.")
+        if exc.status_code == 429:
+            return HTTPException(status_code=429, detail="Proxmox 요청이 너무 많습니다.")
         if exc.status_code == 507 or any(
             marker in content
             for marker in ("insufficient", "not enough", "no space")

--- a/backend/services/proxmox_client.py
+++ b/backend/services/proxmox_client.py
@@ -36,15 +36,17 @@ def proxmox_http_exception(
 
     if isinstance(exc, ResourceException):
         content = f"{exc.content} {exc.errors or ''}".lower()
-        if exc.status_code in (401, 403):
+        if exc.status_code == 401:
             return HTTPException(status_code=401, detail="Proxmox 인증에 실패했습니다.")
+        if exc.status_code == 403:
+            return HTTPException(status_code=403, detail="Proxmox 작업 권한이 없습니다.")
         if exc.status_code == 404:
             return HTTPException(status_code=404, detail="Proxmox 리소스를 찾을 수 없습니다.")
         if exc.status_code == 409:
             return HTTPException(status_code=409, detail="Proxmox 리소스가 현재 작업 중입니다.")
         if exc.status_code == 507 or any(
             marker in content
-            for marker in ("insufficient", "not enough", "no space", "resource")
+            for marker in ("insufficient", "not enough", "no space")
         ):
             return HTTPException(status_code=507, detail="Proxmox 노드의 리소스가 부족합니다.")
         if exc.status_code >= 500:

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -353,7 +353,21 @@ def create_vm(
                 detail=f"노드 '{node_name}'을(를) 찾을 수 없거나 비활성 상태입니다.",
             )
     else:
-        server = get_best_server(db, required_ram_mb=specs["memory"])
+        project_node = settings.PROJECT_NODE_NAME
+        if current_user.role == UserRole.USER:
+            server = get_best_server(
+                db,
+                required_ram_mb=specs["memory"],
+                excluded_nodes={project_node},
+            )
+        elif current_user.role == UserRole.PROJECT_OWNER:
+            server = get_best_server(
+                db,
+                required_ram_mb=specs["memory"],
+                allowed_nodes={project_node},
+            )
+        else:
+            server = get_best_server(db, required_ram_mb=specs["memory"])
 
     # 2. OS별 템플릿 및 유저명 결정
     from schemas.vm_schema import VMOs

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -354,26 +354,18 @@ def create_vm(
             )
     else:
         project_node = settings.PROJECT_NODE_NAME
-        if current_user.role == UserRole.USER:
-            server = get_best_server(
-                db,
-                required_ram_mb=specs["memory"],
-                excluded_nodes={project_node},
-            )
-        elif current_user.role == UserRole.PROJECT_OWNER or tier == VMTierEnum.PROJECT_CUSTOM:
+        if tier == VMTierEnum.PROJECT_CUSTOM or current_user.role == UserRole.PROJECT_OWNER:
             server = get_best_server(
                 db,
                 required_ram_mb=specs["memory"],
                 allowed_nodes={project_node},
             )
-        elif current_user.role == UserRole.ADMIN:
+        else:
             server = get_best_server(
                 db,
                 required_ram_mb=specs["memory"],
                 excluded_nodes={project_node},
             )
-        else:
-            server = get_best_server(db, required_ram_mb=specs["memory"])
 
     # 2. OS별 템플릿 및 유저명 결정
     from schemas.vm_schema import VMOs

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -360,11 +360,17 @@ def create_vm(
                 required_ram_mb=specs["memory"],
                 excluded_nodes={project_node},
             )
-        elif current_user.role == UserRole.PROJECT_OWNER:
+        elif current_user.role == UserRole.PROJECT_OWNER or tier == VMTierEnum.PROJECT_CUSTOM:
             server = get_best_server(
                 db,
                 required_ram_mb=specs["memory"],
                 allowed_nodes={project_node},
+            )
+        elif current_user.role == UserRole.ADMIN:
+            server = get_best_server(
+                db,
+                required_ram_mb=specs["memory"],
+                excluded_nodes={project_node},
             )
         else:
             server = get_best_server(db, required_ram_mb=specs["memory"])

--- a/backend/tests/test_change_password.py
+++ b/backend/tests/test_change_password.py
@@ -415,6 +415,29 @@ class TestChangePassword:
         )
         assert records == []
 
+    def test_password_reset_request_smtp_failure_silently_succeeds_without_record(self, client, db):
+        """SMTP 실패도 계정 존재 여부를 노출하지 않고 재설정 레코드를 남기지 않는다."""
+        from models.email_verification import EmailVerification
+        from unittest.mock import patch
+
+        _make_user(db, email="smtp-fail@gsm.hs.kr")
+
+        with patch("api.routes.auth.send_verification_email", return_value=False), \
+             patch("api.routes.auth._PASSWORD_RESET_MIN_RESPONSE_SECONDS", 0):
+            res = client.post(
+                "/api/v1/auth/password-reset/request",
+                json={"email": "smtp-fail@gsm.hs.kr", "login_role": "user"},
+            )
+
+        assert res.status_code == 200, res.text
+        assert res.json()["email"] == "smtp-fail@gsm.hs.kr"
+        records = (
+            db.query(EmailVerification)
+            .filter(EmailVerification.email == "smtp-fail@gsm.hs.kr")
+            .all()
+        )
+        assert records == []
+
     def test_login_with_new_password_after_change(self, client, db):
         """변경 → 새 비밀번호 로그인 성공, 옛 비밀번호 로그인 실패."""
         user = _make_user(db, email="login@gsm.hs.kr", password="OldPass1!")

--- a/backend/tests/test_change_password.py
+++ b/backend/tests/test_change_password.py
@@ -415,8 +415,8 @@ class TestChangePassword:
         )
         assert records == []
 
-    def test_password_reset_request_smtp_failure_silently_succeeds_without_record(self, client, db):
-        """SMTP 실패도 계정 존재 여부를 노출하지 않고 재설정 레코드를 남기지 않는다."""
+    def test_password_reset_request_smtp_failure_returns_503_without_record(self, client, db):
+        """SMTP 실패 시 사용자가 재시도할 수 있도록 503을 반환하고 재설정 레코드를 남기지 않는다."""
         from models.email_verification import EmailVerification
         from unittest.mock import patch
 
@@ -429,14 +429,29 @@ class TestChangePassword:
                 json={"email": "smtp-fail@gsm.hs.kr", "login_role": "user"},
             )
 
-        assert res.status_code == 200, res.text
-        assert res.json()["email"] == "smtp-fail@gsm.hs.kr"
+        assert res.status_code == 503, res.text
         records = (
             db.query(EmailVerification)
             .filter(EmailVerification.email == "smtp-fail@gsm.hs.kr")
             .all()
         )
         assert records == []
+
+    def test_password_reset_request_db_failure_returns_503(self, client, db):
+        """비밀번호 재설정 DB 처리 실패는 500 traceback 대신 503으로 응답한다."""
+        from sqlalchemy.exc import SQLAlchemyError
+        from unittest.mock import patch
+
+        _make_user(db, email="db-fail@gsm.hs.kr")
+
+        with patch.object(db, "commit", side_effect=SQLAlchemyError("db down")), \
+             patch("api.routes.auth._PASSWORD_RESET_MIN_RESPONSE_SECONDS", 0):
+            res = client.post(
+                "/api/v1/auth/password-reset/request",
+                json={"email": "db-fail@gsm.hs.kr", "login_role": "user"},
+            )
+
+        assert res.status_code == 503, res.text
 
     def test_login_with_new_password_after_change(self, client, db):
         """변경 → 새 비밀번호 로그인 성공, 옛 비밀번호 로그인 실패."""

--- a/backend/tests/test_change_password.py
+++ b/backend/tests/test_change_password.py
@@ -374,7 +374,8 @@ class TestChangePassword:
         # USER만 존재
         _make_user(db, email="onlyuser@gsm.hs.kr")
 
-        with patch("api.routes.auth.send_verification_email", return_value=True):
+        with patch("api.routes.auth.send_verification_email", return_value=True), \
+             patch("api.routes.auth._PASSWORD_RESET_MIN_RESPONSE_SECONDS", 0):
             res = client.post(
                 "/api/v1/auth/password-reset/request",
                 json={
@@ -389,6 +390,30 @@ class TestChangePassword:
             .all()
         )
         assert len(recs) == 0, "PO 계정이 없으므로 레코드도 생성되지 않아야 함"
+
+    def test_password_reset_request_oauth_user_silently_succeeds_without_record(self, client, db):
+        """OAuth 계정은 비밀번호 재설정 레코드와 메일 발송 없이 같은 성공 응답을 반환한다."""
+        from models.email_verification import EmailVerification
+        from unittest.mock import patch
+
+        _make_user(db, email="oauth-reset@gsm.hs.kr", oauth=True)
+
+        with patch("api.routes.auth.send_verification_email", return_value=True) as mock_send, \
+             patch("api.routes.auth._PASSWORD_RESET_MIN_RESPONSE_SECONDS", 0):
+            res = client.post(
+                "/api/v1/auth/password-reset/request",
+                json={"email": "oauth-reset@gsm.hs.kr", "login_role": "user"},
+            )
+
+        assert res.status_code == 200, res.text
+        assert res.json()["email"] == "oauth-reset@gsm.hs.kr"
+        mock_send.assert_not_called()
+        records = (
+            db.query(EmailVerification)
+            .filter(EmailVerification.email == "oauth-reset@gsm.hs.kr")
+            .all()
+        )
+        assert records == []
 
     def test_login_with_new_password_after_change(self, client, db):
         """변경 → 새 비밀번호 로그인 성공, 옛 비밀번호 로그인 실패."""

--- a/backend/tests/test_email_verification_reuse.py
+++ b/backend/tests/test_email_verification_reuse.py
@@ -98,7 +98,8 @@ class TestEmailVerificationReuse:
 
         with patch("api.routes.auth.now_kst", _naive_now), \
              patch("api.routes.auth.send_verification_email", return_value=True):
-            client.post("/api/v1/auth/resend-code", json={"email": "reuse2@gsm.hs.kr"})
+            resend = client.post("/api/v1/auth/resend-code", json={"email": "reuse2@gsm.hs.kr"})
+            assert resend.status_code == 200
 
             # 이전 코드로 인증 시도 → 최신 레코드와 코드 불일치 → 400
             res = client.post("/api/v1/auth/verify", json={"email": "reuse2@gsm.hs.kr", "code": "222222"})

--- a/backend/tests/test_external_services.py
+++ b/backend/tests/test_external_services.py
@@ -362,7 +362,35 @@ class TestProxmoxExceptionMapping:
 
         http_exc = proxmox_client.proxmox_http_exception(FakeResourceException())
 
-        assert http_exc.status_code == 500
+        assert http_exc.status_code == 400
+
+    def test_resource_exception_400_maps_to_400(self, monkeypatch):
+        import services.proxmox_client as proxmox_client
+
+        class FakeResourceException(Exception):
+            status_code = 400
+            content = "parameter verification failed"
+            errors = None
+
+        monkeypatch.setattr(proxmox_client, "ResourceException", FakeResourceException)
+
+        http_exc = proxmox_client.proxmox_http_exception(FakeResourceException())
+
+        assert http_exc.status_code == 400
+
+    def test_resource_exception_429_maps_to_429(self, monkeypatch):
+        import services.proxmox_client as proxmox_client
+
+        class FakeResourceException(Exception):
+            status_code = 429
+            content = "too many requests"
+            errors = None
+
+        monkeypatch.setattr(proxmox_client, "ResourceException", FakeResourceException)
+
+        http_exc = proxmox_client.proxmox_http_exception(FakeResourceException())
+
+        assert http_exc.status_code == 429
 
 
 # ── EXT-TC-06: /notifications/read-all — 삭제가 아닌 읽음 처리 ─

--- a/backend/tests/test_external_services.py
+++ b/backend/tests/test_external_services.py
@@ -333,6 +333,38 @@ class TestProxmoxConnectionCache:
             _connection_cache.pop(999, None)
 
 
+class TestProxmoxExceptionMapping:
+    """Proxmox 예외를 HTTP 상태로 변환하는 정책 검증"""
+
+    def test_resource_exception_403_maps_to_403(self, monkeypatch):
+        import services.proxmox_client as proxmox_client
+
+        class FakeResourceException(Exception):
+            status_code = 403
+            content = "permission denied"
+            errors = None
+
+        monkeypatch.setattr(proxmox_client, "ResourceException", FakeResourceException)
+
+        http_exc = proxmox_client.proxmox_http_exception(FakeResourceException())
+
+        assert http_exc.status_code == 403
+
+    def test_resource_word_alone_does_not_map_to_507(self, monkeypatch):
+        import services.proxmox_client as proxmox_client
+
+        class FakeResourceException(Exception):
+            status_code = 400
+            content = "resource does not exist"
+            errors = None
+
+        monkeypatch.setattr(proxmox_client, "ResourceException", FakeResourceException)
+
+        http_exc = proxmox_client.proxmox_http_exception(FakeResourceException())
+
+        assert http_exc.status_code == 500
+
+
 # ── EXT-TC-06: /notifications/read-all — 삭제가 아닌 읽음 처리 ─
 
 

--- a/backend/tests/test_vm_lifecycle.py
+++ b/backend/tests/test_vm_lifecycle.py
@@ -645,7 +645,37 @@ class TestBestServerRoleFilters:
                 allowed_nodes={None},
             )
 
-        assert exc_info.value.status_code == 500
+        assert exc_info.value.status_code == 503
+
+    @patch("services.vm_service.settings")
+    @patch("services.mon_service.get_best_server")
+    def test_admin_basic_auto_assignment_excludes_project_node(
+        self, mock_best_server, mock_settings, db, admin_user
+    ):
+        from fastapi import HTTPException
+
+        mock_settings.PROJECT_NODE_NAME = "project-node"
+        mock_best_server.side_effect = HTTPException(status_code=418, detail="stop")
+
+        with pytest.raises(HTTPException):
+            create_vm(db, admin_user, VMTier.MICRO)
+
+        assert mock_best_server.call_args.kwargs["excluded_nodes"] == {"project-node"}
+
+    @patch("services.vm_service.settings")
+    @patch("services.mon_service.get_best_server")
+    def test_admin_project_custom_auto_assignment_uses_project_node(
+        self, mock_best_server, mock_settings, db, admin_user
+    ):
+        from fastapi import HTTPException
+
+        mock_settings.PROJECT_NODE_NAME = "project-node"
+        mock_best_server.side_effect = HTTPException(status_code=418, detail="stop")
+
+        with pytest.raises(HTTPException):
+            create_vm(db, admin_user, VMTier.PROJECT_CUSTOM)
+
+        assert mock_best_server.call_args.kwargs["allowed_nodes"] == {"project-node"}
 
 
 class TestSnapshotCreation:

--- a/backend/tests/test_vm_lifecycle.py
+++ b/backend/tests/test_vm_lifecycle.py
@@ -620,6 +620,33 @@ class TestBestServerRoleFilters:
 
         assert selected.name == project.name
 
+    @patch("services.mon_service.update_server_stats")
+    def test_none_excluded_node_is_ignored(self, mock_update, db, server):
+        mock_update.side_effect = lambda session, selected: selected.last_free_ram_mb
+
+        selected = get_best_server(
+            db,
+            required_ram_mb=2048,
+            excluded_nodes={None},
+        )
+
+        assert selected.name == server.name
+
+    @patch("services.mon_service.update_server_stats")
+    def test_none_only_allowed_nodes_matches_no_server(self, mock_update, db, server):
+        from fastapi import HTTPException
+
+        mock_update.side_effect = lambda session, selected: selected.last_free_ram_mb
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_best_server(
+                db,
+                required_ram_mb=2048,
+                allowed_nodes={None},
+            )
+
+        assert exc_info.value.status_code == 500
+
 
 class TestSnapshotCreation:
     """스냅샷 생성 정책 검증"""
@@ -656,3 +683,33 @@ class TestSnapshotCreation:
         assert exc_info.value.status_code == 400
         assert "이미 존재" in exc_info.value.detail
         qemu.snapshot.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("api.routes.vmcontrol.get_proxmox_for_server")
+    async def test_none_snapshot_name_does_not_crash(self, mock_proxmox_fn, db, user, server):
+        proxmox = MagicMock()
+        qemu = proxmox.nodes.return_value.qemu.return_value
+        qemu.snapshot.get.return_value = [
+            {"name": "current"},
+            {"name": None},
+        ]
+        qemu.snapshot.post.return_value = "UPID:test"
+        mock_proxmox_fn.return_value = proxmox
+        db.add(Vm(
+            hypervisor_vmid=201,
+            name="test-vm-2",
+            server_id=server.id,
+            owner_id=user.id,
+            internal_ip="10.0.0.101",
+        ))
+        db.commit()
+
+        result = await create_snapshot(
+            node=server.name,
+            vmid=201,
+            body=SnapshotCreateRequest(name="manual-2"),
+            db=db,
+            current_user=user,
+        )
+
+        assert result["success"] is True

--- a/backend/tests/test_vm_lifecycle.py
+++ b/backend/tests/test_vm_lifecycle.py
@@ -15,7 +15,8 @@ from models.server import Server
 from models.vm import Vm
 from models.vm_port import VmPort
 from models.notification import Notification
-from schemas.vm_schema import VMCreate, VMTier
+from schemas.vm_schema import VMCreate, VMTier, SnapshotCreateRequest
+from api.routes.vmcontrol import create_snapshot
 from services.vm_service import (
     create_vm,
     delete_vm,
@@ -24,6 +25,7 @@ from services.vm_service import (
 )
 from services.network_service import calculate_ports, manage_iptables
 from services.mon_service import update_server_stats
+from services.mon_service import get_best_server
 
 # ── 테스트용 DB 엔진 ──────────────────────────────────────────
 
@@ -568,3 +570,89 @@ class TestVMIDRetry:
         proxmox.cluster.nextid.get.side_effect = Exception("API error")
         proxmox.nodes.return_value.qemu.get.return_value = []
         assert _get_next_vmid(proxmox, "node1") == 100
+
+
+class TestBestServerRoleFilters:
+    """자동 서버 선택 시 역할별 노드 필터링 검증"""
+
+    def _add_server(self, db, name: str, ram: int) -> Server:
+        server = Server(
+            name=name,
+            ip_address=f"192.168.1.{len(name)}",
+            port=8006,
+            api_user="root@pam",
+            api_password="password",
+            is_active=True,
+            gateway_ip="192.168.1.1",
+            gateway_user="admin",
+            gateway_password="gwpass",
+            base_port=22000 + len(name),
+            last_free_ram_mb=ram,
+        )
+        db.add(server)
+        db.commit()
+        db.refresh(server)
+        return server
+
+    @patch("services.mon_service.update_server_stats")
+    def test_excluded_nodes_are_not_selected(self, mock_update, db, server):
+        mock_update.side_effect = lambda session, selected: selected.last_free_ram_mb
+        project = self._add_server(db, "project-node", 64000)
+
+        selected = get_best_server(
+            db,
+            required_ram_mb=2048,
+            excluded_nodes={project.name},
+        )
+
+        assert selected.name == server.name
+
+    @patch("services.mon_service.update_server_stats")
+    def test_allowed_nodes_limit_selection(self, mock_update, db, server):
+        mock_update.side_effect = lambda session, selected: selected.last_free_ram_mb
+        project = self._add_server(db, "project-node", 64000)
+
+        selected = get_best_server(
+            db,
+            required_ram_mb=2048,
+            allowed_nodes={project.name},
+        )
+
+        assert selected.name == project.name
+
+
+class TestSnapshotCreation:
+    """스냅샷 생성 정책 검증"""
+
+    @pytest.mark.asyncio
+    @patch("api.routes.vmcontrol.get_proxmox_for_server")
+    async def test_duplicate_snapshot_name_returns_400(self, mock_proxmox_fn, db, user, server):
+        proxmox = MagicMock()
+        qemu = proxmox.nodes.return_value.qemu.return_value
+        qemu.snapshot.get.return_value = [
+            {"name": "current"},
+            {"name": "manual-1"},
+        ]
+        mock_proxmox_fn.return_value = proxmox
+        db.add(Vm(
+            hypervisor_vmid=200,
+            name="test-vm",
+            server_id=server.id,
+            owner_id=user.id,
+            internal_ip="10.0.0.100",
+        ))
+        db.commit()
+
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc_info:
+            await create_snapshot(
+                node=server.name,
+                vmid=200,
+                body=SnapshotCreateRequest(name="manual-1"),
+                db=db,
+                current_user=user,
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "이미 존재" in exc_info.value.detail
+        qemu.snapshot.post.assert_not_called()

--- a/backend/tests/test_vm_lifecycle.py
+++ b/backend/tests/test_vm_lifecycle.py
@@ -647,6 +647,21 @@ class TestBestServerRoleFilters:
 
         assert exc_info.value.status_code == 503
 
+    @patch("services.mon_service.update_server_stats")
+    def test_excluded_nodes_filter_matching_all_servers_returns_503(self, mock_update, db, server):
+        from fastapi import HTTPException
+
+        mock_update.side_effect = lambda session, selected: selected.last_free_ram_mb
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_best_server(
+                db,
+                required_ram_mb=2048,
+                excluded_nodes={server.name},
+            )
+
+        assert exc_info.value.status_code == 503
+
     @patch("services.vm_service.settings")
     @patch("services.mon_service.get_best_server")
     def test_admin_basic_auto_assignment_excludes_project_node(


### PR DESCRIPTION
## Summary
- **권한/보안**: 자동 VM 배정에서 일반 사용자는 프로젝트 노드 제외, 프로젝트 오너/PROJECT_CUSTOM 자동 배정은 프로젝트 노드로 제한하고 OAuth 계정 비밀번호 재설정은 메일/레코드 생성 없이 동일 응답 처리
- **VM/방화벽/스냅샷**: Proxmox 예외를 의미 있는 HTTP 상태로 매핑하고, 방화벽 rules API에 `node` 경로를 반영하며, 중복 스냅샷명 검증과 삭제 응답 코드를 정리
- **모니터링/상수/테스트**: 모니터링 응답 모델을 추가하고 자동 스냅샷/프로비저닝 상수를 공통화, 관련 회귀 테스트 추가

## Related issues
Closes #128
Closes #105
Closes #104
Closes #102
Closes #84
Closes #61
Closes #54
Closes #44

## Test plan
- [x] `uv run python -m py_compile backend/services/proxmox_client.py backend/api/routes/vmcontrol.py backend/api/routes/firewall.py backend/api/routes/auth.py backend/api/routes/monitoring.py backend/services/mon_service.py backend/services/vm_service.py backend/core/constants.py backend/schemas/monitoring_schema.py`
- [x] `SECRET_KEY=test-secret-key-for-local-tests uv run pytest backend/tests/test_change_password.py::TestChangePassword::test_password_reset_request_oauth_user_silently_succeeds_without_record backend/tests/test_email_verification_reuse.py::TestEmailVerificationReuse::test_resend_invalidates_old_code backend/tests/test_monitoring_rbac.py backend/tests/test_input_validation.py backend/tests/test_vm_lifecycle.py::TestBestServerRoleFilters backend/tests/test_vm_lifecycle.py::TestSnapshotCreation`
- [x] `SECRET_KEY=test-secret-key-for-local-tests uv run pytest backend/tests/test_change_password.py::TestChangePassword::test_password_reset_request_smtp_failure_returns_503_without_record backend/tests/test_change_password.py::TestChangePassword::test_password_reset_request_db_failure_returns_503 backend/tests/test_external_services.py::TestProxmoxExceptionMapping backend/tests/test_vm_lifecycle.py::TestBestServerRoleFilters backend/tests/test_vm_lifecycle.py::TestSnapshotCreation`