### PR TITLE
fix: serverless 함수 목록 조회 시 역할 관계없이 본인 것만 반환

### DIFF
--- a/serverless/src/routes/functions.ts
+++ b/serverless/src/routes/functions.ts
@@ -46,7 +46,7 @@ router.post("/", async (req, res, next) => {
 
 router.get("/", async (req, res, next) => {
   try {
-    const where = req.user!.role === "admin" ? {} : { ownerId: req.user!.userId };
+    const where = { ownerId: req.user!.userId };
     const functions = await prisma.function.findMany({ where, orderBy: { createdAt: "desc" } });
     res.json(functions.map(f => ({ ...f, envVars: JSON.parse(f.envVars) })));
   } catch (err) { next(err); }


### PR DESCRIPTION
admin에서 서버리스 탭에 다른 유저의 함수도 표시되던 부분을 수정했습니다.
향후 필요에 따라 어드민 탭에 따로 함수 관리 메뉴를 추가할 예정입니다.