### PR TITLE
fix: 알림 읽음 처리 보존

### DIFF
--- a/BACKEND.md
+++ b/BACKEND.md
@@ -315,7 +315,7 @@ SVC  : base_port + 2000 + vmid
 |--------|------|------|
 | GET | `` | 알림 목록 (최신 50개) |
 | PATCH | `/{notification_id}/read` | 단일 알림 읽음 처리 |
-| POST | `/read-all` | 전체 알림 삭제 |
+| POST | `/read-all` | 전체 알림 읽음 처리 |
 | DELETE | `/{notification_id}` | 단일 알림 삭제 |
 
 모든 엔드포인트 인증 필요. 알림 타입: `info` / `success` / `error`

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,39 @@
+# Notification Read-All Persistence Fix
+
+## Summary
+
+Opening the notification dropdown calls `POST /api/v1/notifications/read-all` through the frontend notification context. The frontend expects this endpoint to mark notifications as read, keep them in the list, then refetch. The backend currently deletes all notifications for the user, so notifications briefly appear from optimistic cache and disappear after the query invalidates.
+
+## Requirements
+
+- `POST /api/v1/notifications/read-all` must mark the current user's unread notifications as read.
+- The endpoint must not delete notification rows.
+- The frontend "모두 읽음" action must mark local in-memory notifications as read instead of clearing them.
+- The endpoint must remain idempotent when all notifications are already read.
+- Single-notification deletion via `DELETE /api/v1/notifications/{id}` remains the explicit delete path.
+- No API shape change is required.
+
+## Data Model
+
+No schema changes. Reuse `Notification.is_read`.
+
+## API Behavior
+
+- Request: authenticated `POST /api/v1/notifications/read-all`
+- Response: unchanged, `{"success": true}`
+- Side effect: update rows where `user_id == current_user.id` and `is_read == False` to `is_read=True`
+
+## Frontend Behavior
+
+- Opening the notification menu marks local and remote notifications as read.
+- Clicking "모두 읽음" does the same and keeps notification entries visible.
+- Clicking "삭제" remains the only per-notification removal action in the menu.
+
+## Security
+
+The endpoint keeps using `Depends(get_current_user)` and scopes updates to `current_user.id`.
+
+## Tests
+
+- Add a route-level test proving `read-all` does not delete rows and marks both unread notifications as read.
+- Existing single delete behavior is unchanged.

--- a/backend/api/routes/notifications.py
+++ b/backend/api/routes/notifications.py
@@ -56,10 +56,11 @@ async def mark_all_as_read(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """모든 알림 삭제"""
+    """모든 알림 읽음 처리"""
     db.query(Notification).filter(
         Notification.user_id == current_user.id,
-    ).delete()
+        Notification.is_read == False,
+    ).update({"is_read": True})
     db.commit()
     return {"success": True}
 

--- a/backend/api/routes/notifications.py
+++ b/backend/api/routes/notifications.py
@@ -59,8 +59,8 @@ async def mark_all_as_read(
     """모든 알림 읽음 처리"""
     db.query(Notification).filter(
         Notification.user_id == current_user.id,
-        Notification.is_read == False,
-    ).update({"is_read": True})
+        Notification.is_read.is_(False),
+    ).update({"is_read": True}, synchronize_session=False)
     db.commit()
     return {"success": True}
 

--- a/backend/api/routes/notifications.py
+++ b/backend/api/routes/notifications.py
@@ -60,7 +60,7 @@ async def mark_all_as_read(
     db.query(Notification).filter(
         Notification.user_id == current_user.id,
         Notification.is_read.is_(False),
-    ).update({"is_read": True}, synchronize_session=False)
+    ).update({"is_read": True}, synchronize_session="fetch")
     db.commit()
     return {"success": True}
 

--- a/backend/tests/test_external_services.py
+++ b/backend/tests/test_external_services.py
@@ -399,6 +399,46 @@ class TestProxmoxExceptionMapping:
 class TestNotificationsReadAll:
     """EXT-TC-06: read-all은 삭제가 아닌 is_read=True 설정"""
 
+    def test_read_all_endpoint_marks_as_read_not_delete(self, db, user):
+        """POST /read-all은 알림을 삭제하지 않고 읽음 처리"""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from api.dependencies import get_current_user
+        from api.routes import notifications
+        from core.database import get_db
+
+        for i in range(2):
+            db.add(
+                Notification(
+                    user_id=user.id,
+                    type="info",
+                    message=f"만료 임박 알림 {i}",
+                    is_read=False,
+                )
+            )
+        db.commit()
+
+        app = FastAPI()
+        app.include_router(notifications.router, prefix="/api/v1/notifications")
+
+        def override_db():
+            yield db
+
+        app.dependency_overrides[get_db] = override_db
+        app.dependency_overrides[get_current_user] = lambda: user
+
+        with TestClient(app) as client:
+            response = client.post("/api/v1/notifications/read-all")
+
+        assert response.status_code == 200
+        assert response.json() == {"success": True}
+
+        all_notifs = (
+            db.query(Notification).filter(Notification.user_id == user.id).all()
+        )
+        assert len(all_notifs) == 2
+        assert all(n.is_read for n in all_notifs)
+
     def test_read_all_marks_as_read_not_delete(self, db, user):
         """미읽음 5개 → read-all → 5개 모두 is_read=True, 삭제 아님"""
         for i in range(5):

