### PR TITLE
Feat/mc detect hookscript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/backend/scripts/hooks/mc-detect-hook.sh
+++ b/backend/scripts/hooks/mc-detect-hook.sh
@@ -3,19 +3,21 @@
 
 VMID="$1" # VMID: Proxmox가 넘긴 대상 VM 번호
 PHASE="$2" # PHASE: 생애주기 단계
+MAX_RETRIES=10 # MAX_RETRIES: for문 횟수 상수
+SLEEP_SEC=5 # SLEEP_SEC: for문 대기 시간 상수
 
 if [ -z "$PHASE" ]; then
     echo "proxmox가 수집한 단계 정보가 없습니다."
     exit
 fi
 
-if [ "$PHASE" = "post-start" ]; then 
+if [ "$PHASE" = "post-start" ]; then
     echo "post-start 상태"
 
-    # guest-agent가 post-start 직후 아직 안 떴을 수 있어 최대 50회 재시도
+    # guest-agent가 post-start 직후 아직 안 떴을 수 있어 최대 10회 재시도
     success=false
 
-    for((i=1; i<=20; i++)); do
+    for((i=1; i<=MAX_RETRIES; i++)); do
         if qm guest cmd "$VMID" ping; then
             # ping 성공, agent 응답 가능 상태
             
@@ -44,7 +46,7 @@ if [ "$PHASE" = "post-start" ]; then
             success=true
             break # 검사 완료 및 loop 탈출
         fi
-        sleep 5 # agent 부팅 대기 후 다음 시도
+        sleep "$SLEEP_SEC" # agent 부팅 대기 후 다음 시도
     done
 
     if [ "$success" = false ]; then

--- a/backend/scripts/hooks/mc-detect-hook.sh
+++ b/backend/scripts/hooks/mc-detect-hook.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
+set -uo pipefail
 
-# hookscript 
+# hookscript
 VMID="$1" # VMID: Proxmox가 넘긴 대상 VM 번호
 PHASE="$2" # PHASE: 생애주기 단계
 MAX_RETRIES=10 # MAX_RETRIES: for문 횟수 상수
 SLEEP_SEC=5 # SLEEP_SEC: for문 대기 시간 상수
+
 
 if [ -z "$PHASE" ]; then
     echo "proxmox가 수집한 단계 정보가 없습니다."
@@ -12,6 +14,13 @@ if [ -z "$PHASE" ]; then
 fi
 
 if [ "$PHASE" = "post-start" ]; then
+    WEBHOOK_URL=$(cat /etc/mc-detect/webhook 2>/dev/null)
+    message="$VMID 에서 마인크래프트 서버가 발견되었습니다"
+
+    if [ -z "$WEBHOOK_URL" ]; then
+        echo "WEBHOOK URL이 NULL 이거나 문자열의 길이가 0 입니다."
+        exit 0
+    fi
     echo "post-start 상태"
 
     # guest-agent가 post-start 직후 아직 안 떴을 수 있어 최대 10회 재시도
@@ -35,8 +44,6 @@ if [ "$PHASE" = "post-start" ]; then
                         echo "검사 할 폴더가 없습니다." >&2 # stderr로 전송
                         exit 0
                 fi
-                
-                # find의 에러는 out-data가 아닌 err-data로 분리되므로 JSON 파싱에 영향 없음. 단, exitcode는 0이 아니게 되므로 없는 경로는 위 -d 검사로 미리 걸러냄
                 ')
             
             exitcode=$(echo "$result" | jq -r '.exitcode') # exitcode 검사 후 0 이면, path 검사 진행하는 로직
@@ -49,11 +56,17 @@ if [ "$PHASE" = "post-start" ]; then
             path=$(echo "$result" | jq -r '.["out-data"] // ""') # jq Null check
 
             if [ -n "$path" ]; then
-                echo "발견 : '$VMID' 에 마인크래프트 서버가 발견되었습니다."
-                # discord 웹훅으로 알림 기능 확장
+                payload=$(jq -n --arg content "$message" '{content: $content}')
+                if curl --max-time 5 --fail -s -o /dev/null -H "Content-Type: application/json" -d "$payload" "$WEBHOOK_URL"; then
+                    echo "성공"
+                else
+                    echo "실패"
+                fi
             fi
+
+            # agent 응답 + 검사 완료(발견 여부 무관) 시점에 loop 탈출
             success=true
-            break # 검사 완료 및 loop 탈출
+            break
         fi
         sleep "$SLEEP_SEC" # agent 부팅 대기 후 다음 시도
     done

