### PR TITLE
feat: Discord 웹훅 일일 모니터링 요약 발송 기능 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,3 +71,7 @@ DB_PASSWORD=
 # ── 서버리스 서비스 ───────────────────────────────────────────────
 SERVERLESS_SERVICE_URL=http://serverless:3001
 MAX_FUNCTIONS_PER_USER=5
+
+# ── Discord 모니터링 알림 ─────────────────────────────────────────
+DISCORD_WEBHOOK_URL=
+DISCORD_DAILY_HOUR=9

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -59,6 +59,10 @@ class Settings(BaseSettings):
     # 프로젝트 오너 전용 설정
     PROJECT_NODE_NAME: str = "gsmgpu3"            # 프로젝트 VM 전용 노드
 
+    # Discord 모니터링 알림
+    DISCORD_WEBHOOK_URL: str = ""
+    DISCORD_DAILY_HOUR: int = 9
+
     # 내부 네트워크 (단일 서브넷)
     INTERNAL_SUBNET: str = "10.0.0"                  # /24 서브넷 프리픽스
     INTERNAL_IP_START: int = 100                     # 할당 시작 (.100)

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,4 +1,5 @@
 import sys
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import List
 
@@ -61,7 +62,7 @@ class Settings(BaseSettings):
 
     # Discord 모니터링 알림
     DISCORD_WEBHOOK_URL: str = ""
-    DISCORD_DAILY_HOUR: int = 9
+    DISCORD_DAILY_HOUR: int = Field(default=9, ge=0, le=23)
 
     # 내부 네트워크 (단일 서브넷)
     INTERNAL_SUBNET: str = "10.0.0"                  # /24 서브넷 프리픽스

--- a/backend/main.py
+++ b/backend/main.py
@@ -508,7 +508,7 @@ async def _oauth_store_cleanup_loop():
 def _collect_discord_daily_report(db, now) -> dict:
     """활성 노드 사용률 + 7일 이내 만료 VM 목록을 수집."""
     nodes = []
