### PR TITLE
fix: main 병합 리뷰 지적 반영

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -116,7 +116,20 @@ def _send_admin_expiry_notifications(db, now) -> None:
         .filter(User.role == UserRole.ADMIN, User.is_active == True)
         .all()
     )
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
     for admin in admins:
+        existing = (
+            db.query(Notification)
+            .filter(
+                Notification.user_id == admin.id,
+                Notification.type == "info",
+                Notification.message.like("만료 임박 VM%"),
+                Notification.created_at >= today_start,
+            )
+            .first()
+        )
+        if existing:
+            continue
         db.add(
             Notification(
                 user_id=admin.id,

--- a/backend/main.py
+++ b/backend/main.py
@@ -117,18 +117,23 @@ def _send_admin_expiry_notifications(db, now) -> None:
         .all()
     )
     today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
-    for admin in admins:
-        existing = (
-            db.query(Notification)
+    admin_ids = [admin.id for admin in admins]
+    existing_user_ids = set()
+    if admin_ids:
+        existing_user_ids = {
+            row[0]
+            for row in db.query(Notification.user_id)
             .filter(
-                Notification.user_id == admin.id,
+                Notification.user_id.in_(admin_ids),
                 Notification.type == "info",
                 Notification.message.like("만료 임박 VM%"),
                 Notification.created_at >= today_start,
             )
-            .first()
-        )
-        if existing:
+            .all()
+        }
+
+    for admin in admins:
+        if admin.id in existing_user_ids:
             continue
         db.add(
             Notification(

--- a/backend/services/mon_service.py
+++ b/backend/services/mon_service.py
@@ -29,8 +29,12 @@ def update_server_stats(db: Session, server: Server):
         return free_ram_mb
     except Exception as e:
         logger.exception(f"서버 {server.name} 상태 업데이트 실패: {e}")
-        server.last_free_ram_mb = 0
-        db.commit()
+        try:
+            db.rollback()
+            server.last_free_ram_mb = 0
+            db.commit()
+        except Exception as db_err:
+            logger.error(f"서버 {server.name} RAM 상태 초기화 실패: {db_err}")
         return None
 
 def get_best_server(

--- a/backend/services/mon_service.py
+++ b/backend/services/mon_service.py
@@ -34,7 +34,7 @@ def update_server_stats(db: Session, server: Server):
             server.last_free_ram_mb = 0
             db.commit()
         except Exception as db_err:
-            logger.error(f"서버 {server.name} RAM 상태 초기화 실패: {db_err}")
+            logger.exception(f"서버 {server.name} RAM 상태 초기화 실패: {db_err}")
         return None
 
 def get_best_server(

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -24,6 +24,7 @@ from models.vm_port import VmPort
 logger = logging.getLogger(__name__)
 
 _IP_ALLOCATION_LOCK_KEY = 0x47534D53
+_FALLBACK_LOCK_TIMEOUT_SECONDS = 10.0
 _fallback_ip_allocation_lock = threading.Lock()
 _FALLBACK_LOCK_INFO_KEY = "internal_ip_allocation_lock_held"
 
@@ -96,7 +97,11 @@ def _acquire_internal_ip_allocation_lock(db: Session) -> None:
     if db.info.get(_FALLBACK_LOCK_INFO_KEY):
         return
 
-    _fallback_ip_allocation_lock.acquire()
+    if not _fallback_ip_allocation_lock.acquire(timeout=_FALLBACK_LOCK_TIMEOUT_SECONDS):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="IP 할당 중 동시성 제어 락 획득에 실패했습니다. 잠시 후 다시 시도해주세요.",
+        )
     db.info[_FALLBACK_LOCK_INFO_KEY] = _fallback_ip_allocation_lock
     event.listen(db, "after_commit", _release_fallback_ip_allocation_lock, once=True)
     event.listen(db, "after_rollback", _release_fallback_ip_allocation_lock, once=True)

--- a/backend/tests/test_background_tasks.py
+++ b/backend/tests/test_background_tasks.py
@@ -245,3 +245,23 @@ class TestSendAdminExpiryNotifications:
 
         db.expire_all()
         assert db.query(Notification).count() == 2
+
+    def test_duplicate_same_day_notification_skipped(self, db):
+        """같은 날 이미 만료 임박 알림을 받은 ADMIN에게 중복 발송하지 않는다."""
+        from main import _send_admin_expiry_notifications
+        now = datetime(2026, 5, 26, 12, 0, 0)
+        server = _make_server(db)
+        admin = _make_admin(db, "dup-admin@gsm.hs.kr")
+        _make_vm(db, "vm-soon", server, now + timedelta(days=3))
+        db.add(Notification(
+            user_id=admin.id,
+            type="info",
+            message="만료 임박 VM 1개: old-vm(1일 0시간)",
+            created_at=now.replace(hour=1),
+        ))
+        db.commit()
+
+        _send_admin_expiry_notifications(db, now)
+
+        db.expire_all()
+        assert db.query(Notification).filter(Notification.user_id == admin.id).count() == 1

--- a/backend/tests/test_vm_lifecycle.py
+++ b/backend/tests/test_vm_lifecycle.py
@@ -366,6 +366,34 @@ class TestMonServiceFailure:
         db.refresh(server)
         assert server.last_free_ram_mb == 0
 
+    @patch("services.mon_service.get_proxmox_for_server")
+    def test_failure_reset_db_error_is_swallowed(self, mock_proxmox, db, server):
+        """상태 초기화 commit 실패도 update_server_stats 밖으로 전파하지 않는다."""
+        mock_proxmox.side_effect = Exception("connection refused")
+
+        with patch.object(db, "commit", side_effect=Exception("db down")):
+            result = update_server_stats(db, server)
+
+        assert result is None
+
+
+class TestFallbackIpAllocationLock:
+    """비-PostgreSQL fallback IP 할당 락 동작 검증"""
+
+    def test_fallback_lock_timeout_returns_503(self, db):
+        from fastapi import HTTPException
+        import services.vm_service as vm_service
+
+        acquired = vm_service._fallback_ip_allocation_lock.acquire(blocking=False)
+        assert acquired
+        try:
+            with patch("services.vm_service._FALLBACK_LOCK_TIMEOUT_SECONDS", 0.01):
+                with pytest.raises(HTTPException) as exc_info:
+                    vm_service._acquire_internal_ip_allocation_lock(db)
+            assert exc_info.value.status_code == 503
+        finally:
+            vm_service._fallback_ip_allocation_lock.release()
+
 
 # ── VM-TC-12: MAX_VMS_PER_USER 한도 초과 ─────────────────────
 


### PR DESCRIPTION
## Summary
- **모니터링**: `update_server_stats()` 실패 시 DB 세션을 rollback한 뒤 RAM 상태 초기화를 best-effort로 처리해 2차 DB 예외 전파를 막았습니다.
- **VM 생성**: 비-PostgreSQL fallback IP 할당 락에 timeout을 추가해 로컬/테스트 환경에서 무한 대기를 방지했습니다.
- **알림**: 관리자 만료 임박 알림이 같은 날 중복 발송되지 않도록 기존 알림을 확인합니다.

## Related
- Follow-up for https://github.com/GSMSV/GSM-SV/pull/134 review comments

## Test plan
- [x] `uv run python -m py_compile backend/services/mon_service.py backend/services/vm_service.py backend/main.py backend/tests/test_vm_lifecycle.py backend/tests/test_background_tasks.py`
- [x] `SECRET_KEY=test-secret-key-for-local-tests uv run pytest backend/tests/test_vm_lifecycle.py::TestMonServiceFailure backend/tests/test_vm_lifecycle.py::TestFallbackIpAllocationLock backend/tests/test_background_tasks.py::TestSendAdminExpiryNotifications`