### PR TITLE
feat: VM 생성 노드 자동배정 제거·비밀번호 특수문자 제한·자원 80% 생성 차단

### DIFF
--- a/BACKEND.md
+++ b/BACKEND.md
@@ -315,7 +315,7 @@ SVC  : base_port + 2000 + vmid
 |--------|------|------|
 | GET | `` | 알림 목록 (최신 50개) |
 | PATCH | `/{notification_id}/read` | 단일 알림 읽음 처리 |
-| POST | `/read-all` | 전체 알림 삭제 |
+| POST | `/read-all` | 전체 알림 읽음 처리 |
 | DELETE | `/{notification_id}` | 단일 알림 삭제 |
 
 모든 엔드포인트 인증 필요. 알림 타입: `info` / `success` / `error`

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,39 @@
+# Notification Read-All Persistence Fix
+
+## Summary
+
+Opening the notification dropdown calls `POST /api/v1/notifications/read-all` through the frontend notification context. The frontend expects this endpoint to mark notifications as read, keep them in the list, then refetch. The backend currently deletes all notifications for the user, so notifications briefly appear from optimistic cache and disappear after the query invalidates.
+
+## Requirements
+
+- `POST /api/v1/notifications/read-all` must mark the current user's unread notifications as read.
+- The endpoint must not delete notification rows.
+- The frontend "모두 읽음" action must mark local in-memory notifications as read instead of clearing them.
+- The endpoint must remain idempotent when all notifications are already read.
+- Single-notification deletion via `DELETE /api/v1/notifications/{id}` remains the explicit delete path.
+- No API shape change is required.
+
+## Data Model
+
+No schema changes. Reuse `Notification.is_read`.
+
+## API Behavior
+
+- Request: authenticated `POST /api/v1/notifications/read-all`
+- Response: unchanged, `{"success": true}`
+- Side effect: update rows where `user_id == current_user.id` and `is_read == False` to `is_read=True`
+
+## Frontend Behavior
+
+- Opening the notification menu marks local and remote notifications as read.
+- Clicking "모두 읽음" does the same and keeps notification entries visible.
+- Clicking "삭제" remains the only per-notification removal action in the menu.
+
+## Security
+
+The endpoint keeps using `Depends(get_current_user)` and scopes updates to `current_user.id`.
+
+## Tests
+
+- Add a route-level test proving `read-all` does not delete rows and marks both unread notifications as read.
+- Existing single delete behavior is unchanged.

--- a/backend/api/routes/notifications.py
+++ b/backend/api/routes/notifications.py
@@ -56,10 +56,11 @@ async def mark_all_as_read(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """모든 알림 삭제"""
+    """모든 알림 읽음 처리"""
     db.query(Notification).filter(
         Notification.user_id == current_user.id,
-    ).delete()
+        Notification.is_read == False,
+    ).update({"is_read": True})
     db.commit()
     return {"success": True}
 

--- a/backend/api/routes/notifications.py
+++ b/backend/api/routes/notifications.py
@@ -59,8 +59,8 @@ async def mark_all_as_read(
     """모든 알림 읽음 처리"""
     db.query(Notification).filter(
         Notification.user_id == current_user.id,
-        Notification.is_read == False,
-    ).update({"is_read": True})
+        Notification.is_read.is_(False),
+    ).update({"is_read": True}, synchronize_session=False)
     db.commit()
     return {"success": True}
 

--- a/backend/api/routes/notifications.py
+++ b/backend/api/routes/notifications.py
@@ -60,7 +60,7 @@ async def mark_all_as_read(
     db.query(Notification).filter(
         Notification.user_id == current_user.id,
         Notification.is_read.is_(False),
-    ).update({"is_read": True}, synchronize_session=False)
+    ).update({"is_read": True}, synchronize_session="fetch")
     db.commit()
     return {"success": True}
 

--- a/backend/services/mon_service.py
+++ b/backend/services/mon_service.py
@@ -36,12 +36,12 @@ def get_server_resource_usage(server: Server) -> dict:
     proxmox = get_proxmox_for_server(server)
     node_status = proxmox.nodes(server.name).status.get()
 