-    for server in db.query(Server).filter(Server.is_active == True).all():
+    for server in db.query(Server).filter(Server.is_active.is_(True)).all():
         try:
             usage = get_server_resource_usage(server)
             nodes.append({
@@ -530,6 +530,7 @@ def _collect_discord_daily_report(db, now) -> dict:
 
     soon_vms = (
         db.query(Vm)
+        .options(joinedload(Vm.owner))
         .filter(
             Vm.expires_at.isnot(None),
             Vm.expires_at > now,
@@ -542,7 +543,7 @@ def _collect_discord_daily_report(db, now) -> dict:
         {
             "name": vm.name,
             "owner_email": vm.owner.email if vm.owner else "(소유자 없음)",
-            "days_left": (vm.expires_at - now.replace(tzinfo=None)).days,
+            "days_left": (vm.expires_at - (now.replace(tzinfo=None) if vm.expires_at.tzinfo is None else now)).days,
             "expires_at": vm.expires_at,
         }
         for vm in soon_vms
@@ -604,6 +605,7 @@ async def _discord_daily_loop():
             await _send_discord_message(message)
             logger.info("[discord-daily] 일일 모니터링 리포트 발송 완료")
             consecutive_failures = 0
+            await asyncio.sleep(60)
         except Exception as e:
             if db:
                 db.rollback()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import httpx
 import os
 from contextlib import asynccontextmanager
 from datetime import timedelta
@@ -30,6 +31,8 @@ from core.init_servers import sync_servers
 from models.vm import Vm
 from models.notification import Notification
 from models.user import User, UserRole
+from models.server import Server
+from services.mon_service import get_server_resource_usage
 from models.faq_question import FaqQuestion  # noqa: F401 — create_all 자동 반영
 from models.vm_port import VmPort  # noqa: F401 — create_all 자동 반영
 
@@ -502,6 +505,133 @@ async def _oauth_store_cleanup_loop():
         await asyncio.sleep(BACKGROUND_FAST_RETRY_SECONDS)  # 5분마다
 
 
+def _collect_discord_daily_report(db, now) -> dict:
+    """활성 노드 사용률 + 7일 이내 만료 VM 목록을 수집."""
+    nodes = []
+    for server in db.query(Server).filter(Server.is_active == True).all():
+        try:
+            usage = get_server_resource_usage(server)
+            nodes.append({
+                "name": server.name,
+                "cpu_pct": usage["cpu_pct"],
+                "ram_pct": usage["ram_pct"],
+                "disk_pct": usage["disk_pct"],
+                "ok": usage["cpu_pct"] < 90 and usage["ram_pct"] < 90,
+            })
+        except Exception:
+            logger.exception(f"[discord-daily] 노드 {server.name} 상태 조회 실패")
+            nodes.append({
+                "name": server.name,
+                "cpu_pct": None,
+                "ram_pct": None,
+                "disk_pct": None,
+                "ok": False,
+            })
+
+    soon_vms = (
+        db.query(Vm)
+        .filter(
+            Vm.expires_at.isnot(None),
+            Vm.expires_at > now,
+            Vm.expires_at <= now + timedelta(days=7),
+        )
+        .order_by(Vm.expires_at.asc())
+        .all()
+    )
+    vms = [
+        {
+            "name": vm.name,
+            "owner_email": vm.owner.email if vm.owner else "(소유자 없음)",
+            "days_left": (vm.expires_at - now.replace(tzinfo=None)).days,
+            "expires_at": vm.expires_at,
+        }
+        for vm in soon_vms
+    ]
+
+    return {"nodes": nodes, "vms": vms}
+
+
+def _format_discord_daily_message(report: dict, now) -> str:
+    """일일 리포트 데이터를 Discord 메시지 텍스트로 변환."""
+    lines = [f"🖥️ GSM-SV 일일 모니터링 리포트 — {now.strftime('%Y-%m-%d %H:%M')}", "", "[노드 상태]"]
+
+    for node in report["nodes"]:
+        if node["cpu_pct"] is None:
+            lines.append(f"{node['name']}  조회 실패  🔴")
+            continue
+        icon = "✅" if node["ok"] else "⚠️"
+        disk = f"{node['disk_pct']}%" if node["disk_pct"] is not None else "N/A"
+        lines.append(
+            f"{node['name']}  CPU {node['cpu_pct']}%  RAM {node['ram_pct']}%  Disk {disk}  {icon}"
+        )
+
+    if report["vms"]:
+        lines.append("")
+        lines.append("[만료 예정 VM]")
+        for vm in report["vms"]:
+            lines.append(
+                f"{vm['name']}  {vm['owner_email']}  D-{vm['days_left']}  ({vm['expires_at'].strftime('%Y-%m-%d')})"
+            )
+
+    return "\n".join(lines)
+
+
+async def _send_discord_message(content: str) -> None:
+    """Discord 웹훅으로 메시지 발송. URL 미설정 시 스킵."""
+    if not settings.DISCORD_WEBHOOK_URL:
+        logger.warning("[discord-daily] DISCORD_WEBHOOK_URL 미설정 — 발송 스킵")
+        return
+    async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
+        response = await client.post(settings.DISCORD_WEBHOOK_URL, json={"content": content})
+        response.raise_for_status()
+
+
+async def _discord_daily_loop():
+    """매일 KST DISCORD_DAILY_HOUR시, 노드 상태 + 만료 예정 VM Discord 요약 발송."""
+    consecutive_failures = 0
+    while True:
+        db = None
+        try:
+            if consecutive_failures == 0:
+                now = now_kst()
+                wait = _next_notify_sleep_seconds(now, [settings.DISCORD_DAILY_HOUR])
+                await asyncio.sleep(wait)
+
+            db = SessionLocal()
+            now = now_kst()
+            report = _collect_discord_daily_report(db, now)
+            message = _format_discord_daily_message(report, now)
+            await _send_discord_message(message)
+            logger.info("[discord-daily] 일일 모니터링 리포트 발송 완료")
+            consecutive_failures = 0
+        except Exception as e:
+            if db:
+                db.rollback()
+            consecutive_failures += 1
+            logger.exception(
+                f"[discord-daily] 백그라운드 태스크 오류 ({consecutive_failures}회 연속): {e}"
+            )
+            if consecutive_failures >= BACKGROUND_FAILURE_NOTIFY_THRESHOLD:
+                logger.critical(
+                    f"[discord-daily] 연속 {consecutive_failures}회 실패 — 점검 필요"
+                )
+            if consecutive_failures == BACKGROUND_FAILURE_NOTIFY_THRESHOLD:
+                try:
+                    await asyncio.to_thread(
+                        _notify_admins_background_failure,
+                        "discord-daily",
+                        consecutive_failures,
+                    )
+                except Exception as notify_err:
+                    logger.exception(f"[discord-daily] 관리자 알림 발송 실패: {notify_err}")
+        finally:
+            if db:
+                db.close()
+
+        if consecutive_failures > 0:
+            await asyncio.sleep(BACKGROUND_FAST_RETRY_SECONDS)
+
+
 async def _admin_expiry_notify_loop():
     """KST 06:00·12:00·18:00·00:00 마다 7일 이내 만료 VM 어드민 알림."""
     consecutive_failures = 0
@@ -568,6 +698,8 @@ async def lifespan(app: FastAPI):
     oauth_cleanup_task = asyncio.create_task(_oauth_store_cleanup_loop())
     # 어드민 VM 만료 임박 알림 (KST 06/12/18/00시)
     expiry_notify_task = asyncio.create_task(_admin_expiry_notify_loop())
+    # Discord 일일 모니터링 리포트 (KST DISCORD_DAILY_HOUR시)
+    discord_daily_task = asyncio.create_task(_discord_daily_loop())
 
     yield
     # ── 종료 시 ──
@@ -576,6 +708,7 @@ async def lifespan(app: FastAPI):
     snapshot_task.cancel()
     oauth_cleanup_task.cancel()
     expiry_notify_task.cancel()
+    discord_daily_task.cancel()
     await serverless._http_client.aclose()
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -600,7 +600,7 @@ async def _discord_daily_loop():
 
             db = SessionLocal()
             now = now_kst()
-            report = _collect_discord_daily_report(db, now)
+            report = await asyncio.to_thread(_collect_discord_daily_report, db, now)
             message = _format_discord_daily_message(report, now)
             await _send_discord_message(message)
             logger.info("[discord-daily] 일일 모니터링 리포트 발송 완료")

--- a/backend/main.py
+++ b/backend/main.py
@@ -570,8 +570,9 @@ def _format_discord_daily_message(report: dict, now) -> str:
         lines.append("")
         lines.append("[만료 예정 VM]")
         for vm in report["vms"]:
+            name = vm["name"] if len(vm["name"]) <= 40 else vm["name"][:37] + "..."
             lines.append(
-                f"{vm['name']}  {vm['owner_email']}  D-{vm['days_left']}  ({vm['expires_at'].strftime('%Y-%m-%d')})"
+                f"{name}  {vm['owner_email']}  D-{vm['days_left']}  ({vm['expires_at'].strftime('%Y-%m-%d')})"
             )
 
     return "\n".join(lines)

--- a/backend/tests/test_discord_daily_report.py
+++ b/backend/tests/test_discord_daily_report.py
@@ -1,0 +1,273 @@
+"""_collect_discord_daily_report / _format_discord_daily_message 단위 테스트."""
+
+import pytest
+from datetime import timedelta
+from unittest.mock import patch
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from core.database import Base
+from core.security import get_password_hash
+from core.timezone import now_kst
+from models.server import Server
+from models.user import User, UserRole
+from models.vm import Vm
+
+TEST_DB_URL = "sqlite:///./test_discord_daily_report.db"
+engine = create_engine(TEST_DB_URL, connect_args={"check_same_thread": False})
+TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def db():
+    s = TestSession()
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+def _make_server(db, name="gsmgpu1"):
+    server = Server(
+        name=name,
+        ip_address="10.0.0.1",
+        port=8006,
+        api_user="root@pam",
+        api_password="dummy",
+        is_active=True,
+    )
+    db.add(server)
+    db.commit()
+    return server
+
+
+def _make_user(db, email="hong@gsm.hs.kr"):
+    user = User(
+        email=email,
+        hashed_password=get_password_hash("Pass1!aa"),
+        role=UserRole.USER,
+        is_active=True,
+    )
+    db.add(user)
+    db.commit()
+    return user
+
+
+class TestCollectDiscordDailyReport:
+    def test_includes_node_usage(self, db):
+        """활성 서버의 CPU/RAM/Disk 사용률을 nodes에 포함."""
+        _make_server(db, "gsmgpu1")
+        now = now_kst()
+
+        from main import _collect_discord_daily_report
+        with patch(
+            "main.get_server_resource_usage",
+            return_value={"cpu_pct": 23.0, "ram_pct": 61.0, "disk_pct": 44.0, "free_ram_mb": 1000},
+        ):
+            report = _collect_discord_daily_report(db, now)
+
+        assert len(report["nodes"]) == 1
+        assert report["nodes"][0]["name"] == "gsmgpu1"
+        assert report["nodes"][0]["cpu_pct"] == 23.0
+        assert report["nodes"][0]["ok"] is True
+
+    def test_node_marked_not_ok_when_usage_high(self, db):
+        """CPU/RAM 90% 이상이면 ok=False."""
+        _make_server(db, "gsmgpu2")
+        now = now_kst()
+
+        from main import _collect_discord_daily_report
+        with patch(
+            "main.get_server_resource_usage",
+            return_value={"cpu_pct": 95.0, "ram_pct": 50.0, "disk_pct": 30.0, "free_ram_mb": 1000},
+        ):
+            report = _collect_discord_daily_report(db, now)
+
+        assert report["nodes"][0]["ok"] is False
+
+    def test_node_query_failure_marked_not_ok(self, db):
+        """get_server_resource_usage 예외 시 cpu_pct=None, ok=False."""
+        _make_server(db, "gsmgpu3")
+        now = now_kst()
+
+        from main import _collect_discord_daily_report
+        with patch("main.get_server_resource_usage", side_effect=Exception("연결 실패")):
+            report = _collect_discord_daily_report(db, now)
+
+        assert report["nodes"][0]["cpu_pct"] is None
+        assert report["nodes"][0]["ok"] is False
+
+    def test_includes_vm_expiring_within_7_days(self, db):
+        """7일 이내 만료 VM을 days_left와 함께 포함."""
+        user = _make_user(db)
+        server = _make_server(db, "gsmgpu1")
+        now = now_kst()
+        db.add(Vm(
+            hypervisor_vmid=101,
+            name="vm-042",
+            server_id=server.id,
+            owner_id=user.id,
+            expires_at=now + timedelta(days=3),
+        ))
+        db.commit()
+
+        from main import _collect_discord_daily_report
+        with patch(
+            "main.get_server_resource_usage",
+            return_value={"cpu_pct": 10.0, "ram_pct": 10.0, "disk_pct": 10.0, "free_ram_mb": 1000},
+        ):
+            report = _collect_discord_daily_report(db, now)
+
+        assert len(report["vms"]) == 1
+        assert report["vms"][0]["name"] == "vm-042"
+        assert report["vms"][0]["owner_email"] == "hong@gsm.hs.kr"
+        assert report["vms"][0]["days_left"] == 3
+
+    def test_excludes_vm_expiring_after_7_days(self, db):
+        """7일 이후 만료 VM은 제외."""
+        server = _make_server(db, "gsmgpu1")
+        now = now_kst()
+        db.add(Vm(
+            hypervisor_vmid=102,
+            name="vm-far",
+            server_id=server.id,
+            expires_at=now + timedelta(days=10),
+        ))
+        db.commit()
+
+        from main import _collect_discord_daily_report
+        with patch(
+            "main.get_server_resource_usage",
+            return_value={"cpu_pct": 10.0, "ram_pct": 10.0, "disk_pct": 10.0, "free_ram_mb": 1000},
+        ):
+            report = _collect_discord_daily_report(db, now)
+
+        assert report["vms"] == []
+
+    def test_vm_without_owner_shows_placeholder(self, db):
+        """소유자 없는 VM은 owner_email '(소유자 없음)'으로 표시."""
+        server = _make_server(db, "gsmgpu1")
+        now = now_kst()
+        db.add(Vm(
+            hypervisor_vmid=103,
+            name="vm-no-owner",
+            server_id=server.id,
+            owner_id=None,
+            expires_at=now + timedelta(days=1),
+        ))
+        db.commit()
+
+        from main import _collect_discord_daily_report
+        with patch(
+            "main.get_server_resource_usage",
+            return_value={"cpu_pct": 10.0, "ram_pct": 10.0, "disk_pct": 10.0, "free_ram_mb": 1000},
+        ):
+            report = _collect_discord_daily_report(db, now)
+
+        assert report["vms"][0]["owner_email"] == "(소유자 없음)"
+
+
+class TestFormatDiscordDailyMessage:
+    def test_formats_node_status_with_ok_icon(self):
+        report = {
+            "nodes": [{"name": "gsmgpu1", "cpu_pct": 23.0, "ram_pct": 61.0, "disk_pct": 44.0, "ok": True}],
+            "vms": [],
+        }
+        from main import _format_discord_daily_message
+        now = now_kst()
+
+        message = _format_discord_daily_message(report, now)
+
+        assert "gsmgpu1" in message
+        assert "CPU 23.0%" in message
+        assert "✅" in message
+
+    def test_formats_node_status_with_warning_icon_when_not_ok(self):
+        report = {
+            "nodes": [{"name": "gsmgpu2", "cpu_pct": 95.0, "ram_pct": 50.0, "disk_pct": 30.0, "ok": False}],
+            "vms": [],
+        }
+        from main import _format_discord_daily_message
+        now = now_kst()
+
+        message = _format_discord_daily_message(report, now)
+
+        assert "⚠️" in message
+
+    def test_formats_query_failure_with_red_icon(self):
+        report = {
+            "nodes": [{"name": "gsmgpu3", "cpu_pct": None, "ram_pct": None, "disk_pct": None, "ok": False}],
+            "vms": [],
+        }
+        from main import _format_discord_daily_message
+        now = now_kst()
+
+        message = _format_discord_daily_message(report, now)
+
+        assert "🔴" in message
+
+    def test_omits_vm_section_when_no_expiring_vms(self):
+        report = {"nodes": [], "vms": []}
+        from main import _format_discord_daily_message
+        now = now_kst()
+
+        message = _format_discord_daily_message(report, now)
+
+        assert "[만료 예정 VM]" not in message
+
+    def test_includes_vm_expiry_section(self):
+        now = now_kst()
+        report = {
+            "nodes": [],
+            "vms": [{"name": "vm-042", "owner_email": "hong@gsm.hs.kr", "days_left": 3, "expires_at": now + timedelta(days=3)}],
+        }
+        from main import _format_discord_daily_message
+
+        message = _format_discord_daily_message(report, now)
+
+        assert "[만료 예정 VM]" in message
+        assert "vm-042" in message
+        assert "hong@gsm.hs.kr" in message
+        assert "D-3" in message
+
+
+class TestSendDiscordMessage:
+    @pytest.mark.asyncio
+    async def test_posts_content_to_webhook_when_configured(self, monkeypatch):
+        from unittest.mock import AsyncMock
+        import main
+
+        monkeypatch.setattr(main.settings, "DISCORD_WEBHOOK_URL", "https://discord.com/api/webhooks/test")
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = lambda: None
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("main.httpx.AsyncClient", return_value=mock_client):
+            await main._send_discord_message("test content")
+
+        mock_client.post.assert_called_once_with(
+            "https://discord.com/api/webhooks/test", json={"content": "test content"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_when_webhook_not_configured(self, monkeypatch):
+        from unittest.mock import AsyncMock
+        import main
+
+        monkeypatch.setattr(main.settings, "DISCORD_WEBHOOK_URL", "")
+
+        with patch("main.httpx.AsyncClient") as mock_client_cls:
+            await main._send_discord_message("test content")
+
+        mock_client_cls.assert_not_called()

--- a/backend/tests/test_discord_daily_report.py
+++ b/backend/tests/test_discord_daily_report.py
@@ -262,7 +262,6 @@ class TestSendDiscordMessage:
 
     @pytest.mark.asyncio
     async def test_skips_when_webhook_not_configured(self, monkeypatch):
-        from unittest.mock import AsyncMock
         import main
 
         monkeypatch.setattr(main.settings, "DISCORD_WEBHOOK_URL", "")


### PR DESCRIPTION
## Summary
- **`_discord_daily_loop`**: 매일 KST `DISCORD_DAILY_HOUR`시 Discord 웹훅으로 노드 상태 + 만료 예정 VM 요약 발송
- **`_collect_discord_daily_report`**: 활성 노드 CPU/RAM/Disk 사용률 + 7일 이내 만료 VM 수집
- **`_format_discord_daily_message`**: 수집 데이터를 Discord 텍스트 메시지로 포맷 (✅/⚠️/🔴 아이콘)
- **`_send_discord_message`**: `httpx`로 Discord 웹훅 POST, URL 미설정 시 스킵
- `core/config.py`에 `DISCORD_WEBHOOK_URL`, `DISCORD_DAILY_HOUR` 환경변수 추가

## Test plan
- [x] `pytest tests/test_discord_daily_report.py` 13개 통과
- [ ] 서버 `.env`에 `DISCORD_WEBHOOK_URL` 설정 후 백엔드 재시작
- [ ] `DISCORD_DAILY_HOUR`를 현재 시각+1분으로 임시 설정해 Discord 채널 메시지 수신 확인