### PR TITLE
feat: 마인크래프트 탐지 hookscript 추가 (예방, 미션 2)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/backend/scripts/hooks/mc-detect-hook.sh
+++ b/backend/scripts/hooks/mc-detect-hook.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+
+VMID="$1" # VMID: Proxmox가 넘긴 대상 VM 번호
+PHASE="$2" # PHASE: 생애주기 단계
+
+if [ -z "$PHASE" ]; then
+    echo "proxmox가 수집한 단계 정보가 없습니다."
+    exit
+fi
+
+if [ "$PHASE" = "post-start" ]; then
+    echo "post-start 상태"
+
+    # guest-agent가 post-start 직후 아직 안 떴을 수 있어 최대 20회 재시도
+    success=false
+
+    for((i=1; i<=20; i++)); do
+        if qm guest cmd "$VMID" ping; then
+            # ping 성공, agent 응답 가능 상태
+
+            result=$(qm guest exec "$VMID" -- sh -c '
+                for dir in /home /opt /srv /root; do # vm에 folder 있는지 확인
+                    if [ -d "$dir" ]; then
+                        paths="$paths $dir"
+                    fi
+                done
+                # find의 에러는 out-data가 아닌 err-data로 분리되므로 JSON 파싱에 영향 없음. 단, exitcode는 0이 아니게 되므로 없는 경로는 위 -d 검사로 미리 걸러냄
+                find $paths -name "server.properties" -type f # vm에 있는 folder만 조회')
+
+            exitcode=$(echo "$result" | jq -r '.exitcode') # exitcode 검사 후 0 이면, path 검사 진행하는 로직
+
+            if [ "$exitcode" -ne 0 ]; then
+                echo "검사 실패 (exitcode: $exitcode)"
+                exit
+            fi
+
+            path=$(echo "$result" | jq -r '.["out-data"] // ""') # jq Null check
+
+            if [ -n "$path" ]; then
+                echo "발견 : '$VMID' 에 마인크래프트 서버가 발견되었습니다."
+                # discord 웹훅으로 알림 기능 확장
+            fi
+            success=true
+            break # 검사 완료 및 loop 탈출
+        fi
+        sleep 5 # agent 부팅 대기 후 다음 시도
+    done
+
+    if [ "$success" = false ]; then
+        echo "agent 부팅 실패"
+        exit
+    fi
+
+fi


### PR DESCRIPTION
## 목적
학생이 gsmsv 플랫폼으로 생성한 VM에서 무단 마인크래프트 서버가 켜지는 것을
예방하기 위한 hookscript 추가 (미션 2 — 예방).

## 이 PR의 범위 (Draft)
- `backend/scripts/hooks/mc-detect-hook.sh` — post-start 단계에서 guest exec로
  VM 내부를 검사하는 후크 본체 추가 (실행권한 755 기록).
- `.gitattributes` — `.sh` 파일 LF 고정 (CRLF로 커밋돼 호스트에서 깨지는 것 방지).

## 동작 / 설계 근거
- **post-start 단계에서만 동작**: VM이 켜지는 이벤트 시점에만 검사
  (꺼진 VM 전수조사는 무거워서 "쓰려면 켜야 한다"를 역이용).
- **guest-agent 부팅 재시도(최대 20회 × 5s)**: post-start 직후엔 agent가
  아직 안 떠서 ping 실패할 수 있어 재시도 루프로 대기.
- **경로 스코프 검사**: `/home /opt /srv /root` 중 존재하는 디렉터리만 find
  대상에 넣어 exitcode 오염 방지.
- **out-data null 방어**: find 결과가 없으면 Proxmox가 out-data 키를 생략 →
  jq가 "null" 문자열을 반환해 오탐하던 문제를 `// ""`로 방어.

## 아직 안 된 것 (WIP — 이번 PR 범위 밖)
- [ ] `backend/services/vm_service.py`에서 clone 직후 config에 hookscript를
      주입하는 코드 — 후크만 있고 아직 VM에 자동 부착 안 됨.
- [ ] 탐지 시 알림 — 현재는 로그 echo만. 레포에 이미 있는 Discord 웹훅 인프라
      재사용 검토.
- [ ] 검사 정확도 강화: 단일 신호(파일 존재) → server.properties 내용 기반
      조합 판정(포트 + 월드 폴더)으로 개선 검토 중.

## 미결 / 리뷰 요청
- 미션 1 방향 A(켜진 VM만 탐지) vs B(꺼진 것까지 전수) 결정 대기.
- 검사 신호를 server.properties로 갈지 world 폴더 세트로 갈지 피드백 요청.

## 테스트
- 실제 Proxmox 호스트에서 미검증. 로직/문법 리뷰 우선.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