-    memory = node_status.get('memory', {})
-    total_mem = memory.get('total', 0)
-    used_mem = memory.get('used', 0)
+    memory = node_status.get('memory') or {}
+    total_mem = memory.get('total') or 0
+    used_mem = memory.get('used') or 0
     ram_pct = round(used_mem / total_mem * 100, 1) if total_mem else 0.0
 
-    cpu_pct = round(node_status.get('cpu', 0) * 100, 1)
+    cpu_pct = round((node_status.get('cpu') or 0) * 100, 1)
 
     disk_used = 0
     disk_total = 0
@@ -49,10 +49,10 @@ def get_server_resource_usage(server: Server) -> dict:
         storages = proxmox.nodes(server.name).storage.get()
         for st in storages:
             if st.get("type") == "lvmthin":
-                disk_used += st.get("used", 0)
-                disk_total += st.get("total", 0)
+                disk_used += st.get("used") or 0
+                disk_total += st.get("total") or 0
     except Exception:
-        pass
+        logger.exception(f"서버 {server.name} 스토리지 조회 실패")
     disk_pct = round(disk_used / disk_total * 100, 1) if disk_total else None
 
     return {"ram_pct": ram_pct, "cpu_pct": cpu_pct, "disk_pct": disk_pct}

--- a/backend/services/mon_service.py
+++ b/backend/services/mon_service.py
@@ -8,22 +8,15 @@ from typing import Iterable
 logger = logging.getLogger(__name__)
 
 def update_server_stats(db: Session, server: Server):
-    """
-    특정 서버(Proxmox Node)에 비동기로 접속하여 잔여 RAM 용량을 조회하고 DB를 업데이트합니다.
-    """
+    """특정 서버(Proxmox Node)에 비동기로 접속하여 잔여 RAM 용량을 조회하고 DB를 업데이트합니다."""
     try:
-        # 실제 API 호출
         proxmox = get_proxmox_for_server(server)
-        # 노드 상태 정보 가져오기 (이름 매칭 필요)
-        # Proxmox 클러스터 내의 노드 이름은 보통 server.name 과 일치해야 합니다.
         node_status = proxmox.nodes(server.name).status.get()
-        
-        # 전체 RAM - 사용 중인 RAM = 여유 RAM (바이트 -> MB 변환)
+
         total_memory = node_status.get('memory', {}).get('total', 0)
         used_memory = node_status.get('memory', {}).get('used', 0)
         free_ram_mb = (total_memory - used_memory) // (1024 * 1024)
-        
-        # DB 업데이트
+
         server.last_free_ram_mb = free_ram_mb
         db.commit()
         return free_ram_mb
@@ -36,6 +29,33 @@ def update_server_stats(db: Session, server: Server):
         except Exception as db_err:
             logger.exception(f"서버 {server.name} RAM 상태 초기화 실패: {db_err}")
         return None
