### PR TITLE
fix: serverless 함수 목록 조회 역할 무관 ownerId 필터 적용

### DIFF
--- a/serverless/src/routes/functions.ts
+++ b/serverless/src/routes/functions.ts
@@ -46,7 +46,7 @@ router.post("/", async (req, res, next) => {
 
 router.get("/", async (req, res, next) => {
   try {
-    const where = req.user!.role === "admin" ? {} : { ownerId: req.user!.userId };
+    const where = { ownerId: req.user!.userId };
     const functions = await prisma.function.findMany({ where, orderBy: { createdAt: "desc" } });
     res.json(functions.map(f => ({ ...f, envVars: JSON.parse(f.envVars) })));
   } catch (err) { next(err); }


### PR DESCRIPTION
## Summary
- **역할 기반 전체 조회 제거**: `GET /functions`에서 `admin` 역할이면 모든 함수를 반환하던 분기 제거
- `functions.ts` `GET /` — `where` 조건을 항상 `{ ownerId: req.user!.userId }`로 고정

## Test plan
- [x] admin 계정으로 함수 목록 조회 시 본인 함수만 반환되는지 확인
- [ ] 일반 user 계정 함수 목록 조회 정상 동작 확인