--- a/backend/tests/test_external_services.py
+++ b/backend/tests/test_external_services.py
@@ -399,13 +399,34 @@ class TestProxmoxExceptionMapping:
 class TestNotificationsReadAll:
     """EXT-TC-06: read-all은 삭제가 아닌 is_read=True 설정"""
 
-    def test_read_all_endpoint_marks_as_read_not_delete(self, db, user):
-        """POST /read-all은 알림을 삭제하지 않고 읽음 처리"""
+    def _make_client(self, db, user):
         from fastapi import FastAPI
         from fastapi.testclient import TestClient
         from api.dependencies import get_current_user
         from api.routes import notifications
         from core.database import get_db
+
+        app = FastAPI()
+        app.include_router(notifications.router, prefix="/api/v1/notifications")
+
+        def override_db():
+            yield db
+
+        app.dependency_overrides[get_db] = override_db
+        app.dependency_overrides[get_current_user] = lambda: user
+        return TestClient(app)
+
+    def test_read_all_endpoint_scopes_to_current_user(self, db, user):
+        """POST /read-all은 현재 사용자 알림만 읽음 처리"""
+        other_user = User(
+            email="other@gsm.hs.kr",
+            hashed_password="hashed",
+            role=UserRole.USER,
+            is_active=True,
+        )
+        db.add(other_user)
+        db.commit()
+        db.refresh(other_user)
 
         for i in range(2):
             db.add(
@@ -416,56 +437,32 @@ class TestNotificationsReadAll:
                     is_read=False,
                 )
             )
+        db.add(
+            Notification(
+                user_id=other_user.id,
+                type="info",
+                message="다른 사용자 알림",
+                is_read=False,
+            )
+        )
         db.commit()
 
-        app = FastAPI()
-        app.include_router(notifications.router, prefix="/api/v1/notifications")
-
-        def override_db():
-            yield db
-
-        app.dependency_overrides[get_db] = override_db
-        app.dependency_overrides[get_current_user] = lambda: user
-
-        with TestClient(app) as client:
+        with self._make_client(db, user) as client:
             response = client.post("/api/v1/notifications/read-all")
+            user_notifs = (
+                db.query(Notification).filter(Notification.user_id == user.id).all()
+            )
+            other_notif = (
+                db.query(Notification)
+                .filter(Notification.user_id == other_user.id)
+                .one()
+            )
 
         assert response.status_code == 200
         assert response.json() == {"success": True}
-
-        all_notifs = (
-            db.query(Notification).filter(Notification.user_id == user.id).all()
-        )
-        assert len(all_notifs) == 2
-        assert all(n.is_read for n in all_notifs)
-
-    def test_read_all_marks_as_read_not_delete(self, db, user):
-        """미읽음 5개 → read-all → 5개 모두 is_read=True, 삭제 아님"""
-        for i in range(5):
-            db.add(
-                Notification(
-                    user_id=user.id,
-                    type="info",
-                    message=f"알림 {i}",
-                    is_read=False,
-                )
-            )
-        db.commit()
-
-        # read-all 로직 시뮬레이션 (notifications.py의 mark_all_as_read)
-        db.query(Notification).filter(
-            Notification.user_id == user.id,
-            Notification.is_read == False,
-        ).update({"is_read": True})
-        db.commit()
-
-        # 삭제되지 않았는지 확인
-        all_notifs = (
-            db.query(Notification).filter(Notification.user_id == user.id).all()
-        )
-        assert len(all_notifs) == 5
-        # 모두 읽음 상태
-        assert all(n.is_read for n in all_notifs)
+        assert len(user_notifs) == 2
+        assert all(n.is_read for n in user_notifs)
+        assert other_notif.is_read is False
 
     def test_read_all_idempotent(self, db, user):
         """이미 읽은 알림에 다시 read-all 해도 문제 없음"""
@@ -479,14 +476,12 @@ class TestNotificationsReadAll:
         )
         db.commit()
 
-        db.query(Notification).filter(
-            Notification.user_id == user.id,
-            Notification.is_read == False,
-        ).update({"is_read": True})
-        db.commit()
+        with self._make_client(db, user) as client:
+            response = client.post("/api/v1/notifications/read-all")
+            all_notifs = (
+                db.query(Notification).filter(Notification.user_id == user.id).all()
+            )
 
-        all_notifs = (
-            db.query(Notification).filter(Notification.user_id == user.id).all()
-        )
+        assert response.status_code == 200
         assert len(all_notifs) == 2
         assert all(n.is_read for n in all_notifs)


### PR DESCRIPTION
**Summary**
- POST /notifications/read-all이 알림을 삭제하지 않고 is_read=True로 갱신하도록 수정
- 알림 API 문서와 회귀 테스트 추가
- 작업 범위와 기대 동작을 SPEC.md에 기록

**Test plan**
- [x] SECRET_KEY=test-secret-key-for-notification-read-all pytest backend/tests/test_external_services.py::TestNotificationsReadAll -q