+
+
+def get_server_resource_usage(server: Server) -> dict:
+    """서버의 CPU·RAM·SSD 사용률(%)을 실시간 조회해 반환합니다."""
+    proxmox = get_proxmox_for_server(server)
+    node_status = proxmox.nodes(server.name).status.get()
+
+    memory = node_status.get('memory', {})
+    total_mem = memory.get('total', 0)
+    used_mem = memory.get('used', 0)
+    ram_pct = round(used_mem / total_mem * 100, 1) if total_mem else 0.0
+
+    cpu_pct = round(node_status.get('cpu', 0) * 100, 1)
+
+    disk_used = 0
+    disk_total = 0
+    try:
+        storages = proxmox.nodes(server.name).storage.get()
+        for st in storages:
+            if st.get("type") == "lvmthin":
+                disk_used += st.get("used", 0)
+                disk_total += st.get("total", 0)
+    except Exception:
+        pass
+    disk_pct = round(disk_used / disk_total * 100, 1) if disk_total else None
+
+    return {"ram_pct": ram_pct, "cpu_pct": cpu_pct, "disk_pct": disk_pct}
 
 def get_best_server(
     db: Session,

--- a/backend/services/mon_service.py
+++ b/backend/services/mon_service.py
@@ -32,13 +32,18 @@ def update_server_stats(db: Session, server: Server):
 
 
 def get_server_resource_usage(server: Server) -> dict:
-    """서버의 CPU·RAM·SSD 사용률(%)을 실시간 조회해 반환합니다."""
-    proxmox = get_proxmox_for_server(server)
-    node_status = proxmox.nodes(server.name).status.get()
+    """서버의 CPU·RAM·SSD 사용률(%)과 가용 RAM(MB)을 실시간 조회해 반환합니다."""
+    try:
+        proxmox = get_proxmox_for_server(server)
+        node_status = proxmox.nodes(server.name).status.get()
+    except Exception:
+        logger.exception(f"서버 {server.name} 노드 상태 조회 실패")
+        raise
 
     memory = node_status.get('memory') or {}
     total_mem = memory.get('total') or 0
     used_mem = memory.get('used') or 0
+    free_ram_mb = (total_mem - used_mem) // (1024 * 1024)
     ram_pct = round(used_mem / total_mem * 100, 1) if total_mem else 0.0
 
     cpu_pct = round((node_status.get('cpu') or 0) * 100, 1)
@@ -55,7 +60,7 @@ def get_server_resource_usage(server: Server) -> dict:
         logger.exception(f"서버 {server.name} 스토리지 조회 실패")
     disk_pct = round(disk_used / disk_total * 100, 1) if disk_total else None
 
-    return {"ram_pct": ram_pct, "cpu_pct": cpu_pct, "disk_pct": disk_pct}
+    return {"ram_pct": ram_pct, "cpu_pct": cpu_pct, "disk_pct": disk_pct, "free_ram_mb": free_ram_mb}
 
 def get_best_server(
     db: Session,

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -32,12 +32,12 @@ _FALLBACK_LOCK_INFO_KEY = "internal_ip_allocation_lock_held"
 
 def _generate_password(length: int = 8) -> str:
     """영문+숫자+특수문자 랜덤 비밀번호 생성"""
-    chars = string.ascii_letters + string.digits + "!@#$%&*"
+    chars = string.ascii_letters + string.digits + "!@#%&*"
     password = ''.join(secrets.choice(chars) for _ in range(length))
     # 최소 조건 보장 (영문 + 숫자 + 특수문자 각 1개 이상)
     if not (any(c in string.ascii_letters for c in password)
             and any(c in string.digits for c in password)
-            and any(c in "!@#$%&*" for c in password)):
+            and any(c in "!@#%&*" for c in password)):
         return _generate_password(length)
     return password
 
@@ -358,19 +358,29 @@ def create_vm(
                 detail=f"노드 '{node_name}'을(를) 찾을 수 없거나 비활성 상태입니다.",
             )
     else:
-        project_node = settings.PROJECT_NODE_NAME
-        if tier == VMTierEnum.PROJECT_CUSTOM or current_user.role == UserRole.PROJECT_OWNER:
-            server = get_best_server(
-                db,
-                required_ram_mb=specs["memory"],
-                allowed_nodes={project_node},
+        raise HTTPException(status_code=400, detail="노드를 선택해주세요.")
+
+    # 1-1. 서버 자원 실시간 조회 후 80% 임계값 체크
+    from services.mon_service import get_server_resource_usage
+    try:
+        usage = get_server_resource_usage(server)
+        THRESHOLD = 80.0
+        overloaded = []
+        if usage["ram_pct"] >= THRESHOLD:
+            overloaded.append(f"RAM {usage['ram_pct']}%")
+        if usage["cpu_pct"] >= THRESHOLD:
+            overloaded.append(f"CPU {usage['cpu_pct']}%")
+        if usage["disk_pct"] is not None and usage["disk_pct"] >= THRESHOLD:
+            overloaded.append(f"SSD {usage['disk_pct']}%")
+        if overloaded:
+            raise HTTPException(
+                status_code=507,
+                detail=f"서버 자원이 부족합니다 ({', '.join(overloaded)} 점유 중). 75% 이하로 내려오면 다시 시도해주세요.",
             )
-        else:
-            server = get_best_server(
-                db,
-                required_ram_mb=specs["memory"],
-                excluded_nodes={project_node},
-            )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.warning(f"서버 {server.name} 자원 조회 실패, 체크 건너뜀: {e}")
 
     # 2. OS별 템플릿 및 유저명 결정
     from schemas.vm_schema import VMOs

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -303,8 +303,6 @@ def create_vm(
     7. iptables 포트포워딩 등록
     8. VM 부팅 + DB 저장
     """
-    from services.mon_service import get_best_server
-
     # 0. VM 개수 제한 (ADMIN, PROJECT_OWNER는 제한 없음)
     if current_user.role == UserRole.USER:
         user_vm_count = db.query(Vm).filter(Vm.owner_id == current_user.id).count()
@@ -360,7 +358,7 @@ def create_vm(
     else:
         raise HTTPException(status_code=400, detail="노드를 선택해주세요.")
 
-    # 1-1. 서버 자원 실시간 조회 후 80% 임계값 체크
+    # 1-1. 서버 자원 실시간 조회 후 80% 임계값 체크 + 절대 RAM 검증
     from services.mon_service import get_server_resource_usage
     try:
         usage = get_server_resource_usage(server)
@@ -376,6 +374,11 @@ def create_vm(
             raise HTTPException(
                 status_code=507,
                 detail=f"서버 자원이 부족합니다 ({', '.join(overloaded)} 점유 중). {THRESHOLD}% 미만으로 내려오면 다시 시도해주세요.",
+            )
+        if usage["free_ram_mb"] < specs["memory"]:
+            raise HTTPException(
+                status_code=507,
+                detail=f"서버 가용 RAM이 부족합니다 (필요: {specs['memory']}MB, 가용: {usage['free_ram_mb']}MB).",
             )
     except HTTPException:
         raise

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -375,7 +375,7 @@ def create_vm(
         if overloaded:
             raise HTTPException(
                 status_code=507,
-                detail=f"서버 자원이 부족합니다 ({', '.join(overloaded)} 점유 중). 75% 이하로 내려오면 다시 시도해주세요.",
+                detail=f"서버 자원이 부족합니다 ({', '.join(overloaded)} 점유 중). {THRESHOLD}% 미만으로 내려오면 다시 시도해주세요.",
             )
     except HTTPException:
         raise

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,6 +4,7 @@
 - FastAPI TestClient 제공
 """
 import pytest
+from unittest.mock import patch
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from core.database import Base, get_db
@@ -21,6 +22,16 @@ def setup_db():
     Base.metadata.create_all(bind=engine)
     yield
     Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def mock_server_resource_usage():
+    """모든 테스트에서 Proxmox 자원 조회를 mock — 실제 연결 없이 80% 체크 통과"""
+    with patch(
+        "services.mon_service.get_server_resource_usage",
+        return_value={"ram_pct": 10.0, "cpu_pct": 10.0, "disk_pct": 10.0, "free_ram_mb": 99999},
+    ):
+        yield
 
 
 @pytest.fixture

--- a/backend/tests/test_external_services.py
+++ b/backend/tests/test_external_services.py
@@ -399,6 +399,46 @@ class TestProxmoxExceptionMapping:
 class TestNotificationsReadAll:
     """EXT-TC-06: read-all은 삭제가 아닌 is_read=True 설정"""
 
+    def test_read_all_endpoint_marks_as_read_not_delete(self, db, user):
+        """POST /read-all은 알림을 삭제하지 않고 읽음 처리"""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from api.dependencies import get_current_user
+        from api.routes import notifications
+        from core.database import get_db
+
+        for i in range(2):
+            db.add(
+                Notification(
+                    user_id=user.id,
+                    type="info",
+                    message=f"만료 임박 알림 {i}",
+                    is_read=False,
+                )
+            )
+        db.commit()
+
+        app = FastAPI()
+        app.include_router(notifications.router, prefix="/api/v1/notifications")
+
+        def override_db():
+            yield db
+
+        app.dependency_overrides[get_db] = override_db
+        app.dependency_overrides[get_current_user] = lambda: user
+
+        with TestClient(app) as client:
+            response = client.post("/api/v1/notifications/read-all")
+
+        assert response.status_code == 200
+        assert response.json() == {"success": True}
+
+        all_notifs = (
+            db.query(Notification).filter(Notification.user_id == user.id).all()
+        )
+        assert len(all_notifs) == 2
+        assert all(n.is_read for n in all_notifs)
+
     def test_read_all_marks_as_read_not_delete(self, db, user):
         """미읽음 5개 → read-all → 5개 모두 is_read=True, 삭제 아님"""
         for i in range(5):

--- a/backend/tests/test_external_services.py
+++ b/backend/tests/test_external_services.py
@@ -399,13 +399,34 @@ class TestProxmoxExceptionMapping:
 class TestNotificationsReadAll:
     """EXT-TC-06: read-all은 삭제가 아닌 is_read=True 설정"""
 
-    def test_read_all_endpoint_marks_as_read_not_delete(self, db, user):
-        """POST /read-all은 알림을 삭제하지 않고 읽음 처리"""
+    def _make_client(self, db, user):
         from fastapi import FastAPI
         from fastapi.testclient import TestClient
         from api.dependencies import get_current_user
         from api.routes import notifications
         from core.database import get_db
+
+        app = FastAPI()
+        app.include_router(notifications.router, prefix="/api/v1/notifications")
+
+        def override_db():
+            yield db
+
+        app.dependency_overrides[get_db] = override_db
+        app.dependency_overrides[get_current_user] = lambda: user
+        return TestClient(app)
+
+    def test_read_all_endpoint_scopes_to_current_user(self, db, user):
+        """POST /read-all은 현재 사용자 알림만 읽음 처리"""
+        other_user = User(
+            email="other@gsm.hs.kr",
+            hashed_password="hashed",
+            role=UserRole.USER,
+            is_active=True,
+        )
+        db.add(other_user)
+        db.commit()
+        db.refresh(other_user)
 
         for i in range(2):
             db.add(
@@ -416,56 +437,32 @@ class TestNotificationsReadAll:
                     is_read=False,
                 )
             )
+        db.add(
+            Notification(
+                user_id=other_user.id,
+                type="info",
+                message="다른 사용자 알림",
+                is_read=False,
+            )
+        )
         db.commit()
 
-        app = FastAPI()
-        app.include_router(notifications.router, prefix="/api/v1/notifications")
-
-        def override_db():
-            yield db
-
-        app.dependency_overrides[get_db] = override_db
-        app.dependency_overrides[get_current_user] = lambda: user
-
-        with TestClient(app) as client:
+        with self._make_client(db, user) as client:
             response = client.post("/api/v1/notifications/read-all")
+            user_notifs = (
+                db.query(Notification).filter(Notification.user_id == user.id).all()
+            )
+            other_notif = (
+                db.query(Notification)
+                .filter(Notification.user_id == other_user.id)
+                .one()
+            )
 
         assert response.status_code == 200
         assert response.json() == {"success": True}
-
-        all_notifs = (
-            db.query(Notification).filter(Notification.user_id == user.id).all()
-        )
-        assert len(all_notifs) == 2
-        assert all(n.is_read for n in all_notifs)
-
-    def test_read_all_marks_as_read_not_delete(self, db, user):
-        """미읽음 5개 → read-all → 5개 모두 is_read=True, 삭제 아님"""
-        for i in range(5):
-            db.add(
-                Notification(
-                    user_id=user.id,
-                    type="info",
-                    message=f"알림 {i}",
-                    is_read=False,
-                )
-            )
-        db.commit()
-
-        # read-all 로직 시뮬레이션 (notifications.py의 mark_all_as_read)
-        db.query(Notification).filter(
-            Notification.user_id == user.id,
-            Notification.is_read == False,
-        ).update({"is_read": True})
-        db.commit()
-
-        # 삭제되지 않았는지 확인
-        all_notifs = (
-            db.query(Notification).filter(Notification.user_id == user.id).all()
-        )
-        assert len(all_notifs) == 5
-        # 모두 읽음 상태
-        assert all(n.is_read for n in all_notifs)
+        assert len(user_notifs) == 2
+        assert all(n.is_read for n in user_notifs)
+        assert other_notif.is_read is False
 
     def test_read_all_idempotent(self, db, user):
         """이미 읽은 알림에 다시 read-all 해도 문제 없음"""
@@ -479,14 +476,12 @@ class TestNotificationsReadAll:
         )
         db.commit()
 
-        db.query(Notification).filter(
-            Notification.user_id == user.id,
-            Notification.is_read == False,
-        ).update({"is_read": True})
-        db.commit()
+        with self._make_client(db, user) as client:
+            response = client.post("/api/v1/notifications/read-all")
+            all_notifs = (
+                db.query(Notification).filter(Notification.user_id == user.id).all()
+            )
 
-        all_notifs = (
-            db.query(Notification).filter(Notification.user_id == user.id).all()
-        )
+        assert response.status_code == 200
         assert len(all_notifs) == 2
         assert all(n.is_read for n in all_notifs)

--- a/backend/tests/test_vm_lifecycle.py
+++ b/backend/tests/test_vm_lifecycle.py
@@ -690,35 +690,13 @@ class TestBestServerRoleFilters:
 
         assert exc_info.value.status_code == 503
 
-    @patch("services.vm_service.settings")
-    @patch("services.mon_service.get_best_server")
-    def test_admin_basic_auto_assignment_excludes_project_node(
-        self, mock_best_server, mock_settings, db, admin_user
-    ):
+    def test_create_vm_without_node_name_returns_400(self, db, admin_user):
         from fastapi import HTTPException
 
-        mock_settings.PROJECT_NODE_NAME = "project-node"
-        mock_best_server.side_effect = HTTPException(status_code=418, detail="stop")
-
-        with pytest.raises(HTTPException):
+        with pytest.raises(HTTPException) as exc_info:
             create_vm(db, admin_user, VMTier.MICRO)
 
-        assert mock_best_server.call_args.kwargs["excluded_nodes"] == {"project-node"}
-
-    @patch("services.vm_service.settings")
-    @patch("services.mon_service.get_best_server")
-    def test_admin_project_custom_auto_assignment_uses_project_node(
-        self, mock_best_server, mock_settings, db, admin_user
-    ):
-        from fastapi import HTTPException
-
-        mock_settings.PROJECT_NODE_NAME = "project-node"
-        mock_best_server.side_effect = HTTPException(status_code=418, detail="stop")
-
-        with pytest.raises(HTTPException):
-            create_vm(db, admin_user, VMTier.PROJECT_CUSTOM)
-
-        assert mock_best_server.call_args.kwargs["allowed_nodes"] == {"project-node"}
+        assert exc_info.value.status_code == 400
 
 
 class TestSnapshotCreation:


### PR DESCRIPTION
## Summary

- **노드 자동배정 dead code 제거**: `node_name` 없이 요청 시 400 반환 (프론트에서 항상 `node_name` 전송하므로 auto-assign 분기 불필요)
- **비밀번호 `$` 제거**: `_generate_password()` 특수문자 풀 `!@#$%&*` → `!@#%&*` (cloud-init 환경변수 파싱 오류 방지)
- **자원 80% 차단**: VM 생성 전 Proxmox 실시간 조회 → CPU·RAM·SSD(lvmthin 합산) 중 하나라도 80% 이상이면 507 반환, 에러 메시지에 초과 항목 명시
- `mon_service`에 `get_server_resource_usage()` 신규 함수 추가 (DB 컬럼 추가 없이 실시간 조회)

## Test plan

- [ ] `node_name` 없이 VM 생성 요청 → 400 반환 확인
- [ ] 생성된 VM 비밀번호에 `$` 없음 확인
- [ ] 테스트 서버 자원 80% 이상 시뮬레이션 → 507 반환 및 메시지 확인 (`RAM 92.0%` 등)
- [ ] Proxmox 조회 실패 시 체크 건너뛰고 정상 생성되는지 확인 (fallback 로그 출력)

🤖 Generated with [Claude Code](https://claude.com/claude-code)