### PR TITLE
feat: VM 만료 삭제 3일 유예 기간 추가

### DIFF
--- a/backend/api/routes/vmcontrol.py
+++ b/backend/api/routes/vmcontrol.py
@@ -451,6 +451,19 @@ async def control_vm(
 ):
     """VM 전원 제어 (시작/중지/재시작) — 소유자 또는 관리자만 가능"""
     vm_record = get_vm_with_owner_check(db, vmid, current_user, node)
+
+    # 만료 유예 기간 VM은 시작/재시작 차단 (관리자 제외) — 연장 시 자동 해제
+    if (
+        action.action in ("start", "reboot")
+        and vm_record.expires_at
+        and vm_record.expires_at <= now_kst()
+        and current_user.role != UserRole.ADMIN
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="만료된 VM은 시작할 수 없습니다. 기간 연장 후 이용해주세요.",
+        )
+
     node = vm_record.server.name
     proxmox = get_proxmox_for_server(vm_record.server)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -235,16 +235,27 @@ async def _expire_vms_loop():
                     logger.info(
                         f"[expire] 만료 VM 삭제: {vm.name} (VMID {vm.hypervisor_vmid})"
                     )
-                    # 만료 삭제 알림 생성
+                    # 만료 삭제 알림 생성 (삭제 반복 실패 시 중복 방지)
                     if vm.owner_id:
