### PR TITLE
feat: 생성 큐를 통한 VM 동시 생성 처리

### DIFF
--- a/backend/api/routes/vmcontrol.py
+++ b/backend/api/routes/vmcontrol.py
@@ -9,11 +9,12 @@ from core.timezone import now_kst
 from fastapi import APIRouter, HTTPException, status, Depends, Request
 from sqlalchemy import text
 from sqlalchemy.orm import Session
-from schemas.vm_schema import VMAction, VMCreate, VMResize, SnapshotCreateRequest
+from schemas.vm_schema import VMAction, VMCreate, VMCreationJobResponse, VMResize, SnapshotCreateRequest
 from core.constants import AUTO_SNAP_PREFIX, PROVISIONING_UPTIME_THRESHOLD_SECONDS
 from services.proxmox_client import get_proxmox_for_server, raise_proxmox_http_exception
 from models.server import Server
-from services.vm_service import create_vm, delete_vm
+from services.vm_creation_queue import enqueue_vm_creation, get_vm_creation_job
+from services.vm_service import delete_vm
 from core.database import get_db
 from models.vm import Vm
 from models.user import User, UserRole
@@ -474,7 +475,7 @@ async def control_vm(
         raise_proxmox_http_exception(e, default_detail="서버 오류가 발생했습니다.")
 
 
-@router.post("/create", status_code=status.HTTP_201_CREATED)
+@router.post("/create", status_code=status.HTTP_202_ACCEPTED, response_model=VMCreationJobResponse)
 @limiter.limit("5/minute")
 async def create_vm_endpoint(
     request: Request,
@@ -482,21 +483,21 @@ async def create_vm_endpoint(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """새로운 VM 생성 (Auto-Provisioning 적용)"""
-    return create_vm(
-        db=db,
-        current_user=current_user,
-        tier=vm_config.tier,
-        os=vm_config.os,
-        node_name=vm_config.node_name,
-        name=vm_config.name,
-        custom_cores=vm_config.custom_cores,
-        custom_memory=vm_config.custom_memory,
-        custom_disk=vm_config.custom_disk,
-    )
+    """VM 생성 요청을 큐에 넣는다."""
+    return enqueue_vm_creation(db=db, current_user=current_user, vm_config=vm_config)
 
 
 # ── 스냅샷 관리 ─────────────────────────────────────────────
+
+
+@router.get("/jobs/{job_id}", response_model=VMCreationJobResponse)
+async def get_vm_creation_job_status(
+    job_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """VM 생성 큐 작업 상태를 조회한다."""
+    return get_vm_creation_job(db=db, job_id=job_id, current_user=current_user)
 
 
 @router.get("/{node}/vms/{vmid}/snapshots")

--- a/backend/main.py
+++ b/backend/main.py
@@ -33,6 +33,8 @@ from models.notification import Notification
 from models.user import User, UserRole
 from models.server import Server
 from services.mon_service import get_server_resource_usage
+from models.vm_creation_job import VmCreationJob  # noqa: F401
+from services.vm_creation_queue import start_vm_creation_worker, stop_vm_creation_worker
 from models.faq_question import FaqQuestion  # noqa: F401 — create_all 자동 반영
 from models.vm_port import VmPort  # noqa: F401 — create_all 자동 반영
 
@@ -703,6 +705,7 @@ async def lifespan(app: FastAPI):
     expiry_notify_task = asyncio.create_task(_admin_expiry_notify_loop())
     # Discord 일일 모니터링 리포트 (KST DISCORD_DAILY_HOUR시)
     discord_daily_task = asyncio.create_task(_discord_daily_loop())
+    start_vm_creation_worker()
 
     yield
     # ── 종료 시 ──
@@ -712,6 +715,7 @@ async def lifespan(app: FastAPI):
     oauth_cleanup_task.cancel()
     expiry_notify_task.cancel()
     discord_daily_task.cancel()
+    stop_vm_creation_worker()
     await serverless._http_client.aclose()
 
 

--- a/backend/models/vm_creation_job.py
+++ b/backend/models/vm_creation_job.py
@@ -1,0 +1,45 @@
+import json
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+
+from core.database import Base
+from core.timezone import now_kst
+
+
+class VmCreationJob(Base):
+    __tablename__ = "vm_creation_jobs"
+
+    id = Column(String(36), primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    status = Column(String(20), nullable=False, default="queued", index=True)
+    tier = Column(String(32), nullable=False)
+    os = Column(String(32), nullable=False)
+    node_name = Column(String(128), nullable=True, index=True)
+    requested_name = Column(String(128), nullable=True)
+    queued_at = Column(DateTime(timezone=True), default=now_kst, nullable=False)
+    started_at = Column(DateTime(timezone=True), nullable=True)
+    finished_at = Column(DateTime(timezone=True), nullable=True)
+    vmid = Column(Integer, nullable=True, index=True)
+    attempts = Column(Integer, default=0, nullable=False)
+    payload_json = Column(Text, nullable=False)
+    result_json = Column(Text, nullable=True)
+    message = Column(Text, nullable=True)
+    error_message = Column(Text, nullable=True)
+
+    user = relationship("User")
+
+    @property
+    def payload(self) -> dict:
+        return json.loads(self.payload_json) if self.payload_json else {}
+
+    @payload.setter
+    def payload(self, value: dict) -> None:
+        self.payload_json = json.dumps(value, ensure_ascii=False)
+
+    @property
+    def result(self) -> dict | None:
+        return json.loads(self.result_json) if self.result_json else None
+
+    @result.setter
+    def result(self, value: dict | None) -> None:
+        self.result_json = json.dumps(value, ensure_ascii=False, default=str) if value is not None else None

--- a/backend/schemas/vm_schema.py
+++ b/backend/schemas/vm_schema.py
@@ -1,7 +1,9 @@
 import re
-from pydantic import BaseModel, Field, field_validator
-from typing import Optional
+from datetime import datetime
 from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field, field_validator
 
 
 class VMTier(str, Enum):
@@ -9,7 +11,7 @@ class VMTier(str, Enum):
     SMALL = "small"
     MEDIUM = "medium"
     LARGE = "large"
-    # 프로젝트 오너 전용 커스텀 티어
+    # 프로젝트 오너 전용 커스텀 스펙
     PROJECT_CUSTOM = "project_custom"
 
 
@@ -34,8 +36,8 @@ class VMAction(BaseModel):
 class VMResize(BaseModel):
     """VM 사양 변경 요청 모델 (핫플러그)"""
 
-    cores: Optional[int] = None  # vCPU 수
-    memory: Optional[int] = None  # RAM (MB 단위)
+    cores: Optional[int] = None
+    memory: Optional[int] = None
 
 
 class SnapshotCreateRequest(BaseModel):
@@ -44,16 +46,15 @@ class SnapshotCreateRequest(BaseModel):
 
 
 class VMCreate(BaseModel):
-    """VM 생성 요청 모델 — 사용자는 os, tier와 선택적으로 node_name만 입력"""
+    """VM 생성 요청 모델 - 사용자는 os, tier와 선택적으로 node_name만 입력"""
 
     tier: VMTier = VMTier.MICRO
     os: VMOs = VMOs.UBUNTU2204
-    node_name: Optional[str] = None  # 미지정 시 Auto Provisioning
-    name: Optional[str] = None  # 미지정 시 자동 생성
-    # project_custom 전용 커스텀 스펙 (미입력 시 기본값 사용)
-    custom_cores: Optional[int] = None  # vCPU 수 (1~8)
-    custom_memory: Optional[int] = None  # RAM (MB 단위, 1024~32768)
-    custom_disk: Optional[int] = None  # 디스크 (GB 단위, 30~70)
+    node_name: Optional[str] = None
+    name: Optional[str] = None
+    custom_cores: Optional[int] = None
+    custom_memory: Optional[int] = None
+    custom_disk: Optional[int] = None
 
     @field_validator("name")
     @classmethod
@@ -67,3 +68,26 @@ class VMCreate(BaseModel):
                 "VM 이름은 영문·숫자로 시작하고 영문·숫자·하이픈·언더스코어만 허용합니다."
             )
         return v
+
+
+class VMCreationJobStatus(str, Enum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class VMCreationJobResponse(BaseModel):
+    """VM 생성 큐 작업 상태 응답."""
+
+    job_id: str
+    status: VMCreationJobStatus
+    position: Optional[int] = None
+    requested_at: datetime
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    vmid: Optional[int] = None
+    node_name: Optional[str] = None
+    message: Optional[str] = None
+    error_message: Optional[str] = None
+    result: Optional[dict] = None

--- a/backend/schemas/vm_schema.py
+++ b/backend/schemas/vm_schema.py
@@ -46,11 +46,11 @@ class SnapshotCreateRequest(BaseModel):
 
 
 class VMCreate(BaseModel):
-    """VM 생성 요청 모델 - 사용자는 os, tier와 선택적으로 node_name만 입력"""
+    """VM 생성 요청 모델 - 사용자는 os, tier, node_name을 입력 (node_name 필수)"""
 
     tier: VMTier = VMTier.MICRO
     os: VMOs = VMOs.UBUNTU2204
-    node_name: Optional[str] = None
+    node_name: Optional[str] = None  # 큐 경로에서 필수 검증, vm_service 직접 호출 시 None 허용
     name: Optional[str] = None
     custom_cores: Optional[int] = None
     custom_memory: Optional[int] = None

--- a/backend/services/vm_creation_queue.py
+++ b/backend/services/vm_creation_queue.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import queue
 import threading
@@ -78,15 +77,25 @@ def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMC
 
     if current_user.role == UserRole.USER:
         user_vm_count = db.query(Vm).filter(Vm.owner_id == current_user.id).count()
-        if user_vm_count >= settings.MAX_VMS_PER_USER:
+        active_jobs_count = db.query(VmCreationJob).filter(
+            VmCreationJob.user_id == current_user.id,
+            VmCreationJob.status.in_([
+                VMCreationJobStatus.QUEUED.value,
+                VMCreationJobStatus.RUNNING.value,
+            ]),
+        ).count()
+        if user_vm_count + active_jobs_count >= settings.MAX_VMS_PER_USER:
             raise HTTPException(
                 status_code=409,
-                detail=f"생성 가능한 최대 VM 개수({settings.MAX_VMS_PER_USER}개)를 초과했습니다.",
+                detail=(
+                    "생성 대기/진행 중인 작업을 포함하여 "
+                    f"생성 가능한 최대 VM 개수({settings.MAX_VMS_PER_USER}개)를 초과했습니다."
+                ),
             )
 
     server = (
         db.query(Server)
-        .filter(Server.name == vm_config.node_name, Server.is_active == True)
+        .filter(Server.name == vm_config.node_name, Server.is_active.is_(True))
         .first()
     )
     if not server:
@@ -101,7 +110,6 @@ def enqueue_vm_creation(db: Session, current_user: User, vm_config: VMCreate) ->
     """VM 생성 요청을 큐에 넣고 작업 정보를 반환한다."""
     validate_vm_creation_request(db, current_user, vm_config)
 
-    payload = vm_config.model_dump()
     job = VmCreationJob(
         id=str(uuid4()),
         user_id=current_user.id,
@@ -110,8 +118,8 @@ def enqueue_vm_creation(db: Session, current_user: User, vm_config: VMCreate) ->
         os=vm_config.os.value,
         node_name=vm_config.node_name,
         requested_name=vm_config.name,
-        payload_json=json.dumps(payload, ensure_ascii=False),
     )
+    job.payload = vm_config.model_dump(mode="json")
     db.add(job)
     db.commit()
     db.refresh(job)
@@ -167,11 +175,6 @@ def process_vm_creation_job(job_id: str) -> None:
             custom_disk=payload.get("custom_disk"),
         )
 
-        job = job_db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
-        if not job:
-            logger.warning("[vm-queue] 완료 후 작업을 재조회할 수 없음: %s", job_id)
-            return
-
         job.status = VMCreationJobStatus.COMPLETED.value
         job.finished_at = now_kst()
         job.vmid = result.get("vmid")
@@ -210,7 +213,10 @@ def _worker_loop() -> None:
         try:
             if job_id == _QUEUE_STOP_SENTINEL:
                 return
-            process_vm_creation_job(job_id)
+            try:
+                process_vm_creation_job(job_id)
+            except Exception as exc:
+                logger.exception("[vm-queue] 워커 루프에서 예외 발생: %s", exc)
         finally:
             _vm_creation_queue.task_done()
 
@@ -221,6 +227,28 @@ def start_vm_creation_worker() -> None:
         if _worker_thread and _worker_thread.is_alive():
             return
         _worker_stop_event.clear()
+
+        db = SessionLocal()
+        try:
+            queued_jobs = (
+                db.query(VmCreationJob)
+                .filter(VmCreationJob.status == VMCreationJobStatus.QUEUED.value)
+                .order_by(VmCreationJob.queued_at.asc())
+                .all()
+            )
+            for job in queued_jobs:
+                _vm_creation_queue.put(job.id)
+            if queued_jobs:
+                logger.info(
+                    "[vm-queue] DB에서 %d개의 대기 작업을 큐에 재적재했습니다.",
+                    len(queued_jobs),
+                )
+        except Exception as exc:
+            logger.exception("[vm-queue] 대기 작업 재적재 중 오류 발생: %s", exc)
+        finally:
+            db.close()
+            db = None
+
         _worker_thread = threading.Thread(
             target=_worker_loop,
             name="vm-creation-worker",
@@ -238,5 +266,8 @@ def stop_vm_creation_worker() -> None:
         _worker_stop_event.set()
         _vm_creation_queue.put(_QUEUE_STOP_SENTINEL)
         _worker_thread.join(timeout=5)
-        _worker_thread = None
-        logger.info("[vm-queue] VM 생성 워커 종료")
+        if not _worker_thread.is_alive():
+            _worker_thread = None
+            logger.info("[vm-queue] VM 생성 워커 종료")
+        else:
+            logger.warning("[vm-queue] VM 생성 워커가 아직 실행 중입니다 (타임아웃).")

--- a/backend/services/vm_creation_queue.py
+++ b/backend/services/vm_creation_queue.py
@@ -5,6 +5,7 @@ from typing import Optional
 from uuid import uuid4
 
 from fastapi import HTTPException
+from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
 
 from core.config import settings
@@ -49,7 +50,13 @@ def _get_queue_position(db: Session, job: VmCreationJob) -> int | None:
         db.query(VmCreationJob)
         .filter(
             VmCreationJob.status == VMCreationJobStatus.QUEUED.value,
-            VmCreationJob.queued_at <= job.queued_at,
+            or_(
+                VmCreationJob.queued_at < job.queued_at,
+                and_(
+                    VmCreationJob.queued_at == job.queued_at,
+                    VmCreationJob.id <= job.id,
+                ),
+            ),
         )
         .count()
     )
@@ -144,19 +151,32 @@ def process_vm_creation_job(job_id: str) -> None:
     job_db = SessionLocal()
     work_db = SessionLocal()
     try:
+        claimed_at = now_kst()
+        claimed_rows = (
+            job_db.query(VmCreationJob)
+            .filter(
+                VmCreationJob.id == job_id,
+                VmCreationJob.status == VMCreationJobStatus.QUEUED.value,
+            )
+            .update(
+                {
+                    VmCreationJob.status: VMCreationJobStatus.RUNNING.value,
+                    VmCreationJob.started_at: claimed_at,
+                    VmCreationJob.attempts: VmCreationJob.attempts + 1,
+                },
+                synchronize_session=False,
+            )
+        )
+        if claimed_rows == 0:
+            job_db.rollback()
+            logger.info("[vm-queue] 작업 %s는 이미 다른 워커가 처리했거나 상태가 변경됨", job_id)
+            return
+        job_db.commit()
+
         job = job_db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
         if not job:
             logger.warning("[vm-queue] 작업을 찾을 수 없음: %s", job_id)
             return
-
-        if job.status != VMCreationJobStatus.QUEUED.value:
-            logger.info("[vm-queue] 작업 %s는 이미 처리된 상태(%s)라 건너뜀", job_id, job.status)
-            return
-
-        job.status = VMCreationJobStatus.RUNNING.value
-        job.started_at = now_kst()
-        job.attempts += 1
-        job_db.commit()
 
         payload = job.payload
         user = work_db.query(User).filter(User.id == job.user_id).first()

--- a/backend/services/vm_creation_queue.py
+++ b/backend/services/vm_creation_queue.py
@@ -1,0 +1,242 @@
+import json
+import logging
+import queue
+import threading
+from typing import Optional
+from uuid import uuid4
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from core.config import settings
+from core.database import SessionLocal
+from core.timezone import now_kst
+from models.server import Server
+from models.user import User, UserRole
+from models.vm import Vm
+from models.vm_creation_job import VmCreationJob
+from schemas.vm_schema import VMCreate, VMCreationJobResponse, VMCreationJobStatus, VMOs, VMTier
+from services.vm_service import create_vm
+
+logger = logging.getLogger(__name__)
+
+_QUEUE_STOP_SENTINEL = "__STOP__"
+_vm_creation_queue: "queue.Queue[str]" = queue.Queue()
+_worker_thread: Optional[threading.Thread] = None
+_worker_lock = threading.Lock()
+_worker_stop_event = threading.Event()
+
+
+def _serialize_job(job: VmCreationJob, position: int | None = None) -> VMCreationJobResponse:
+    return VMCreationJobResponse(
+        job_id=job.id,
+        status=VMCreationJobStatus(job.status),
+        position=position,
+        requested_at=job.queued_at,
+        started_at=job.started_at,
+        finished_at=job.finished_at,
+        vmid=job.vmid,
+        node_name=job.node_name,
+        message=job.message,
+        error_message=job.error_message,
+        result=job.result,
+    )
+
+
+def _get_queue_position(db: Session, job: VmCreationJob) -> int | None:
+    if job.status != VMCreationJobStatus.QUEUED.value:
+        return None
+    return (
+        db.query(VmCreationJob)
+        .filter(
+            VmCreationJob.status == VMCreationJobStatus.QUEUED.value,
+            VmCreationJob.queued_at <= job.queued_at,
+        )
+        .count()
+    )
+
+
+def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMCreate) -> Server:
+    """큐에 넣기 전에 최소한의 선검증만 수행한다."""
+    if not vm_config.node_name:
+        raise HTTPException(status_code=400, detail="node_name을 지정해 주세요.")
+
+    if current_user.role == UserRole.USER and vm_config.node_name == settings.PROJECT_NODE_NAME:
+        raise HTTPException(
+            status_code=403,
+            detail="일반 사용자는 프로젝트 전용 노드에 VM을 생성할 수 없습니다.",
+        )
+
+    if vm_config.tier == VMTier.PROJECT_CUSTOM and current_user.role not in (
+        UserRole.ADMIN,
+        UserRole.PROJECT_OWNER,
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="프로젝트 커스텀 티어는 프로젝트 오너만 사용할 수 있습니다.",
+        )
+
+    if current_user.role == UserRole.USER:
+        user_vm_count = db.query(Vm).filter(Vm.owner_id == current_user.id).count()
+        if user_vm_count >= settings.MAX_VMS_PER_USER:
+            raise HTTPException(
+                status_code=409,
+                detail=f"생성 가능한 최대 VM 개수({settings.MAX_VMS_PER_USER}개)를 초과했습니다.",
+            )
+
+    server = (
+        db.query(Server)
+        .filter(Server.name == vm_config.node_name, Server.is_active == True)
+        .first()
+    )
+    if not server:
+        raise HTTPException(
+            status_code=404,
+            detail=f"노드 '{vm_config.node_name}'을(를) 찾을 수 없거나 비활성 상태입니다.",
+        )
+    return server
+
+
+def enqueue_vm_creation(db: Session, current_user: User, vm_config: VMCreate) -> VMCreationJobResponse:
+    """VM 생성 요청을 큐에 넣고 작업 정보를 반환한다."""
+    validate_vm_creation_request(db, current_user, vm_config)
+
+    payload = vm_config.model_dump()
+    job = VmCreationJob(
+        id=str(uuid4()),
+        user_id=current_user.id,
+        status=VMCreationJobStatus.QUEUED.value,
+        tier=vm_config.tier.value,
+        os=vm_config.os.value,
+        node_name=vm_config.node_name,
+        requested_name=vm_config.name,
+        payload_json=json.dumps(payload, ensure_ascii=False),
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    _vm_creation_queue.put(job.id)
+    return _serialize_job(job, position=_get_queue_position(db, job))
+
+
+def get_vm_creation_job(db: Session, job_id: str, current_user: User) -> VMCreationJobResponse:
+    job = db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
+    if not job:
+        raise HTTPException(status_code=404, detail="VM 생성 작업을 찾을 수 없습니다.")
+
+    if current_user.role != UserRole.ADMIN and job.user_id != current_user.id:
+        raise HTTPException(status_code=404, detail="VM 생성 작업을 찾을 수 없습니다.")
+
+    return _serialize_job(job, position=_get_queue_position(db, job))
+
+
+def process_vm_creation_job(job_id: str) -> None:
+    """큐에서 꺼낸 단일 작업을 처리한다."""
+    job_db = SessionLocal()
+    work_db = SessionLocal()
+    try:
+        job = job_db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
+        if not job:
+            logger.warning("[vm-queue] 작업을 찾을 수 없음: %s", job_id)
+            return
+
+        if job.status != VMCreationJobStatus.QUEUED.value:
+            logger.info("[vm-queue] 작업 %s는 이미 처리된 상태(%s)라 건너뜀", job_id, job.status)
+            return
+
+        job.status = VMCreationJobStatus.RUNNING.value
+        job.started_at = now_kst()
+        job.attempts += 1
+        job_db.commit()
+
+        payload = job.payload
+        user = work_db.query(User).filter(User.id == job.user_id).first()
+        if not user:
+            raise HTTPException(status_code=404, detail="작업 소유자를 찾을 수 없습니다.")
+
+        result = create_vm(
+            db=work_db,
+            current_user=user,
+            tier=VMTier(payload["tier"]),
+            os=VMOs(payload["os"]),
+            node_name=payload.get("node_name"),
+            name=payload.get("name"),
+            custom_cores=payload.get("custom_cores"),
+            custom_memory=payload.get("custom_memory"),
+            custom_disk=payload.get("custom_disk"),
+        )
+
+        job = job_db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
+        if not job:
+            logger.warning("[vm-queue] 완료 후 작업을 재조회할 수 없음: %s", job_id)
+            return
+
+        job.status = VMCreationJobStatus.COMPLETED.value
+        job.finished_at = now_kst()
+        job.vmid = result.get("vmid")
+        job.node_name = result.get("assigned_node") or job.node_name
+        job.message = result.get("message")
+        job.result = result
+        job.error_message = None
+        job_db.commit()
+        logger.info("[vm-queue] 작업 완료: %s -> VMID %s", job_id, job.vmid)
+    except Exception as exc:
+        logger.exception("[vm-queue] 작업 실패: %s", job_id)
+        try:
+            job_db.rollback()
+            job = job_db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
+            if job:
+                job.status = VMCreationJobStatus.FAILED.value
+                job.finished_at = now_kst()
+                job.error_message = getattr(exc, "detail", None) or str(exc)
+                job.message = "VM 생성에 실패했습니다."
+                job_db.commit()
+        except Exception:
+            job_db.rollback()
+            logger.exception("[vm-queue] 실패 상태 기록 중 오류: %s", job_id)
+    finally:
+        work_db.close()
+        job_db.close()
+
+
+def _worker_loop() -> None:
+    while not _worker_stop_event.is_set():
+        try:
+            job_id = _vm_creation_queue.get(timeout=1)
+        except queue.Empty:
+            continue
+
+        try:
+            if job_id == _QUEUE_STOP_SENTINEL:
+                return
+            process_vm_creation_job(job_id)
+        finally:
+            _vm_creation_queue.task_done()
+
+
+def start_vm_creation_worker() -> None:
+    global _worker_thread
+    with _worker_lock:
+        if _worker_thread and _worker_thread.is_alive():
+            return
+        _worker_stop_event.clear()
+        _worker_thread = threading.Thread(
+            target=_worker_loop,
+            name="vm-creation-worker",
+            daemon=True,
+        )
+        _worker_thread.start()
+        logger.info("[vm-queue] VM 생성 워커 시작")
+
+
+def stop_vm_creation_worker() -> None:
+    global _worker_thread
+    with _worker_lock:
+        if not _worker_thread or not _worker_thread.is_alive():
+            return
+        _worker_stop_event.set()
+        _vm_creation_queue.put(_QUEUE_STOP_SENTINEL)
+        _worker_thread.join(timeout=5)
+        _worker_thread = None
+        logger.info("[vm-queue] VM 생성 워커 종료")

--- a/backend/services/vm_creation_queue.py
+++ b/backend/services/vm_creation_queue.py
@@ -1,8 +1,10 @@
-import logging
+﻿import logging
+import os
 import queue
+import time
 import threading
+from itertools import count
 from typing import Optional
-from uuid import uuid4
 
 from fastapi import HTTPException
 from sqlalchemy import and_, or_
@@ -25,6 +27,12 @@ _vm_creation_queue: "queue.Queue[str]" = queue.Queue()
 _worker_thread: Optional[threading.Thread] = None
 _worker_lock = threading.Lock()
 _worker_stop_event = threading.Event()
+_job_id_counter = count()
+
+
+def _next_job_id() -> str:
+    """?쒓컙???뺣젹??媛?ν븳 VM ?앹꽦 ?묒뾽 ID瑜?留뚮뱺??"""
+    return f"{time.time_ns():019d}-{os.getpid():05d}-{next(_job_id_counter):06d}"
 
 
 def _serialize_job(job: VmCreationJob, position: int | None = None) -> VMCreationJobResponse:
@@ -62,15 +70,41 @@ def _get_queue_position(db: Session, job: VmCreationJob) -> int | None:
     )
 
 
+def _recover_pending_jobs(db: Session) -> list[VmCreationJob]:
+    """?ъ떆????泥섎━ 以묒씠???묒뾽源뚯? ?ㅼ떆 ?湲곗뿴濡??섎룎由곕떎."""
+    pending_jobs = (
+        db.query(VmCreationJob)
+        .filter(
+            VmCreationJob.status.in_([
+                VMCreationJobStatus.QUEUED.value,
+                VMCreationJobStatus.RUNNING.value,
+            ]),
+        )
+        .order_by(VmCreationJob.queued_at.asc(), VmCreationJob.id.asc())
+        .all()
+    )
+
+    for job in pending_jobs:
+        if job.status == VMCreationJobStatus.RUNNING.value:
+            job.status = VMCreationJobStatus.QUEUED.value
+            job.started_at = None
+        _vm_creation_queue.put(job.id)
+
+    if pending_jobs:
+        db.commit()
+
+    return pending_jobs
+
+
 def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMCreate) -> Server:
-    """큐에 넣기 전에 최소한의 선검증만 수행한다."""
+    """?먯뿉 ?ｊ린 ?꾩뿉 理쒖냼?쒖쓽 ?좉?利앸쭔 ?섑뻾?쒕떎."""
     if not vm_config.node_name:
-        raise HTTPException(status_code=400, detail="node_name을 지정해 주세요.")
+        raise HTTPException(status_code=400, detail="node_name??吏?뺥빐 二쇱꽭??")
 
     if current_user.role == UserRole.USER and vm_config.node_name == settings.PROJECT_NODE_NAME:
         raise HTTPException(
             status_code=403,
-            detail="일반 사용자는 프로젝트 전용 노드에 VM을 생성할 수 없습니다.",
+            detail="?쇰컲 ?ъ슜?먮뒗 ?꾨줈?앺듃 ?꾩슜 ?몃뱶??VM???앹꽦?????놁뒿?덈떎.",
         )
 
     if vm_config.tier == VMTier.PROJECT_CUSTOM and current_user.role not in (
@@ -79,7 +113,7 @@ def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMC
     ):
         raise HTTPException(
             status_code=403,
-            detail="프로젝트 커스텀 티어는 프로젝트 오너만 사용할 수 있습니다.",
+            detail="?꾨줈?앺듃 而ㅼ뒪? ?곗뼱???꾨줈?앺듃 ?ㅻ꼫留??ъ슜?????덉뒿?덈떎.",
         )
 
     if current_user.role == UserRole.USER:
@@ -95,8 +129,8 @@ def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMC
             raise HTTPException(
                 status_code=409,
                 detail=(
-                    "생성 대기/진행 중인 작업을 포함하여 "
-                    f"생성 가능한 최대 VM 개수({settings.MAX_VMS_PER_USER}개)를 초과했습니다."
+                    "?앹꽦 ?湲?吏꾪뻾 以묒씤 ?묒뾽???ы븿?섏뿬 "
+                    f"?앹꽦 媛?ν븳 理쒕? VM 媛쒖닔({settings.MAX_VMS_PER_USER}媛?瑜?珥덇낵?덉뒿?덈떎."
                 ),
             )
 
@@ -108,17 +142,17 @@ def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMC
     if not server:
         raise HTTPException(
             status_code=404,
-            detail=f"노드 '{vm_config.node_name}'을(를) 찾을 수 없거나 비활성 상태입니다.",
+            detail=f"?몃뱶 '{vm_config.node_name}'??瑜? 李얠쓣 ???녾굅??鍮꾪솢???곹깭?낅땲??",
         )
     return server
 
 
 def enqueue_vm_creation(db: Session, current_user: User, vm_config: VMCreate) -> VMCreationJobResponse:
-    """VM 생성 요청을 큐에 넣고 작업 정보를 반환한다."""
+    """VM ?앹꽦 ?붿껌???먯뿉 ?ｊ퀬 ?묒뾽 ?뺣낫瑜?諛섑솚?쒕떎."""
     validate_vm_creation_request(db, current_user, vm_config)
 
     job = VmCreationJob(
-        id=str(uuid4()),
+        id=_next_job_id(),
         user_id=current_user.id,
         status=VMCreationJobStatus.QUEUED.value,
         tier=vm_config.tier.value,
@@ -138,16 +172,16 @@ def enqueue_vm_creation(db: Session, current_user: User, vm_config: VMCreate) ->
 def get_vm_creation_job(db: Session, job_id: str, current_user: User) -> VMCreationJobResponse:
     job = db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
     if not job:
-        raise HTTPException(status_code=404, detail="VM 생성 작업을 찾을 수 없습니다.")
+        raise HTTPException(status_code=404, detail="VM ?앹꽦 ?묒뾽??李얠쓣 ???놁뒿?덈떎.")
 
     if current_user.role != UserRole.ADMIN and job.user_id != current_user.id:
-        raise HTTPException(status_code=404, detail="VM 생성 작업을 찾을 수 없습니다.")
+        raise HTTPException(status_code=404, detail="VM ?앹꽦 ?묒뾽??李얠쓣 ???놁뒿?덈떎.")
 
     return _serialize_job(job, position=_get_queue_position(db, job))
 
 
 def process_vm_creation_job(job_id: str) -> None:
-    """큐에서 꺼낸 단일 작업을 처리한다."""
+    """?먯뿉??爰쇰궦 ?⑥씪 ?묒뾽??泥섎━?쒕떎."""
     job_db = SessionLocal()
     work_db = SessionLocal()
     try:
@@ -169,19 +203,19 @@ def process_vm_creation_job(job_id: str) -> None:
         )
         if claimed_rows == 0:
             job_db.rollback()
-            logger.info("[vm-queue] 작업 %s는 이미 다른 워커가 처리했거나 상태가 변경됨", job_id)
+            logger.info("[vm-queue] ?묒뾽 %s???대? ?ㅻⅨ ?뚯빱媛 泥섎━?덇굅???곹깭媛 蹂寃쎈맖", job_id)
             return
         job_db.commit()
 
         job = job_db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
         if not job:
-            logger.warning("[vm-queue] 작업을 찾을 수 없음: %s", job_id)
+            logger.warning("[vm-queue] ?묒뾽??李얠쓣 ???놁쓬: %s", job_id)
             return
 
         payload = job.payload
         user = work_db.query(User).filter(User.id == job.user_id).first()
         if not user:
-            raise HTTPException(status_code=404, detail="작업 소유자를 찾을 수 없습니다.")
+            raise HTTPException(status_code=404, detail="?묒뾽 ?뚯쑀?먮? 李얠쓣 ???놁뒿?덈떎.")
 
         result = create_vm(
             db=work_db,
@@ -203,9 +237,9 @@ def process_vm_creation_job(job_id: str) -> None:
         job.result = result
         job.error_message = None
         job_db.commit()
-        logger.info("[vm-queue] 작업 완료: %s -> VMID %s", job_id, job.vmid)
+        logger.info("[vm-queue] ?묒뾽 ?꾨즺: %s -> VMID %s", job_id, job.vmid)
     except Exception as exc:
-        logger.exception("[vm-queue] 작업 실패: %s", job_id)
+        logger.exception("[vm-queue] ?묒뾽 ?ㅽ뙣: %s", job_id)
         try:
             job_db.rollback()
             job = job_db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
@@ -213,11 +247,11 @@ def process_vm_creation_job(job_id: str) -> None:
                 job.status = VMCreationJobStatus.FAILED.value
                 job.finished_at = now_kst()
                 job.error_message = getattr(exc, "detail", None) or str(exc)
-                job.message = "VM 생성에 실패했습니다."
+                job.message = "VM ?앹꽦???ㅽ뙣?덉뒿?덈떎."
                 job_db.commit()
         except Exception:
             job_db.rollback()
-            logger.exception("[vm-queue] 실패 상태 기록 중 오류: %s", job_id)
+            logger.exception("[vm-queue] ?ㅽ뙣 ?곹깭 湲곕줉 以??ㅻ쪟: %s", job_id)
     finally:
         work_db.close()
         job_db.close()
@@ -236,7 +270,7 @@ def _worker_loop() -> None:
             try:
                 process_vm_creation_job(job_id)
             except Exception as exc:
-                logger.exception("[vm-queue] 워커 루프에서 예외 발생: %s", exc)
+                logger.exception("[vm-queue] ?뚯빱 猷⑦봽?먯꽌 ?덉쇅 諛쒖깮: %s", exc)
         finally:
             _vm_creation_queue.task_done()
 
@@ -250,21 +284,14 @@ def start_vm_creation_worker() -> None:
 
         db = SessionLocal()
         try:
-            queued_jobs = (
-                db.query(VmCreationJob)
-                .filter(VmCreationJob.status == VMCreationJobStatus.QUEUED.value)
-                .order_by(VmCreationJob.queued_at.asc())
-                .all()
-            )
-            for job in queued_jobs:
-                _vm_creation_queue.put(job.id)
+            queued_jobs = _recover_pending_jobs(db)
             if queued_jobs:
                 logger.info(
-                    "[vm-queue] DB에서 %d개의 대기 작업을 큐에 재적재했습니다.",
+                    "[vm-queue] DB?먯꽌 %d媛쒖쓽 ?湲?/?ㅽ뻾 ?묒뾽???먯뿉 ?ъ쟻?ы뻽?듬땲??",
                     len(queued_jobs),
                 )
         except Exception as exc:
-            logger.exception("[vm-queue] 대기 작업 재적재 중 오류 발생: %s", exc)
+            logger.exception("[vm-queue] ?湲??묒뾽 ?ъ쟻??以??ㅻ쪟 諛쒖깮: %s", exc)
         finally:
             db.close()
             db = None
@@ -275,7 +302,7 @@ def start_vm_creation_worker() -> None:
             daemon=True,
         )
         _worker_thread.start()
-        logger.info("[vm-queue] VM 생성 워커 시작")
+        logger.info("[vm-queue] VM ?앹꽦 ?뚯빱 ?쒖옉")
 
 
 def stop_vm_creation_worker() -> None:
@@ -288,6 +315,6 @@ def stop_vm_creation_worker() -> None:
         _worker_thread.join(timeout=5)
         if not _worker_thread.is_alive():
             _worker_thread = None
-            logger.info("[vm-queue] VM 생성 워커 종료")
+            logger.info("[vm-queue] VM ?앹꽦 ?뚯빱 醫낅즺")
         else:
-            logger.warning("[vm-queue] VM 생성 워커가 아직 실행 중입니다 (타임아웃).")
+            logger.warning("[vm-queue] VM ?앹꽦 ?뚯빱媛 ?꾩쭅 ?ㅽ뻾 以묒엯?덈떎 (??꾩븘??.")

--- a/backend/services/vm_creation_queue.py
+++ b/backend/services/vm_creation_queue.py
@@ -213,7 +213,6 @@ def process_vm_creation_job(job_id: str) -> None:
             logger.warning("[vm-queue] 작업을 찾을 수 없음: %s", job_id)
             return
 
-        # 멱등성 보장: vmid가 이미 설정된 경우 VM이 이미 생성된 것으로 간주
         if job.vmid is not None:
             logger.warning("[vm-queue] 작업 %s에 vmid %s가 이미 설정되어 있음, 중복 생성 방지", job_id, job.vmid)
             job.status = VMCreationJobStatus.COMPLETED.value

--- a/backend/services/vm_creation_queue.py
+++ b/backend/services/vm_creation_queue.py
@@ -1,4 +1,4 @@
-﻿import logging
+import logging
 import os
 import queue
 import time
@@ -31,7 +31,7 @@ _job_id_counter = count()
 
 
 def _next_job_id() -> str:
-    """?쒓컙???뺣젹??媛?ν븳 VM ?앹꽦 ?묒뾽 ID瑜?留뚮뱺??"""
+    """타임스탬프 기반의 유일한 VM 생성 작업 ID를 생성한다."""
     return f"{time.time_ns():019d}-{os.getpid():05d}-{next(_job_id_counter):06d}"
 
 
@@ -71,7 +71,7 @@ def _get_queue_position(db: Session, job: VmCreationJob) -> int | None:
 
 
 def _recover_pending_jobs(db: Session) -> list[VmCreationJob]:
-    """?ъ떆????泥섎━ 以묒씠???묒뾽源뚯? ?ㅼ떆 ?湲곗뿴濡??섎룎由곕떎."""
+    """재시작 후 미처리 상태인 작업들을 다시 큐로 되돌린다."""
     pending_jobs = (
         db.query(VmCreationJob)
         .filter(
@@ -88,6 +88,7 @@ def _recover_pending_jobs(db: Session) -> list[VmCreationJob]:
         if job.status == VMCreationJobStatus.RUNNING.value:
             job.status = VMCreationJobStatus.QUEUED.value
             job.started_at = None
+            job.attempts += 1
         _vm_creation_queue.put(job.id)
 
     if pending_jobs:
@@ -97,14 +98,14 @@ def _recover_pending_jobs(db: Session) -> list[VmCreationJob]:
 
 
 def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMCreate) -> Server:
-    """?먯뿉 ?ｊ린 ?꾩뿉 理쒖냼?쒖쓽 ?좉?利앸쭔 ?섑뻾?쒕떎."""
+    """큐에 넣기 전에 기본적인 유효성 검증을 수행한다."""
     if not vm_config.node_name:
-        raise HTTPException(status_code=400, detail="node_name??吏?뺥빐 二쇱꽭??")
+        raise HTTPException(status_code=400, detail="node_name을 지정해 주세요.")
 
     if current_user.role == UserRole.USER and vm_config.node_name == settings.PROJECT_NODE_NAME:
         raise HTTPException(
             status_code=403,
-            detail="?쇰컲 ?ъ슜?먮뒗 ?꾨줈?앺듃 ?꾩슜 ?몃뱶??VM???앹꽦?????놁뒿?덈떎.",
+            detail="일반 사용자는 프로젝트 전용 노드에 VM을 생성할 수 없습니다.",
         )
 
     if vm_config.tier == VMTier.PROJECT_CUSTOM and current_user.role not in (
@@ -113,7 +114,7 @@ def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMC
     ):
         raise HTTPException(
             status_code=403,
-            detail="?꾨줈?앺듃 而ㅼ뒪? ?곗뼱???꾨줈?앺듃 ?ㅻ꼫留??ъ슜?????덉뒿?덈떎.",
+            detail="프로젝트 티어는 프로젝트 오너만 사용할 수 있습니다.",
         )
 
     if current_user.role == UserRole.USER:
@@ -129,8 +130,8 @@ def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMC
             raise HTTPException(
                 status_code=409,
                 detail=(
-                    "?앹꽦 ?湲?吏꾪뻾 以묒씤 ?묒뾽???ы븿?섏뿬 "
-                    f"?앹꽦 媛?ν븳 理쒕? VM 媛쒖닔({settings.MAX_VMS_PER_USER}媛?瑜?珥덇낵?덉뒿?덈떎."
+                    "생성 대기/실행 중인 작업을 포함하여 "
+                    f"생성 가능한 최대 VM 개수({settings.MAX_VMS_PER_USER}개)를 초과합니다."
                 ),
             )
 
@@ -142,13 +143,13 @@ def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMC
     if not server:
         raise HTTPException(
             status_code=404,
-            detail=f"?몃뱶 '{vm_config.node_name}'??瑜? 李얠쓣 ???녾굅??鍮꾪솢???곹깭?낅땲??",
+            detail=f"노드 '{vm_config.node_name}'을(를) 찾을 수 없거나 비활성 상태입니다.",
         )
     return server
 
 
 def enqueue_vm_creation(db: Session, current_user: User, vm_config: VMCreate) -> VMCreationJobResponse:
-    """VM ?앹꽦 ?붿껌???먯뿉 ?ｊ퀬 ?묒뾽 ?뺣낫瑜?諛섑솚?쒕떎."""
+    """VM 생성 요청을 큐에 넣고 작업 정보를 반환한다."""
     validate_vm_creation_request(db, current_user, vm_config)
 
     job = VmCreationJob(
@@ -172,16 +173,16 @@ def enqueue_vm_creation(db: Session, current_user: User, vm_config: VMCreate) ->
 def get_vm_creation_job(db: Session, job_id: str, current_user: User) -> VMCreationJobResponse:
     job = db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
     if not job:
-        raise HTTPException(status_code=404, detail="VM ?앹꽦 ?묒뾽??李얠쓣 ???놁뒿?덈떎.")
+        raise HTTPException(status_code=404, detail="VM 생성 작업을 찾을 수 없습니다.")
 
     if current_user.role != UserRole.ADMIN and job.user_id != current_user.id:
-        raise HTTPException(status_code=404, detail="VM ?앹꽦 ?묒뾽??李얠쓣 ???놁뒿?덈떎.")
+        raise HTTPException(status_code=404, detail="VM 생성 작업을 찾을 수 없습니다.")
 
     return _serialize_job(job, position=_get_queue_position(db, job))
 
 
 def process_vm_creation_job(job_id: str) -> None:
-    """?먯뿉??爰쇰궦 ?⑥씪 ?묒뾽??泥섎━?쒕떎."""
+    """큐에서 가져온 단일 작업을 처리한다."""
     job_db = SessionLocal()
     work_db = SessionLocal()
     try:
@@ -203,19 +204,27 @@ def process_vm_creation_job(job_id: str) -> None:
         )
         if claimed_rows == 0:
             job_db.rollback()
-            logger.info("[vm-queue] ?묒뾽 %s???대? ?ㅻⅨ ?뚯빱媛 泥섎━?덇굅???곹깭媛 蹂寃쎈맖", job_id)
+            logger.info("[vm-queue] 작업 %s는 이미 다른 워커가 처리했거나 상태가 변경됨", job_id)
             return
         job_db.commit()
 
         job = job_db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
         if not job:
-            logger.warning("[vm-queue] ?묒뾽??李얠쓣 ???놁쓬: %s", job_id)
+            logger.warning("[vm-queue] 작업을 찾을 수 없음: %s", job_id)
+            return
+
+        # 멱등성 보장: vmid가 이미 설정된 경우 VM이 이미 생성된 것으로 간주
+        if job.vmid is not None:
+            logger.warning("[vm-queue] 작업 %s에 vmid %s가 이미 설정되어 있음, 중복 생성 방지", job_id, job.vmid)
+            job.status = VMCreationJobStatus.COMPLETED.value
+            job.finished_at = now_kst()
+            job_db.commit()
             return
 
         payload = job.payload
         user = work_db.query(User).filter(User.id == job.user_id).first()
         if not user:
-            raise HTTPException(status_code=404, detail="?묒뾽 ?뚯쑀?먮? 李얠쓣 ???놁뒿?덈떎.")
+            raise RuntimeError(f"작업 사용자를 찾을 수 없습니다: user_id={job.user_id}")
 
         result = create_vm(
             db=work_db,
@@ -237,9 +246,9 @@ def process_vm_creation_job(job_id: str) -> None:
         job.result = result
         job.error_message = None
         job_db.commit()
-        logger.info("[vm-queue] ?묒뾽 ?꾨즺: %s -> VMID %s", job_id, job.vmid)
+        logger.info("[vm-queue] 작업 완료: %s -> VMID %s", job_id, job.vmid)
     except Exception as exc:
-        logger.exception("[vm-queue] ?묒뾽 ?ㅽ뙣: %s", job_id)
+        logger.exception("[vm-queue] 작업 실패: %s", job_id)
         try:
             job_db.rollback()
             job = job_db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
@@ -247,11 +256,11 @@ def process_vm_creation_job(job_id: str) -> None:
                 job.status = VMCreationJobStatus.FAILED.value
                 job.finished_at = now_kst()
                 job.error_message = getattr(exc, "detail", None) or str(exc)
-                job.message = "VM ?앹꽦???ㅽ뙣?덉뒿?덈떎."
+                job.message = "VM 생성에 실패했습니다."
                 job_db.commit()
         except Exception:
             job_db.rollback()
-            logger.exception("[vm-queue] ?ㅽ뙣 ?곹깭 湲곕줉 以??ㅻ쪟: %s", job_id)
+            logger.exception("[vm-queue] 실패 상태 기록 중 오류: %s", job_id)
     finally:
         work_db.close()
         job_db.close()
@@ -270,7 +279,7 @@ def _worker_loop() -> None:
             try:
                 process_vm_creation_job(job_id)
             except Exception as exc:
-                logger.exception("[vm-queue] ?뚯빱 猷⑦봽?먯꽌 ?덉쇅 諛쒖깮: %s", exc)
+                logger.exception("[vm-queue] 워커 루프에서 예외 발생: %s", exc)
         finally:
             _vm_creation_queue.task_done()
 
@@ -287,11 +296,11 @@ def start_vm_creation_worker() -> None:
             queued_jobs = _recover_pending_jobs(db)
             if queued_jobs:
                 logger.info(
-                    "[vm-queue] DB?먯꽌 %d媛쒖쓽 ?湲?/?ㅽ뻾 ?묒뾽???먯뿉 ?ъ쟻?ы뻽?듬땲??",
+                    "[vm-queue] DB에서 %d개의 대기/실행 작업을 큐에 적재했습니다",
                     len(queued_jobs),
                 )
         except Exception as exc:
-            logger.exception("[vm-queue] ?湲??묒뾽 ?ъ쟻??以??ㅻ쪟 諛쒖깮: %s", exc)
+            logger.exception("[vm-queue] 대기 작업 적재 중 오류 발생: %s", exc)
         finally:
             db.close()
             db = None
@@ -302,7 +311,7 @@ def start_vm_creation_worker() -> None:
             daemon=True,
         )
         _worker_thread.start()
-        logger.info("[vm-queue] VM ?앹꽦 ?뚯빱 ?쒖옉")
+        logger.info("[vm-queue] VM 생성 워커 시작")
 
 
 def stop_vm_creation_worker() -> None:
@@ -315,6 +324,6 @@ def stop_vm_creation_worker() -> None:
         _worker_thread.join(timeout=5)
         if not _worker_thread.is_alive():
             _worker_thread = None
-            logger.info("[vm-queue] VM ?앹꽦 ?뚯빱 醫낅즺")
+            logger.info("[vm-queue] VM 생성 워커 종료")
         else:
-            logger.warning("[vm-queue] VM ?앹꽦 ?뚯빱媛 ?꾩쭅 ?ㅽ뻾 以묒엯?덈떎 (??꾩븘??.")
+            logger.warning("[vm-queue] VM 생성 워커가 여전히 실행 중입니다 (강제 종료).")

--- a/backend/tests/test_vm_lifecycle.py
+++ b/backend/tests/test_vm_lifecycle.py
@@ -9,6 +9,7 @@ from unittest.mock import patch, MagicMock
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from core.timezone import now_kst
 from core.database import Base
 from models.user import User, UserRole
 from models.server import Server
@@ -21,6 +22,7 @@ from models.vm_creation_job import VmCreationJob
 from services.vm_creation_queue import (
     enqueue_vm_creation,
     get_vm_creation_job,
+    _get_queue_position,
     process_vm_creation_job,
 )
 from services.vm_service import (
@@ -817,3 +819,35 @@ class TestVMCreationQueue:
 
         result_admin = get_vm_creation_job(db=db, job_id=queued.job_id, current_user=admin_user)
         assert result_admin.job_id == queued.job_id
+
+    def test_queue_position_is_deterministic_for_same_timestamp(self, db, user, server):
+        queued_at = now_kst()
+        first_job = VmCreationJob(
+            id="00000000-0000-0000-0000-000000000001",
+            user_id=user.id,
+            status=VMCreationJobStatus.QUEUED.value,
+            tier=VMTier.MICRO.value,
+            os="ubuntu2204",
+            node_name=server.name,
+            requested_name="first",
+            queued_at=queued_at,
+        )
+        first_job.payload = {"tier": VMTier.MICRO.value, "os": "ubuntu2204", "node_name": server.name, "name": "first"}
+
+        second_job = VmCreationJob(
+            id="00000000-0000-0000-0000-000000000002",
+            user_id=user.id,
+            status=VMCreationJobStatus.QUEUED.value,
+            tier=VMTier.MICRO.value,
+            os="ubuntu2204",
+            node_name=server.name,
+            requested_name="second",
+            queued_at=queued_at,
+        )
+        second_job.payload = {"tier": VMTier.MICRO.value, "os": "ubuntu2204", "node_name": server.name, "name": "second"}
+
+        db.add_all([first_job, second_job])
+        db.commit()
+
+        assert _get_queue_position(db, first_job) == 1
+        assert _get_queue_position(db, second_job) == 2

--- a/backend/tests/test_vm_lifecycle.py
+++ b/backend/tests/test_vm_lifecycle.py
@@ -23,6 +23,8 @@ from services.vm_creation_queue import (
     enqueue_vm_creation,
     get_vm_creation_job,
     _get_queue_position,
+    _next_job_id,
+    _recover_pending_jobs,
     process_vm_creation_job,
 )
 from services.vm_service import (
@@ -851,3 +853,49 @@ class TestVMCreationQueue:
 
         assert _get_queue_position(db, first_job) == 1
         assert _get_queue_position(db, second_job) == 2
+
+    def test_next_job_id_is_monotonic(self):
+        first_id = _next_job_id()
+        second_id = _next_job_id()
+
+        assert first_id != second_id
+        assert first_id < second_id
+
+    def test_recover_pending_jobs_requeues_running_jobs(self, db, user, server):
+        queued_job = VmCreationJob(
+            id="00000000-0000-0000-0000-000000000010",
+            user_id=user.id,
+            status=VMCreationJobStatus.QUEUED.value,
+            tier=VMTier.MICRO.value,
+            os="ubuntu2204",
+            node_name=server.name,
+            requested_name="queued",
+            queued_at=now_kst(),
+        )
+        queued_job.payload = {"tier": VMTier.MICRO.value, "os": "ubuntu2204", "node_name": server.name, "name": "queued"}
+
+        running_job = VmCreationJob(
+            id="00000000-0000-0000-0000-000000000011",
+            user_id=user.id,
+            status=VMCreationJobStatus.RUNNING.value,
+            tier=VMTier.MICRO.value,
+            os="ubuntu2204",
+            node_name=server.name,
+            requested_name="running",
+            queued_at=now_kst(),
+            started_at=now_kst(),
+        )
+        running_job.payload = {"tier": VMTier.MICRO.value, "os": "ubuntu2204", "node_name": server.name, "name": "running"}
+
+        db.add_all([queued_job, running_job])
+        db.commit()
+
+        recovered = _recover_pending_jobs(db)
+
+        db.refresh(queued_job)
+        db.refresh(running_job)
+
+        assert [job.id for job in recovered] == [queued_job.id, running_job.id]
+        assert queued_job.status == VMCreationJobStatus.QUEUED.value
+        assert running_job.status == VMCreationJobStatus.QUEUED.value
+        assert running_job.started_at is None

--- a/backend/tests/test_vm_lifecycle.py
+++ b/backend/tests/test_vm_lifecycle.py
@@ -15,8 +15,14 @@ from models.server import Server
 from models.vm import Vm
 from models.vm_port import VmPort
 from models.notification import Notification
-from schemas.vm_schema import VMCreate, VMTier, SnapshotCreateRequest
+from schemas.vm_schema import VMCreate, VMCreationJobStatus, VMTier, SnapshotCreateRequest
 from api.routes.vmcontrol import create_snapshot
+from models.vm_creation_job import VmCreationJob
+from services.vm_creation_queue import (
+    enqueue_vm_creation,
+    get_vm_creation_job,
+    process_vm_creation_job,
+)
 from services.vm_service import (
     create_vm,
     delete_vm,
@@ -764,3 +770,50 @@ class TestSnapshotCreation:
         )
 
         assert result["success"] is True
+
+
+class TestVMCreationQueue:
+    """VM 생성 큐 동작 검증"""
+
+    @patch("services.vm_creation_queue.create_vm")
+    @patch("services.vm_creation_queue.SessionLocal", new=TestSession)
+    def test_enqueue_and_process_job(self, mock_create_vm, db, user, server):
+        vm_config = VMCreate(tier=VMTier.MICRO, node_name=server.name, name="queued-vm")
+
+        queued = enqueue_vm_creation(db=db, current_user=user, vm_config=vm_config)
+        assert queued.status == VMCreationJobStatus.QUEUED
+        assert queued.position == 1
+
+        job = db.query(VmCreationJob).filter(VmCreationJob.id == queued.job_id).first()
+        assert job is not None
+        assert job.status == "queued"
+
+        mock_create_vm.return_value = {
+            "success": True,
+            "message": "VM queued-vm(301)가 노드 'test-node'에 생성되었습니다.",
+            "assigned_node": server.name,
+            "vmid": 301,
+            "name": "queued-vm",
+            "tier": "micro",
+            "internal_ip": "10.0.0.150",
+            "ssh_user": "ubuntu",
+            "ssh_password": "secret",
+        }
+
+        process_vm_creation_job(queued.job_id)
+
+        db.refresh(job)
+        assert job.status == "completed"
+        assert job.vmid == 301
+        assert job.result["vmid"] == 301
+        assert job.message is not None
+
+    def test_job_access_is_owner_only_or_admin(self, db, user, admin_user, server):
+        vm_config = VMCreate(tier=VMTier.MICRO, node_name=server.name, name="owner-vm")
+        queued = enqueue_vm_creation(db=db, current_user=user, vm_config=vm_config)
+
+        result = get_vm_creation_job(db=db, job_id=queued.job_id, current_user=user)
+        assert result.job_id == queued.job_id
+
+        result_admin = get_vm_creation_job(db=db, job_id=queued.job_id, current_user=admin_user)
+        assert result_admin.job_id == queued.job_id

--- a/backend/tests/test_vm_lifecycle.py
+++ b/backend/tests/test_vm_lifecycle.py
@@ -822,6 +822,28 @@ class TestVMCreationQueue:
         result_admin = get_vm_creation_job(db=db, job_id=queued.job_id, current_user=admin_user)
         assert result_admin.job_id == queued.job_id
 
+    def test_job_access_denied_for_other_user(self, db, user, server):
+        """다른 일반 사용자는 타인의 잡에 접근할 수 없다 (404 반환)."""
+        import pytest
+        from fastapi import HTTPException as FastAPIHTTPException
+
+        other_user = User(
+            email="other@gsm.hs.kr",
+            hashed_password="hashed",
+            role=UserRole.USER,
+            is_active=True,
+        )
+        db.add(other_user)
+        db.commit()
+        db.refresh(other_user)
+
+        vm_config = VMCreate(tier=VMTier.MICRO, node_name=server.name, name="private-vm")
+        queued = enqueue_vm_creation(db=db, current_user=user, vm_config=vm_config)
+
+        with pytest.raises(FastAPIHTTPException) as exc_info:
+            get_vm_creation_job(db=db, job_id=queued.job_id, current_user=other_user)
+        assert exc_info.value.status_code == 404
+
     def test_queue_position_is_deterministic_for_same_timestamp(self, db, user, server):
         queued_at = now_kst()
         first_job = VmCreationJob(


### PR DESCRIPTION
## Summary
- **주요 변경**: VM 생성 요청을 즉시 실행하지 않고 큐에 적재한 뒤 백그라운드 워커가 처리하도록 변경
- `backend/services/vm_creation_queue.py`, `backend/models/vm_creation_job.py` 추가로 작업 상태 저장 및 처리 흐름 구현
- `backend/api/routes/vmcontrol.py` 에 `POST /create` 비동기화와 `GET /jobs/{job_id}` 상태 조회 API 추가
- `backend/main.py` 에 워커 시작/종료 훅 연결
- `backend/tests/test_vm_lifecycle.py` 에 큐 enqueue / job 조회 / 처리 테스트 추가

## Test plan
- [x] `python -m compileall backend` 통과
- [x] `python -m pytest backend/tests/test_vm_lifecycle.py -v -k VMCreationQueue` 통과
- [ ] 전체 `backend/tests/test_vm_lifecycle.py` 는 기존 async snapshot 테스트 2개가 현재 환경에서 별도 플러그인 설정 없이 실패