--- a/backend/scripts/hooks/mc-detect-hook.sh
+++ b/backend/scripts/hooks/mc-detect-hook.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+
+VMID="$1" # VMID: Proxmox가 넘긴 대상 VM 번호
+PHASE="$2" # PHASE: 생애주기 단계
+
+if [ -z "$PHASE" ]; then
+    echo "proxmox가 수집한 단계 정보가 없습니다."
+    exit
+fi
+
+if [ "$PHASE" = "post-start" ]; then 
+    echo "post-start 상태"
+
+    # guest-agent가 post-start 직후 아직 안 떴을 수 있어 최대 50회 재시도
+    success=false
+
+    for((i=1; i<=20; i++)); do
+        if qm guest cmd "$VMID" ping; then
+            # ping 성공, agent 응답 가능 상태
+            
+            result=$(qm guest exec "$VMID" -- sh -c '
+                for dir in /home /opt /srv /root; do # vm에 folder 있는지 확인
+                    if [ -d "$dir" ]; then
+                        paths="$paths $dir"
+                    fi
+                done
+                # find의 에러는 out-data가 아닌 err-data로 분리되므로 JSON 파싱에 영향 없음. 단, exitcode는 0이 아니게 되므로 없는 경로는 위 -d 검사로 미리 걸러냄
+                find $paths -name "server.properties" -type f # vm에 있는 folder만 조회')
+            
+            exitcode=$(echo "$result" | jq -r '.exitcode') # exitcode 검사 후 0 이면, path 검사 진행하는 로직
+
+            if [ "$exitcode" -ne 0 ]; then
+                echo "검사 실패 (exitcode: $exitcode)"
+                exit 
+            fi
+
+            path=$(echo "$result" | jq -r '.["out-data"] // ""') # jq Null check
+
+            if [ -n "$path" ]; then
+                echo "발견 : '$VMID' 에 마인크래프트 서버가 발견되었습니다."
+                # discord 웹훅으로 알림 기능 확장
+            fi
+            success=true
+            break # 검사 완료 및 loop 탈출
+        fi
+        sleep 5 # agent 부팅 대기 후 다음 시도
+    done
+
+    if [ "$success" = false ]; then
+        echo "agent 부팅 실패"
+        exit
+    fi 
+
+fi

--- a/backend/scripts/hooks/mc-detect-hook.sh
+++ b/backend/scripts/hooks/mc-detect-hook.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-
+# hookscript 
 VMID="$1" # VMID: Proxmox가 넘긴 대상 VM 번호
 PHASE="$2" # PHASE: 생애주기 단계
 MAX_RETRIES=10 # MAX_RETRIES: for문 횟수 상수
@@ -8,7 +8,7 @@ SLEEP_SEC=5 # SLEEP_SEC: for문 대기 시간 상수
 
 if [ -z "$PHASE" ]; then
     echo "proxmox가 수집한 단계 정보가 없습니다."
-    exit
+    exit 0
 fi
 
 if [ "$PHASE" = "post-start" ]; then
@@ -22,19 +22,28 @@ if [ "$PHASE" = "post-start" ]; then
             # ping 성공, agent 응답 가능 상태
             
             result=$(qm guest exec "$VMID" -- sh -c '
+                paths=""
                 for dir in /home /opt /srv /root; do # vm에 folder 있는지 확인
                     if [ -d "$dir" ]; then
                         paths="$paths $dir"
                     fi
                 done
+
+                if [ -n "$paths" ]; then
+                        find $paths -name "server.properties" -type f
+                    else
+                        echo "검사 할 폴더가 없습니다." >&2 # stderr로 전송
+                        exit 0
+                fi
+                
                 # find의 에러는 out-data가 아닌 err-data로 분리되므로 JSON 파싱에 영향 없음. 단, exitcode는 0이 아니게 되므로 없는 경로는 위 -d 검사로 미리 걸러냄
-                find $paths -name "server.properties" -type f # vm에 있는 folder만 조회')
+                ')
             
             exitcode=$(echo "$result" | jq -r '.exitcode') # exitcode 검사 후 0 이면, path 검사 진행하는 로직
 
-            if [ "$exitcode" -ne 0 ]; then
+            if [ "$exitcode" != "0" ]; then # -ne 0는 result가 비정상 json일 때 interger expression ecpected error 발생
                 echo "검사 실패 (exitcode: $exitcode)"
-                exit 
+                exit 0 # proxmox 기준 검사는 실패했지만, vm은 동작하기 때문에 exitcode는 0
             fi
 
             path=$(echo "$result" | jq -r '.["out-data"] // ""') # jq Null check
@@ -51,7 +60,6 @@ if [ "$PHASE" = "post-start" ]; then
 
     if [ "$success" = false ]; then
         echo "agent 부팅 실패"
-        exit
+        exit 0 # proxmox 기준 검사는 실패했지만, vm은 동작하기 때문에 exitcode는 0
     fi 
-
 fi

--- a/backend/scripts/hooks/mc-detect-hook.sh
+++ b/backend/scripts/hooks/mc-detect-hook.sh
@@ -17,7 +17,7 @@ if [ "$PHASE" = "post-start" ]; then
     # guest-agent가 post-start 직후 아직 안 떴을 수 있어 최대 10회 재시도
     success=false
 
-    for((i=1; i<=MAX_RETRIES; i++)); do
+    for((i=1; i<=$MAX_RETRIES; i++)); do
         if qm guest cmd "$VMID" ping; then
             # ping 성공, agent 응답 가능 상태
             

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -6,6 +6,7 @@ import time
 import threading
 import paramiko
 from datetime import timedelta
+from pathlib import Path
 from core.timezone import now_kst
 
 from fastapi import HTTPException, status
@@ -134,6 +135,11 @@ def _allocate_internal_ip(db: Session) -> str:
 
 SNIPPETS_DIR = "/var/lib/vz/snippets"
 
+# mc-detect hookscript (학생 VM 마인크래프트 서버 탐지) — 모든 VM이 공유하는 고정 스크립트
+_HOOK_SCRIPT_NAME = "mc-detect-hook.sh"
+_HOOK_SCRIPT_LOCAL = Path(__file__).resolve().parent.parent / "scripts" / "hooks" / _HOOK_SCRIPT_NAME
+_HOOK_SCRIPT_STORAGE = f"local:snippets/{_HOOK_SCRIPT_NAME}"
+
 
 def _cleanup_vm_db_record(db: Session, vm: Vm) -> None:
     """조기 커밋된 VM 레코드와 연관 VmPort를 삭제합니다. 실패 시 경고 로깅."""
@@ -229,6 +235,47 @@ def _delete_snippet(server: Server, filename: str):
     except Exception as e:
         logger.warning(f"스니펫 삭제 실패 (무시): {e}")
     finally:
+        ssh.close()
+
+
+def _ensure_hook_script(server: Server) -> None:
+    """Proxmox 노드에 mc-detect hookscript가 없으면 업로드하고 실행권한(+x)을 부여합니다.
+
+    모든 VM이 공유하는 고정 스크립트이므로 이미 존재하면 아무것도 하지 않습니다(멱등).
+    """
+    if not server.ssh_user:
+        raise RuntimeError(f"서버 {server.name}에 SSH 계정이 설정되지 않았습니다.")
+
+    remote_path = f"{SNIPPETS_DIR}/{_HOOK_SCRIPT_NAME}"
+
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.WarningPolicy())
+    sftp = None
+    try:
+        ssh.connect(
+            hostname=server.ip_address,
+            port=server.ssh_port or 22,
+            username=server.ssh_user,
+            password=server.ssh_password,
+            timeout=10,
+        )
+        sftp = ssh.open_sftp()
+        sftp.get_channel().settimeout(15)  # SFTP 작업 타임아웃
+        try:
+            sftp.stat(remote_path)
+            return  # 이미 존재 → skip (finally에서 연결 정리)
+        except FileNotFoundError:
+            pass  # 파일 없음(ENOENT) → 아래에서 업로드. 권한 등 다른 오류는 전파
+
+        # Windows 작업 환경의 CRLF가 섞이면 리눅스 bash가 깨지므로 LF로 정규화
+        content = _HOOK_SCRIPT_LOCAL.read_text(encoding="utf-8").replace("\r\n", "\n")
+        with sftp.file(remote_path, "w") as f:
+            f.write(content)
+        sftp.chmod(remote_path, 0o755)  # 실행 권한 필수 — 없으면 Proxmox가 훅 무시
+        logger.info(f"mc-detect hookscript 업로드 완료: {server.name}:{remote_path}")
+    finally:
+        if sftp is not None:
+            sftp.close()
         ssh.close()
 
 
@@ -504,6 +551,14 @@ def create_vm(
         if not manage_iptables(server, vmid, internal_ip, action="ADD"):
             raise RuntimeError("iptables 포트포워딩 등록에 실패했습니다.")
         iptables_added = True
+
+        # 8-1. 학생(USER) VM만 mc-detect hookscript 등록 (best-effort — 실패해도 생성 계속)
+        if current_user.role == UserRole.USER:
+            try:
+                _ensure_hook_script(server)
+                proxmox.nodes(server.name).qemu(vmid).config.put(hookscript=_HOOK_SCRIPT_STORAGE)
+            except Exception as e:
+                logger.warning(f"VM {vmid} mc-detect hookscript 등록 실패 (무시): {e}")
 
         # 9. VM 부팅
         proxmox.nodes(server.name).qemu(vmid).status.start.post()

--- a/backend/tests/test_vm_lifecycle.py
+++ b/backend/tests/test_vm_lifecycle.py
@@ -32,6 +32,8 @@ from services.vm_service import (
     delete_vm,
     _allocate_internal_ip,
     _get_next_vmid,
+    _ensure_hook_script,
+    _HOOK_SCRIPT_STORAGE,
 )
 from services.network_service import calculate_ports, manage_iptables
 from services.mon_service import update_server_stats
@@ -205,6 +207,7 @@ class TestIPExhaustion:
 class TestVMCreationCleanup:
     """VM-TC-04/05: VM 생성 중 실패 시 Proxmox VM + iptables 정리"""
 
+    @patch("services.vm_service._ensure_hook_script")
     @patch("services.vm_service._delete_snippet")
     @patch("services.vm_service._upload_snippet")
     @patch("services.vm_service.manage_iptables", return_value=True)
@@ -212,7 +215,7 @@ class TestVMCreationCleanup:
     @patch("services.vm_service._allocate_internal_ip", return_value="10.0.0.100")
     def test_boot_failure_triggers_cleanup(
         self, mock_alloc, mock_proxmox_fn, mock_iptables,
-        mock_upload, mock_del_snippet, db, user, server
+        mock_upload, mock_del_snippet, mock_ensure_hook, db, user, server
     ):
         """VM-TC-04: 부팅 실패 시 Proxmox 삭제 + iptables DELETE + DB 롤백"""
         proxmox = _make_mock_proxmox(200)
@@ -437,6 +440,7 @@ class TestVMCountLimit:
 class TestVMCreationHappyPath:
     """VM-TC-13: 정상 경로 VM 생성"""
 
+    @patch("services.vm_service._ensure_hook_script")
     @patch("services.vm_service._delete_snippet")
     @patch("services.vm_service._upload_snippet")
     @patch("services.vm_service.manage_iptables", return_value=True)
@@ -444,7 +448,7 @@ class TestVMCreationHappyPath:
     @patch("services.vm_service._allocate_internal_ip", return_value="10.0.0.100")
     def test_create_vm_returns_expected_fields(
         self, mock_alloc, mock_proxmox_fn, mock_iptables,
-        mock_upload, mock_del_snippet, db, user, server
+        mock_upload, mock_del_snippet, mock_ensure_hook, db, user, server
     ):
         """생성 결과에 vmid, name, internal_ip, ssh 자격증명 포함"""
         proxmox = _make_mock_proxmox(200)
@@ -471,6 +475,99 @@ class TestVMCreationHappyPath:
             Notification.type == "success",
         ).first()
         assert notif is not None
+
+
+# ── mc-detect hookscript 자동 주입 ────────────────────────────
+
+class TestMcDetectHookScript:
+    """USER VM 생성 시 mc-detect hookscript 노드 배치(_ensure_hook_script) + 등록"""
+
+    def _mock_server(self):
+        s = MagicMock()
+        s.name = "test-node"
+        s.ip_address = "192.168.1.10"
+        s.ssh_port = 22
+        s.ssh_user = "root"
+        s.ssh_password = "sshpass"
+        return s
+
+    @patch("services.vm_service.paramiko.SSHClient")
+    def test_ensure_skips_when_script_exists(self, mock_ssh_class):
+        """이미 존재(stat 성공)하면 업로드/실행권한 설정 생략 (멱등)"""
+        mock_ssh = MagicMock()
+        mock_ssh_class.return_value = mock_ssh
+        sftp = mock_ssh.open_sftp.return_value
+        sftp.stat.return_value = MagicMock()  # 파일 존재 → 예외 없음
+
+        _ensure_hook_script(self._mock_server())
+
+        sftp.file.assert_not_called()
+        sftp.chmod.assert_not_called()
+
+    @patch("services.vm_service._HOOK_SCRIPT_LOCAL")
+    @patch("services.vm_service.paramiko.SSHClient")
+    def test_ensure_uploads_and_chmods_when_missing(self, mock_ssh_class, mock_local):
+        """없으면(stat FileNotFoundError) 업로드 + chmod 0o755"""
+        mock_local.read_text.return_value = "#!/bin/bash\necho hi\n"
+        mock_ssh = MagicMock()
+        mock_ssh_class.return_value = mock_ssh
+        sftp = mock_ssh.open_sftp.return_value
+        sftp.stat.side_effect = FileNotFoundError()
+
+        _ensure_hook_script(self._mock_server())
+
+        sftp.file.assert_called_once()               # 업로드 발생
+        sftp.chmod.assert_called_once()              # 실행권한 부여
+        assert sftp.chmod.call_args.args[1] == 0o755
+
+    def test_ensure_raises_without_ssh_user(self):
+        """SSH 계정 미설정 시 RuntimeError"""
+        s = self._mock_server()
+        s.ssh_user = None
+        with pytest.raises(RuntimeError):
+            _ensure_hook_script(s)
+
+    @patch("services.vm_service._ensure_hook_script")
+    @patch("services.vm_service._delete_snippet")
+    @patch("services.vm_service._upload_snippet")
+    @patch("services.vm_service.manage_iptables", return_value=True)
+    @patch("services.vm_service.get_proxmox_for_server")
+    @patch("services.vm_service._allocate_internal_ip", return_value="10.0.0.100")
+    def test_hookscript_registered_for_user_vm(
+        self, mock_alloc, mock_proxmox_fn, mock_iptables,
+        mock_upload, mock_del_snippet, mock_ensure_hook, db, user, server
+    ):
+        """USER VM: _ensure_hook_script 호출 + config.put(hookscript=...) 등록"""
+        proxmox = _make_mock_proxmox(200)
+        mock_proxmox_fn.return_value = proxmox
+
+        create_vm(db, user, VMTier.MICRO, node_name="test-node")
+
+        mock_ensure_hook.assert_called_once()
+        put_calls = proxmox.nodes.return_value.qemu.return_value.config.put.call_args_list
+        assert any(c.kwargs.get("hookscript") == _HOOK_SCRIPT_STORAGE for c in put_calls), \
+            "USER VM엔 hookscript가 등록되어야 합니다"
+
+    @patch("services.vm_service._ensure_hook_script")
+    @patch("services.vm_service._delete_snippet")
+    @patch("services.vm_service._upload_snippet")
+    @patch("services.vm_service.manage_iptables", return_value=True)
+    @patch("services.vm_service.get_proxmox_for_server")
+    @patch("services.vm_service._allocate_internal_ip", return_value="10.0.0.100")
+    def test_hookscript_not_registered_for_admin_vm(
+        self, mock_alloc, mock_proxmox_fn, mock_iptables,
+        mock_upload, mock_del_snippet, mock_ensure_hook, db, admin_user, server
+    ):
+        """ADMIN VM: 훅 미등록 (_ensure_hook_script 미호출, hookscript 미등록)"""
+        proxmox = _make_mock_proxmox(200)
+        mock_proxmox_fn.return_value = proxmox
+
+        create_vm(db, admin_user, VMTier.MICRO, node_name="test-node")
+
+        mock_ensure_hook.assert_not_called()
+        put_calls = proxmox.nodes.return_value.qemu.return_value.config.put.call_args_list
+        assert all(c.kwargs.get("hookscript") is None for c in put_calls), \
+            "ADMIN VM엔 hookscript가 등록되지 않아야 합니다"
 
 
 # ── VM-TC-14: 정상 VM 삭제 흐름 ──────────────────────────────


### PR DESCRIPTION
## 개요
Proxmox VM에서 minecraft server를 탐지하는 hookscript.
post-start 시 자동 실행되어 server.properties 존재를 검사.

## 동작 방식
1. post-start 단계에서만 동작
2. guest-agent 준비까지 재시도 (최대 10회, 5초 간격)
3. VM 내부의 존재하는 경로만 골라 find 실행
4. exitcode 검사 후 out-data 파싱 (null check 포함)
5. 마크 발견 시 로그 (웹훅 알림 예정)

## 의존성
- qemu-guest-agent (VM)
- jq (host)

## 남은 작업 (draft 사유)
- [x] result 비정상 시 exitcode/paths 가드
- [x] Discord 웹훅 알림
- [x] backend VM 생성 코드에 hookscript 자동 주입
- [ ] 테스트 환경 검증

Closes #149