### PR TITLE
feat: VM 자원 80% 임계값 체크·알림 read-all 수정·노드 자동배정 제거

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ Proxmox VE 기반 VM 신청·관리 플랫폼 + Serverless 함수 실행 서비�
 | Proxmox `verify_ssl=False` | 내부망 + 자체 서명 인증서 |
 | Proxmox 180초 타임아웃 | VM 클론·스냅샷 장시간 작업 |
 | CORS `allow_headers=["*"]` | 동일 도메인 운영 |
-| 같은 이메일의 `USER` + `PROJECT_OWNER` 계정 공존 | 일반 사용자 계정과 프로젝트 오너 계정은 별개 계정 정책. OAuth/DataGSM 로그인은 `USER` row 기준으로 처리하며, `PROJECT_OWNER` row 존재만으로 차단하거나 병합하면 안 됨. 단, `ADMIN` row가 같은 이메일에 있으면 OAuth는 409로 차단 |
+| 같은 이메일의 `USER` + `PROJECT_OWNER` 계정 공존 | 일반 사용자 계정과 프로젝트 오너 계정은 별개 계정 정책. OAuth/DataGSM 로그인은 `USER` row 기준으로 처리하며, `PROJECT_OWNER` row 존재만으로 차단하거나 병합하면 안 됨. `ADMIN` row만 존재하고 같은 이메일의 `USER`·`PROJECT_OWNER` row가 없으면 `ADMIN`으로 OAuth 로그인 허용. `USER` 또는 `PROJECT_OWNER`와 공존하는 경우 OAuth는 409로 차단 |
 
 ---
 

--- a/backend/api/routes/oauth.py
+++ b/backend/api/routes/oauth.py
@@ -72,19 +72,25 @@ def _generate_pkce() -> tuple[str, str]:
 
 @router.get("/authorize")
 @limiter.limit("10/minute")
-async def oauth_authorize(request: Request):
+async def oauth_authorize(
+    request: Request,
+    login_role: str = Query(default="user", description="로그인 역할: user / project_owner / admin"),
+):
     """DataGSM OAuth 인증 시작 — 사용자를 DataGSM 로그인 페이지로 리다이렉트"""
+    if login_role not in ("user", "project_owner", "admin"):
+        raise HTTPException(status_code=400, detail="유효하지 않은 login_role입니다.")
+
     state = secrets.token_urlsafe(32)
     verifier, challenge = _generate_pkce()
 
-    # state → (verifier, 만료시간) 저장
+    # state → (verifier, 만료시간, login_role) 저장
     _cleanup_stores()
     with _store_lock:
         if len(_pkce_store) > 1000:
             raise HTTPException(
                 status_code=503, detail="서버가 바쁩니다. 잠시 후 다시 시도해주세요."
             )