-                        db.add(
-                            Notification(
-                                user_id=vm.owner_id,
-                                type="error",
-                                message=f"VM '{vm.name}'이(가) 만료되어 자동 삭제되었습니다.",
+                        existing = (
+                            db.query(Notification)
+                            .filter(
+                                Notification.user_id == vm.owner_id,
+                                Notification.message.contains(f"'{vm.name}'"),
+                                Notification.message.contains("자동 삭제되었습니다"),
+                                Notification.created_at >= vm.expires_at,
                             )
+                            .first()
                         )
-                        db.commit()
+                        if not existing:
+                            db.add(
+                                Notification(
+                                    user_id=vm.owner_id,
+                                    type="error",
+                                    message=f"VM '{vm.name}'이(가) 만료되어 자동 삭제되었습니다.",
+                                )
+                            )
+                            db.commit()
                     delete_vm(db, vm, purge=True)
                 except Exception as e:
                     logger.error(f"[expire] VM {vm.hypervisor_vmid} 삭제 실패: {e}")

--- a/backend/main.py
+++ b/backend/main.py
@@ -153,10 +153,11 @@ limiter = Limiter(key_func=get_remote_address)
 
 
 async def _expire_vms_loop():
-    """만료된 VM 삭제 + 만료 임박 알림 + 오래된 알림 정리 (1시간 간격)"""
+    """만료 유예 정지 + 만료 3일 경과 VM 삭제 + 만료 임박 알림 + 오래된 알림 정리 (1시간 간격)"""
     from services.vm_service import delete_vm
-    from datetime import timedelta
+    from services.proxmox_client import get_proxmox_for_server
 
+    EXPIRE_GRACE_DAYS = 3
     consecutive_failures = 0
     while True:
         db = None
@@ -164,12 +165,54 @@ async def _expire_vms_loop():
             db = SessionLocal()
             now = now_kst()
 
-            # 1. 만료된 VM 삭제
-            expired_vms = (
+            # 1. 유예 기간 진입 VM 강제 정지 (만료 ~ 만료+3일)
+            grace_vms = (
                 db.query(Vm)
                 .filter(
                     Vm.expires_at.isnot(None),
                     Vm.expires_at <= now,
+                    Vm.expires_at > now - timedelta(days=EXPIRE_GRACE_DAYS),
+                )
+                .all()
+            )
+
+            for vm in grace_vms:
+                try:
+                    proxmox = get_proxmox_for_server(vm.server)
+                    vmid = vm.hypervisor_vmid
+                    vm_status = proxmox.nodes(vm.server.name).qemu(vmid).status.current.get()
+                    if vm_status.get("status") == "running":
+                        proxmox.nodes(vm.server.name).qemu(vmid).status.stop.post()
+
+                    if vm.owner_id:
+                        existing = (
+                            db.query(Notification)
+                            .filter(
+                                Notification.user_id == vm.owner_id,
+                                Notification.message.contains(vm.name),
+                                Notification.message.contains("3일 후 완전 삭제"),
+                                Notification.created_at >= vm.expires_at,
+                            )
+                            .first()
+                        )
+                        if not existing:
+                            db.add(
+                                Notification(
+                                    user_id=vm.owner_id,
+                                    type="error",
+                                    message=f"VM '{vm.name}'이(가) 만료되어 정지되었습니다. 3일 후 완전 삭제됩니다.",
+                                )
+                            )
+                            db.commit()
+                except Exception as e:
+                    logger.error(f"[expire] VM {vm.hypervisor_vmid} 유예 정지 실패: {e}")
+
+            # 2. 만료 3일 경과 VM 삭제
+            expired_vms = (
+                db.query(Vm)
+                .filter(
+                    Vm.expires_at.isnot(None),
+                    Vm.expires_at <= now - timedelta(days=EXPIRE_GRACE_DAYS),
                 )
                 .all()
             )
@@ -193,7 +236,7 @@ async def _expire_vms_loop():
                 except Exception as e:
                     logger.error(f"[expire] VM {vm.hypervisor_vmid} 삭제 실패: {e}")
 
-            # 2. 만료 임박(15일 이내) VM 알림 (하루 1회)
+            # 3. 만료 임박(15일 이내) VM 알림 (하루 1회)
             soon_vms = (
                 db.query(Vm)
                 .filter(
@@ -230,7 +273,7 @@ async def _expire_vms_loop():
                     )
             db.commit()
 
-            # 3. 15일 지난 알림 자동 삭제
+            # 4. 15일 지난 알림 자동 삭제
             cutoff = now - timedelta(days=15)
             db.query(Notification).filter(
                 Notification.created_at < cutoff,

--- a/backend/main.py
+++ b/backend/main.py
@@ -152,12 +152,64 @@ def _send_admin_expiry_notifications(db, now) -> None:
 limiter = Limiter(key_func=get_remote_address)
 
 
+EXPIRE_GRACE_DAYS = 3
+
+
+def _process_grace_vms(db, now):
+    """만료 유예 기간(만료 ~ +3일) VM 강제 정지 + 유예당 1회 알림."""
+    from services.proxmox_client import get_proxmox_for_server
+
+    grace_vms = (
+        db.query(Vm)
+        .filter(
+            Vm.expires_at.isnot(None),
+            Vm.expires_at <= now,
+            Vm.expires_at > now - timedelta(days=EXPIRE_GRACE_DAYS),
+        )
+        .all()
+    )
+
+    for vm in grace_vms:
+        # 알림은 Proxmox 정지 성공 여부와 무관하게 먼저 발송
+        try:
+            if vm.owner_id:
+                existing = (
+                    db.query(Notification)
+                    .filter(
+                        Notification.user_id == vm.owner_id,
+                        Notification.message.contains(f"'{vm.name}'"),
+                        Notification.message.contains("3일 후 완전 삭제"),
+                        Notification.created_at >= vm.expires_at,
+                    )
+                    .first()
+                )
+                if not existing:
+                    db.add(
+                        Notification(
+                            user_id=vm.owner_id,
+                            type="error",
+                            message=f"VM '{vm.name}'이(가) 만료되어 정지되었습니다. 3일 후 완전 삭제됩니다.",
+                        )
+                    )
+                    db.commit()
+        except Exception as e:
+            db.rollback()
+            logger.error(f"[expire] VM {vm.hypervisor_vmid} 유예 알림 실패: {e}")
+
+        try:
+            proxmox = get_proxmox_for_server(vm.server)
+            vmid = vm.hypervisor_vmid
+            vm_status = proxmox.nodes(vm.server.name).qemu(vmid).status.current.get()
+            if vm_status.get("status") == "running":
+                proxmox.nodes(vm.server.name).qemu(vmid).status.stop.post()
+        except Exception as e:
+            logger.error(f"[expire] VM {vm.hypervisor_vmid} 유예 정지 실패: {e}")
+
+
 async def _expire_vms_loop():
     """만료 유예 정지 + 만료 3일 경과 VM 삭제 + 만료 임박 알림 + 오래된 알림 정리 (1시간 간격)"""
     from services.vm_service import delete_vm
-    from services.proxmox_client import get_proxmox_for_server
 
-    EXPIRE_GRACE_DAYS = 3
     consecutive_failures = 0
     while True:
         db = None
@@ -166,46 +218,7 @@ async def _expire_vms_loop():
             now = now_kst()
 
             # 1. 유예 기간 진입 VM 강제 정지 (만료 ~ 만료+3일)
-            grace_vms = (
-                db.query(Vm)
-                .filter(
-                    Vm.expires_at.isnot(None),
-                    Vm.expires_at <= now,
-                    Vm.expires_at > now - timedelta(days=EXPIRE_GRACE_DAYS),
-                )
-                .all()
-            )
-
-            for vm in grace_vms:
-                try:
-                    proxmox = get_proxmox_for_server(vm.server)
-                    vmid = vm.hypervisor_vmid
-                    vm_status = proxmox.nodes(vm.server.name).qemu(vmid).status.current.get()
-                    if vm_status.get("status") == "running":
-                        proxmox.nodes(vm.server.name).qemu(vmid).status.stop.post()
-
-                    if vm.owner_id:
-                        existing = (
-                            db.query(Notification)
-                            .filter(
-                                Notification.user_id == vm.owner_id,
-                                Notification.message.contains(vm.name),
-                                Notification.message.contains("3일 후 완전 삭제"),
-                                Notification.created_at >= vm.expires_at,
-                            )
-                            .first()
-                        )
-                        if not existing:
-                            db.add(
-                                Notification(
-                                    user_id=vm.owner_id,
-                                    type="error",
-                                    message=f"VM '{vm.name}'이(가) 만료되어 정지되었습니다. 3일 후 완전 삭제됩니다.",
-                                )
-                            )
-                            db.commit()
-                except Exception as e:
-                    logger.error(f"[expire] VM {vm.hypervisor_vmid} 유예 정지 실패: {e}")
+            await asyncio.to_thread(_process_grace_vms, db, now)
 
             # 2. 만료 3일 경과 VM 삭제
             expired_vms = (

--- a/backend/main.py
+++ b/backend/main.py
@@ -177,7 +177,7 @@ def _process_grace_vms(db, now):
                     db.query(Notification)
                     .filter(
                         Notification.user_id == vm.owner_id,
-                        Notification.message.contains(f"'{vm.name}'"),
+                        Notification.message.contains(f"'{vm.name}'", autoescape=True),
                         Notification.message.contains("3일 후 완전 삭제"),
                         Notification.created_at >= vm.expires_at,
                     )
@@ -231,34 +231,25 @@ async def _expire_vms_loop():
             )
 
             for vm in expired_vms:
+                vmid = vm.hypervisor_vmid
+                owner_id = vm.owner_id
+                vm_name = vm.name
                 try:
-                    logger.info(
-                        f"[expire] 만료 VM 삭제: {vm.name} (VMID {vm.hypervisor_vmid})"
-                    )
-                    # 만료 삭제 알림 생성 (삭제 반복 실패 시 중복 방지)
-                    if vm.owner_id:
-                        existing = (
-                            db.query(Notification)
-                            .filter(
-                                Notification.user_id == vm.owner_id,
-                                Notification.message.contains(f"'{vm.name}'"),
-                                Notification.message.contains("자동 삭제되었습니다"),
-                                Notification.created_at >= vm.expires_at,
-                            )
-                            .first()
-                        )
-                        if not existing:
-                            db.add(
-                                Notification(
-                                    user_id=vm.owner_id,
-                                    type="error",
-                                    message=f"VM '{vm.name}'이(가) 만료되어 자동 삭제되었습니다.",
-                                )
-                            )
-                            db.commit()
+                    logger.info(f"[expire] 만료 VM 삭제: {vm_name} (VMID {vmid})")
                     delete_vm(db, vm, purge=True)
+                    # 삭제 성공 후에만 알림 생성 (실패 시 허위 알림 방지)
+                    if owner_id:
+                        db.add(
+                            Notification(
+                                user_id=owner_id,
+                                type="error",
+                                message=f"VM '{vm_name}'이(가) 만료되어 자동 삭제되었습니다.",
+                            )
+                        )
+                        db.commit()
                 except Exception as e:
-                    logger.error(f"[expire] VM {vm.hypervisor_vmid} 삭제 실패: {e}")
+                    db.rollback()
+                    logger.error(f"[expire] VM {vmid} 삭제 실패: {e}")
 
             # 3. 만료 임박(15일 이내) VM 알림 (하루 1회)
             soon_vms = (

--- a/backend/tests/test_background_tasks.py
+++ b/backend/tests/test_background_tasks.py
@@ -2,7 +2,7 @@
 
 import pytest
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -162,9 +162,10 @@ def _make_admin(db, email):
     return u
 
 
-def _make_vm(db, name, server, expires_at):
-    v = Vm(hypervisor_vmid=100, name=name, server_id=server.id,
-           allocated_ram_mb=2048, allocated_cores=2, expires_at=expires_at)
+def _make_vm(db, name, server, expires_at, owner=None, vmid=100):
+    v = Vm(hypervisor_vmid=vmid, name=name, server_id=server.id,
+           allocated_ram_mb=2048, allocated_cores=2, expires_at=expires_at,
+           owner_id=owner.id if owner else None)
     db.add(v)
     db.flush()
     return v
@@ -265,3 +266,146 @@ class TestSendAdminExpiryNotifications:
 
         db.expire_all()
         assert db.query(Notification).filter(Notification.user_id == admin.id).count() == 1
+
+
+def _mock_proxmox(status="running"):
+    m = MagicMock()
+    m.nodes.return_value.qemu.return_value.status.current.get.return_value = {
+        "status": status
+    }
+    return m
+
+
+def _stop_post(m):
+    return m.nodes.return_value.qemu.return_value.status.stop.post
+
+
+class TestProcessGraceVms:
+    """_process_grace_vms 단위 테스트 — 만료 3일 유예 정지 + 알림."""
+
+    def test_grace_vm_stopped_and_notified(self, db):
+        """만료 직후 VM은 삭제 없이 정지되고 '3일 후 완전 삭제' 알림 1건 발송."""
+        from main import _process_grace_vms
+        now = datetime(2026, 5, 26, 12, 0, 0)
+        server = _make_server(db)
+        owner = _make_admin(db, "owner@gsm.hs.kr")
+        _make_vm(db, "grace-vm", server, now - timedelta(hours=1), owner=owner)
+        db.commit()
+
+        proxmox = _mock_proxmox("running")
+        with patch("services.proxmox_client.get_proxmox_for_server", return_value=proxmox):
+            _process_grace_vms(db, now)
+
+        _stop_post(proxmox).assert_called_once()
+        db.expire_all()
+        assert db.query(Vm).count() == 1  # 삭제되지 않음
+        notifs = db.query(Notification).filter(Notification.user_id == owner.id).all()
+        assert len(notifs) == 1
+        assert "3일 후 완전 삭제" in notifs[0].message
+        assert "'grace-vm'" in notifs[0].message
+
+    def test_notification_not_duplicated_on_rerun(self, db):
+        """같은 유예 기간 내 루프 재실행 시 알림이 중복 생성되지 않는다."""
+        from main import _process_grace_vms
+        now = datetime(2026, 5, 26, 12, 0, 0)
+        server = _make_server(db)
+        owner = _make_admin(db, "owner2@gsm.hs.kr")
+        _make_vm(db, "rerun-vm", server, now - timedelta(hours=1), owner=owner)
+        db.commit()
+
+        proxmox = _mock_proxmox("stopped")
+        with patch("services.proxmox_client.get_proxmox_for_server", return_value=proxmox):
+            _process_grace_vms(db, now)
+            _process_grace_vms(db, now + timedelta(hours=1))
+
+        db.expire_all()
+        assert db.query(Notification).filter(Notification.user_id == owner.id).count() == 1
+
+    def test_already_stopped_vm_not_stopped_again(self, db):
+        """이미 정지된 VM에는 stop 호출하지 않는다."""
+        from main import _process_grace_vms
+        now = datetime(2026, 5, 26, 12, 0, 0)
+        server = _make_server(db)
+        owner = _make_admin(db, "owner3@gsm.hs.kr")
+        _make_vm(db, "stopped-vm", server, now - timedelta(hours=1), owner=owner)
+        db.commit()
+
+        proxmox = _mock_proxmox("stopped")
+        with patch("services.proxmox_client.get_proxmox_for_server", return_value=proxmox):
+            _process_grace_vms(db, now)
+
+        _stop_post(proxmox).assert_not_called()
+
+    def test_vm_past_grace_excluded(self, db):
+        """만료 3일 경과 VM은 유예 대상이 아니다 (삭제 단계에서 처리)."""
+        from main import _process_grace_vms
+        now = datetime(2026, 5, 26, 12, 0, 0)
+        server = _make_server(db)
+        owner = _make_admin(db, "owner4@gsm.hs.kr")
+        _make_vm(db, "old-vm", server, now - timedelta(days=3, hours=1), owner=owner)
+        db.commit()
+
+        proxmox = _mock_proxmox("running")
+        with patch("services.proxmox_client.get_proxmox_for_server", return_value=proxmox):
+            _process_grace_vms(db, now)
+
+        _stop_post(proxmox).assert_not_called()
+        assert db.query(Notification).count() == 0
+
+    def test_extended_vm_excluded(self, db):
+        """연장 등으로 expires_at이 미래인 VM은 유예 대상이 아니다."""
+        from main import _process_grace_vms
+        now = datetime(2026, 5, 26, 12, 0, 0)
+        server = _make_server(db)
+        owner = _make_admin(db, "owner5@gsm.hs.kr")
+        _make_vm(db, "future-vm", server, now + timedelta(days=30), owner=owner)
+        db.commit()
+
+        proxmox = _mock_proxmox("running")
+        with patch("services.proxmox_client.get_proxmox_for_server", return_value=proxmox):
+            _process_grace_vms(db, now)
+
+        _stop_post(proxmox).assert_not_called()
+        assert db.query(Notification).count() == 0
+
+    def test_owner_none_stops_without_notification(self, db):
+        """소유자 없는 VM도 정지는 되고 알림만 생략된다."""
+        from main import _process_grace_vms
+        now = datetime(2026, 5, 26, 12, 0, 0)
+        server = _make_server(db)
+        _make_vm(db, "orphan-vm", server, now - timedelta(hours=1))
+        db.commit()
+
+        proxmox = _mock_proxmox("running")
+        with patch("services.proxmox_client.get_proxmox_for_server", return_value=proxmox):
+            _process_grace_vms(db, now)
+
+        _stop_post(proxmox).assert_called_once()
+        assert db.query(Notification).count() == 0
+
+    def test_substring_vm_name_not_suppressed(self, db):
+        """다른 VM('app2') 알림이 있어도 이름이 부분 문자열인 VM('app')의 알림은 발송된다."""
+        from main import _process_grace_vms
+        now = datetime(2026, 5, 26, 12, 0, 0)
+        server = _make_server(db)
+        owner = _make_admin(db, "owner6@gsm.hs.kr")
+        _make_vm(db, "app", server, now - timedelta(hours=1), owner=owner)
+        db.add(Notification(
+            user_id=owner.id,
+            type="error",
+            message="VM 'app2'이(가) 만료되어 정지되었습니다. 3일 후 완전 삭제됩니다.",
+            created_at=now,
+        ))
+        db.commit()
+
+        proxmox = _mock_proxmox("stopped")
+        with patch("services.proxmox_client.get_proxmox_for_server", return_value=proxmox):
+            _process_grace_vms(db, now)
+
+        db.expire_all()
+        assert (
+            db.query(Notification)
+            .filter(Notification.message.contains("'app'"))
+            .count()
+            == 1
+        )


### PR DESCRIPTION
## Summary
- **VM 만료 삭제 3일 유예 기간** 추가 — 만료 즉시 삭제 대신 강제 정지 + 알림, 3일 후 완전 삭제 (연장 시 자동 해제)
- 유예 기간 중 만료 VM **시작/재시작 차단** (관리자 제외, `403`)
- 만료 삭제 알림을 **삭제 성공 후 발송**으로 변경 — 삭제 실패 반복 시 허위 알림 방지 (dedup 조회 불필요해져 제거)
- 유예 알림 dedup `contains()`에 **LIKE 와일드카드 이스케이프** 추가 (`autoescape=True`)

## Test plan
- [x] `pytest tests/test_background_tasks.py` 통과 (20 passed)
- [x] `pytest tests/test_vm_lifecycle.py` 통과 (34 passed)
- [x] main 배포 후 VM 만료 유예 정지 → 3일 후 삭제 스케줄 정상 동작 확인
- [x] 만료 VM 시작 시도 시 403 응답 확인
