### PR TITLE
fix: OAuth 전용 계정 로그인·비번재설정 시도에 안내 메시지 추가

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -600,15 +600,21 @@ async def login(
     if not user and login_role == "user":
         user = _find_user_by_email_role(db, form_data.username, UserRole.ADMIN)
 
-    if not user or not verify_password(
-        form_data.password, user.hashed_password or ""
-    ):
-        if user and not user.hashed_password:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="DataGSM OAuth로 로그인해주세요.",
-                headers={"WWW-Authenticate": "Bearer"},
-            )
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="이메일 또는 비밀번호가 일치하지 않습니다.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    if not user.hashed_password:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="DataGSM OAuth로 로그인해주세요.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    if not verify_password(form_data.password, user.hashed_password):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="이메일 또는 비밀번호가 일치하지 않습니다.",
@@ -751,7 +757,7 @@ async def request_password_reset(
     if not user.hashed_password:
         await _pad_password_reset_response(started_at)
         raise HTTPException(
-            status_code=400, detail="DataGSM OAuth로 등록된 계정입니다."
+            status_code=status.HTTP_400_BAD_REQUEST, detail="DataGSM OAuth로 등록된 계정입니다."
         )
 
     try:

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -600,11 +600,15 @@ async def login(
     if not user and login_role == "user":
         user = _find_user_by_email_role(db, form_data.username, UserRole.ADMIN)
 
-    if (
-        not user
-        or not user.hashed_password
-        or not verify_password(form_data.password, user.hashed_password)
+    if not user or not verify_password(
+        form_data.password, user.hashed_password or ""
     ):
+        if user and not user.hashed_password:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="DataGSM OAuth로 로그인해주세요.",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="이메일 또는 비밀번호가 일치하지 않습니다.",
@@ -746,7 +750,9 @@ async def request_password_reset(
 
     if not user.hashed_password:
         await _pad_password_reset_response(started_at)
-        return _password_reset_request_response(body.email)
+        raise HTTPException(
+            status_code=400, detail="DataGSM OAuth로 등록된 계정입니다."
+        )
 
     try:
         sr = _reset_signup_role(body.login_role)

--- a/backend/tests/test_change_password.py
+++ b/backend/tests/test_change_password.py
@@ -391,8 +391,8 @@ class TestChangePassword:
         )
         assert len(recs) == 0, "PO 계정이 없으므로 레코드도 생성되지 않아야 함"
 
-    def test_password_reset_request_oauth_user_silently_succeeds_without_record(self, client, db):
-        """OAuth 계정은 비밀번호 재설정 레코드와 메일 발송 없이 같은 성공 응답을 반환한다."""
+    def test_password_reset_request_oauth_user_returns_oauth_guidance(self, client, db):
+        """OAuth 계정은 재설정 레코드·메일 발송 없이 OAuth 안내 메시지를 반환한다."""
         from models.email_verification import EmailVerification
         from unittest.mock import patch
 
@@ -405,8 +405,8 @@ class TestChangePassword:
                 json={"email": "oauth-reset@gsm.hs.kr", "login_role": "user"},
             )
 
-        assert res.status_code == 200, res.text
-        assert res.json()["email"] == "oauth-reset@gsm.hs.kr"
+        assert res.status_code == 400, res.text
+        assert "OAuth" in res.json()["detail"]
         mock_send.assert_not_called()
         records = (
             db.query(EmailVerification)
@@ -475,6 +475,17 @@ class TestChangePassword:
             data={"username": "login@gsm.hs.kr", "password": "OldPass1!"},
         )
         assert old_login.status_code == 401
+
+    def test_login_oauth_user_returns_oauth_guidance(self, client, db):
+        """OAuth 계정(hashed_password 없음)으로 자체 로그인 시도 시 OAuth 안내 메시지를 반환한다."""
+        _make_user(db, email="oauth-login@gsm.hs.kr", oauth=True)
+
+        res = client.post(
+            "/api/v1/auth/login",
+            data={"username": "oauth-login@gsm.hs.kr", "password": "anything"},
+        )
+        assert res.status_code == 401
+        assert "OAuth" in res.json()["detail"]
 
     def test_admin_password_reset_request_creates_record(self, client, db):
         """ADMIN 계정은 user 탭(login_role=user)으로 재설정 요청 시 레코드가 생성된다."""


### PR DESCRIPTION
## Summary
- `DataGSM OAuth`로만 생성된 계정(`hashed_password` 없음)이 자체 로그인을 시도하면 일반 비번불일치와 동일한 `401`만 떠서 원인 파악이 안 됐던 문제 수정
- 로그인: `401` + `"DataGSM OAuth로 로그인해주세요."`
- 비밀번호 재설정 요청: `400` + `"DataGSM OAuth로 등록된 계정입니다."`
- 임시 조치 — 기존에 비번 미존재 이메일 응답을 "존재하지 않는 이메일"과 동일하게 묻어주던 보안 설계와 다르게, 이번 변경으로 **계정 존재 + OAuth 전용 여부가 노출됨**(이메일 enumeration 트레이드오프 인지하고 진행). 추후 OAuth ↔ 자체 로그인 계정 통합(같은 row에 비번 설정 가능하게) 별도 작업 예정

## Test plan
- [x] `backend/tests/test_change_password.py` 21개 전부 통과 (`test_login_oauth_user_returns_oauth_guidance`, `test_password_reset_request_oauth_user_returns_oauth_guidance` 신규 추가)