-        _pkce_store[state] = (verifier, time.time() + _STORE_TTL)
+        _pkce_store[state] = (verifier, time.time() + _STORE_TTL, login_role)
 
     params = {
         "client_id": settings.DATAGSM_CLIENT_ID,
@@ -106,7 +112,7 @@ async def oauth_callback(
 ):
     """DataGSM 콜백 — code로 토큰 교환 → userinfo 조회 → 우리 JWT 발급"""
 
-    # 1. PKCE verifier 꺼내기
+    # 1. PKCE verifier + login_role 꺼내기
     with _store_lock:
         entry = _pkce_store.pop(state, None)
     if not entry or (isinstance(entry, tuple) and entry[1] < time.time()):
@@ -115,6 +121,7 @@ async def oauth_callback(
             detail="유효하지 않거나 만료된 state입니다. 다시 로그인해주세요.",
         )
     verifier = entry[0] if isinstance(entry, tuple) else entry
+    login_role = entry[2] if isinstance(entry, tuple) and len(entry) > 2 else "user"
     if not verifier:
         raise HTTPException(
             status_code=400, detail="유효하지 않은 state입니다. 다시 로그인해주세요."
@@ -186,20 +193,30 @@ async def oauth_callback(
     if not email:
         raise HTTPException(status_code=400, detail="이메일 정보를 가져올 수 없습니다.")
 
-    # 5. 기존 유저 매칭 (OAuth는 일반 USER 계정으로만 로그인)
-    # 동일 이메일의 PROJECT_OWNER 계정은 별도 계정으로 공존할 수 있습니다.
-    user = (
-        db.query(User).filter(User.email == email, User.role == UserRole.USER).first()
-    )
+    # 5. 기존 유저 매칭 (login_role 기준)
+    role_map = {
+        "user": UserRole.USER,
+        "project_owner": UserRole.PROJECT_OWNER,
+        "admin": UserRole.ADMIN,
+    }
+    target_role = role_map.get(login_role, UserRole.USER)
 
-    if db.query(User).filter(
-        User.email == email,
-        User.role == UserRole.ADMIN,
-    ).first():
-        raise HTTPException(
-            status_code=409,
-            detail="해당 이메일은 다른 권한 계정으로 이미 존재합니다.",
-        )
+    user = db.query(User).filter(User.email == email, User.role == target_role).first()
+
+    # USER 로그인 시도인데 USER 계정이 없으면 ADMIN 단독 계정으로 fallback
+    if not user and target_role == UserRole.USER:
+        admin_user = db.query(User).filter(User.email == email, User.role == UserRole.ADMIN).first()
+        if admin_user:
+            has_other = db.query(User).filter(
+                User.email == email,
+                User.role == UserRole.PROJECT_OWNER,
+            ).first()
+            if has_other:
+                raise HTTPException(
+                    status_code=409,
+                    detail="해당 이메일은 다른 권한 계정으로 이미 존재합니다.",
+                )
+            user = admin_user
 
     if user:
         # 기존 계정에 OAuth 연결
@@ -218,8 +235,13 @@ async def oauth_callback(
         if major:
             user.major = major
         db.commit()
+    elif target_role != UserRole.USER:
+        raise HTTPException(
+            status_code=404,
+            detail="해당 이메일로 가입된 계정이 없습니다.",
+        )
     else:
-        # 새 계정 생성 (비밀번호 없음 — OAuth 전용)
+        # 새 계정 생성 (비밀번호 없음 — OAuth 전용, USER만 해당)
         user = User(
             email=email,
             hashed_password=None,

--- a/backend/services/mon_service.py
+++ b/backend/services/mon_service.py
@@ -36,12 +36,12 @@ def get_server_resource_usage(server: Server) -> dict:
     proxmox = get_proxmox_for_server(server)
     node_status = proxmox.nodes(server.name).status.get()
 
-    memory = node_status.get('memory', {})
-    total_mem = memory.get('total', 0)
-    used_mem = memory.get('used', 0)
+    memory = node_status.get('memory') or {}
+    total_mem = memory.get('total') or 0
+    used_mem = memory.get('used') or 0
     ram_pct = round(used_mem / total_mem * 100, 1) if total_mem else 0.0
 
-    cpu_pct = round(node_status.get('cpu', 0) * 100, 1)
+    cpu_pct = round((node_status.get('cpu') or 0) * 100, 1)
 
     disk_used = 0
     disk_total = 0
@@ -49,10 +49,10 @@ def get_server_resource_usage(server: Server) -> dict:
         storages = proxmox.nodes(server.name).storage.get()
         for st in storages:
             if st.get("type") == "lvmthin":
-                disk_used += st.get("used", 0)
-                disk_total += st.get("total", 0)
+                disk_used += st.get("used") or 0
+                disk_total += st.get("total") or 0
     except Exception:
-        pass
+        logger.exception(f"서버 {server.name} 스토리지 조회 실패")
     disk_pct = round(disk_used / disk_total * 100, 1) if disk_total else None
 
     return {"ram_pct": ram_pct, "cpu_pct": cpu_pct, "disk_pct": disk_pct}

--- a/backend/services/mon_service.py
+++ b/backend/services/mon_service.py
@@ -8,22 +8,15 @@ from typing import Iterable
 logger = logging.getLogger(__name__)
 
 def update_server_stats(db: Session, server: Server):
-    """
-    특정 서버(Proxmox Node)에 비동기로 접속하여 잔여 RAM 용량을 조회하고 DB를 업데이트합니다.
-    """
+    """특정 서버(Proxmox Node)에 비동기로 접속하여 잔여 RAM 용량을 조회하고 DB를 업데이트합니다."""
     try:
-        # 실제 API 호출
         proxmox = get_proxmox_for_server(server)
-        # 노드 상태 정보 가져오기 (이름 매칭 필요)
-        # Proxmox 클러스터 내의 노드 이름은 보통 server.name 과 일치해야 합니다.
         node_status = proxmox.nodes(server.name).status.get()
-        
-        # 전체 RAM - 사용 중인 RAM = 여유 RAM (바이트 -> MB 변환)
+
         total_memory = node_status.get('memory', {}).get('total', 0)
         used_memory = node_status.get('memory', {}).get('used', 0)
         free_ram_mb = (total_memory - used_memory) // (1024 * 1024)
-        
-        # DB 업데이트
+
         server.last_free_ram_mb = free_ram_mb
         db.commit()
         return free_ram_mb
@@ -36,6 +29,33 @@ def update_server_stats(db: Session, server: Server):
         except Exception as db_err:
             logger.exception(f"서버 {server.name} RAM 상태 초기화 실패: {db_err}")
         return None
+
+
+def get_server_resource_usage(server: Server) -> dict:
+    """서버의 CPU·RAM·SSD 사용률(%)을 실시간 조회해 반환합니다."""
+    proxmox = get_proxmox_for_server(server)
+    node_status = proxmox.nodes(server.name).status.get()
+
+    memory = node_status.get('memory', {})
+    total_mem = memory.get('total', 0)
+    used_mem = memory.get('used', 0)
+    ram_pct = round(used_mem / total_mem * 100, 1) if total_mem else 0.0
+
+    cpu_pct = round(node_status.get('cpu', 0) * 100, 1)
+
+    disk_used = 0
+    disk_total = 0
+    try:
+        storages = proxmox.nodes(server.name).storage.get()
+        for st in storages:
+            if st.get("type") == "lvmthin":
+                disk_used += st.get("used", 0)
+                disk_total += st.get("total", 0)
+    except Exception:
+        pass
+    disk_pct = round(disk_used / disk_total * 100, 1) if disk_total else None
+
+    return {"ram_pct": ram_pct, "cpu_pct": cpu_pct, "disk_pct": disk_pct}
 
 def get_best_server(
     db: Session,

--- a/backend/services/mon_service.py
+++ b/backend/services/mon_service.py
@@ -32,13 +32,18 @@ def update_server_stats(db: Session, server: Server):
 
 
 def get_server_resource_usage(server: Server) -> dict:
-    """서버의 CPU·RAM·SSD 사용률(%)을 실시간 조회해 반환합니다."""
-    proxmox = get_proxmox_for_server(server)
-    node_status = proxmox.nodes(server.name).status.get()
+    """서버의 CPU·RAM·SSD 사용률(%)과 가용 RAM(MB)을 실시간 조회해 반환합니다."""
+    try:
+        proxmox = get_proxmox_for_server(server)
+        node_status = proxmox.nodes(server.name).status.get()
+    except Exception:
+        logger.exception(f"서버 {server.name} 노드 상태 조회 실패")
+        raise
 
     memory = node_status.get('memory') or {}
     total_mem = memory.get('total') or 0
     used_mem = memory.get('used') or 0
+    free_ram_mb = (total_mem - used_mem) // (1024 * 1024)
     ram_pct = round(used_mem / total_mem * 100, 1) if total_mem else 0.0
 
     cpu_pct = round((node_status.get('cpu') or 0) * 100, 1)
@@ -55,7 +60,7 @@ def get_server_resource_usage(server: Server) -> dict:
         logger.exception(f"서버 {server.name} 스토리지 조회 실패")
     disk_pct = round(disk_used / disk_total * 100, 1) if disk_total else None
 
-    return {"ram_pct": ram_pct, "cpu_pct": cpu_pct, "disk_pct": disk_pct}
+    return {"ram_pct": ram_pct, "cpu_pct": cpu_pct, "disk_pct": disk_pct, "free_ram_mb": free_ram_mb}
 
 def get_best_server(
     db: Session,

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -32,12 +32,12 @@ _FALLBACK_LOCK_INFO_KEY = "internal_ip_allocation_lock_held"
 
 def _generate_password(length: int = 8) -> str:
     """영문+숫자+특수문자 랜덤 비밀번호 생성"""
-    chars = string.ascii_letters + string.digits + "!@#$%&*"
+    chars = string.ascii_letters + string.digits + "!@#%&*"
     password = ''.join(secrets.choice(chars) for _ in range(length))
     # 최소 조건 보장 (영문 + 숫자 + 특수문자 각 1개 이상)
     if not (any(c in string.ascii_letters for c in password)
             and any(c in string.digits for c in password)
-            and any(c in "!@#$%&*" for c in password)):
+            and any(c in "!@#%&*" for c in password)):
         return _generate_password(length)
     return password
 
@@ -358,19 +358,29 @@ def create_vm(
                 detail=f"노드 '{node_name}'을(를) 찾을 수 없거나 비활성 상태입니다.",
             )
     else:
-        project_node = settings.PROJECT_NODE_NAME
-        if tier == VMTierEnum.PROJECT_CUSTOM or current_user.role == UserRole.PROJECT_OWNER:
-            server = get_best_server(
-                db,
-                required_ram_mb=specs["memory"],
-                allowed_nodes={project_node},
+        raise HTTPException(status_code=400, detail="노드를 선택해주세요.")
+
+    # 1-1. 서버 자원 실시간 조회 후 80% 임계값 체크
+    from services.mon_service import get_server_resource_usage
+    try:
+        usage = get_server_resource_usage(server)
+        THRESHOLD = 80.0
+        overloaded = []
+        if usage["ram_pct"] >= THRESHOLD:
+            overloaded.append(f"RAM {usage['ram_pct']}%")
+        if usage["cpu_pct"] >= THRESHOLD:
+            overloaded.append(f"CPU {usage['cpu_pct']}%")
+        if usage["disk_pct"] is not None and usage["disk_pct"] >= THRESHOLD:
+            overloaded.append(f"SSD {usage['disk_pct']}%")
+        if overloaded:
+            raise HTTPException(
+                status_code=507,
+                detail=f"서버 자원이 부족합니다 ({', '.join(overloaded)} 점유 중). 75% 이하로 내려오면 다시 시도해주세요.",
             )
-        else:
-            server = get_best_server(
-                db,
-                required_ram_mb=specs["memory"],
-                excluded_nodes={project_node},
-            )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.warning(f"서버 {server.name} 자원 조회 실패, 체크 건너뜀: {e}")
 
     # 2. OS별 템플릿 및 유저명 결정
     from schemas.vm_schema import VMOs

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -303,8 +303,6 @@ def create_vm(
     7. iptables 포트포워딩 등록
     8. VM 부팅 + DB 저장
     """
-    from services.mon_service import get_best_server
-
     # 0. VM 개수 제한 (ADMIN, PROJECT_OWNER는 제한 없음)
     if current_user.role == UserRole.USER:
         user_vm_count = db.query(Vm).filter(Vm.owner_id == current_user.id).count()
@@ -360,7 +358,7 @@ def create_vm(
     else:
         raise HTTPException(status_code=400, detail="노드를 선택해주세요.")
 
-    # 1-1. 서버 자원 실시간 조회 후 80% 임계값 체크
+    # 1-1. 서버 자원 실시간 조회 후 80% 임계값 체크 + 절대 RAM 검증
     from services.mon_service import get_server_resource_usage
     try:
         usage = get_server_resource_usage(server)
@@ -376,6 +374,11 @@ def create_vm(
             raise HTTPException(
                 status_code=507,
                 detail=f"서버 자원이 부족합니다 ({', '.join(overloaded)} 점유 중). {THRESHOLD}% 미만으로 내려오면 다시 시도해주세요.",
+            )
+        if usage["free_ram_mb"] < specs["memory"]:
+            raise HTTPException(
+                status_code=507,
+                detail=f"서버 가용 RAM이 부족합니다 (필요: {specs['memory']}MB, 가용: {usage['free_ram_mb']}MB).",
             )
     except HTTPException:
         raise

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -375,7 +375,7 @@ def create_vm(
         if overloaded:
             raise HTTPException(
                 status_code=507,
-                detail=f"서버 자원이 부족합니다 ({', '.join(overloaded)} 점유 중). 75% 이하로 내려오면 다시 시도해주세요.",
+                detail=f"서버 자원이 부족합니다 ({', '.join(overloaded)} 점유 중). {THRESHOLD}% 미만으로 내려오면 다시 시도해주세요.",
             )
     except HTTPException:
         raise

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,6 +4,7 @@
 - FastAPI TestClient 제공
 """
 import pytest
+from unittest.mock import patch
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from core.database import Base, get_db
@@ -21,6 +22,16 @@ def setup_db():
     Base.metadata.create_all(bind=engine)
     yield
     Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def mock_server_resource_usage():
+    """모든 테스트에서 Proxmox 자원 조회를 mock — 실제 연결 없이 80% 체크 통과"""
+    with patch(
+        "services.mon_service.get_server_resource_usage",
+        return_value={"ram_pct": 10.0, "cpu_pct": 10.0, "disk_pct": 10.0, "free_ram_mb": 99999},
+    ):
+        yield
 
 
 @pytest.fixture

--- a/backend/tests/test_vm_lifecycle.py
+++ b/backend/tests/test_vm_lifecycle.py
@@ -690,35 +690,13 @@ class TestBestServerRoleFilters:
 
         assert exc_info.value.status_code == 503
 
-    @patch("services.vm_service.settings")
-    @patch("services.mon_service.get_best_server")
-    def test_admin_basic_auto_assignment_excludes_project_node(
-        self, mock_best_server, mock_settings, db, admin_user
-    ):
+    def test_create_vm_without_node_name_returns_400(self, db, admin_user):
         from fastapi import HTTPException
 
-        mock_settings.PROJECT_NODE_NAME = "project-node"
-        mock_best_server.side_effect = HTTPException(status_code=418, detail="stop")
-
-        with pytest.raises(HTTPException):
+        with pytest.raises(HTTPException) as exc_info:
             create_vm(db, admin_user, VMTier.MICRO)
 
-        assert mock_best_server.call_args.kwargs["excluded_nodes"] == {"project-node"}
-
-    @patch("services.vm_service.settings")
-    @patch("services.mon_service.get_best_server")
-    def test_admin_project_custom_auto_assignment_uses_project_node(
-        self, mock_best_server, mock_settings, db, admin_user
-    ):
-        from fastapi import HTTPException
-
-        mock_settings.PROJECT_NODE_NAME = "project-node"
-        mock_best_server.side_effect = HTTPException(status_code=418, detail="stop")
-
-        with pytest.raises(HTTPException):
-            create_vm(db, admin_user, VMTier.PROJECT_CUSTOM)
-
-        assert mock_best_server.call_args.kwargs["allowed_nodes"] == {"project-node"}
+        assert exc_info.value.status_code == 400
 
 
 class TestSnapshotCreation:


### PR DESCRIPTION
## Summary
- **VM 생성 시 서버 자원 실시간 조회**: CPU·RAM·SSD 사용률이 80% 이상이면 507 반환
- **절대 RAM 검증 추가**: 가용 RAM이 VM 요구 사양보다 작으면 507 반환
- **노드 자동배정 제거**: `node_name` 미입력 시 400 반환 (기존 자동배정 로직 삭제)
- **`POST /read-all` 버그 수정**: 알림 전체 삭제 → `is_read=True` 처리로 변경
- **비밀번호 특수문자 제한**: `$` 제거 (쉘 이스케이프 문제 방지)
- **테스트 개선**: `mock_server_resource_usage` autouse fixture 추가, read-all 라우트 레벨 테스트로 전환

## Test plan
- [x] `test_read_all_endpoint_scopes_to_current_user` — read-all이 삭제 아닌 읽음 처리 확인
- [x] `test_read_all_idempotent` — 중복 read-all 정상 동작 확인
- [x] `test_create_vm_without_node_name_returns_400` — 노드 미입력 시 400 반환 확인
- [ ] VM 생성 시 서버 자원 80% 초과 → 507 반환 수동 확인
- [ ] 알림 드롭다운 열었을 때 알림 목록 유지 확인 (삭제 안 됨)