### PR TITLE
feat: DevFest 이후 인스턴스 정책 변경 — 티어 개편·유지 7일·사용 목적 필드

### DIFF
--- a/backend/api/routes/vmcontrol.py
+++ b/backend/api/routes/vmcontrol.py
@@ -9,7 +9,7 @@ from core.timezone import now_kst
 from fastapi import APIRouter, HTTPException, status, Depends, Request
 from sqlalchemy import text
 from sqlalchemy.orm import Session
-from schemas.vm_schema import VMAction, VMCreate, VMCreationJobResponse, VMResize, SnapshotCreateRequest
+from schemas.vm_schema import VMAction, VMCreate, VMCreationJobResponse, VMPurposeUpdate, VMResize, SnapshotCreateRequest
 from core.constants import AUTO_SNAP_PREFIX, PROVISIONING_UPTIME_THRESHOLD_SECONDS
 from services.proxmox_client import get_proxmox_for_server, raise_proxmox_http_exception
 from models.server import Server
@@ -168,6 +168,7 @@ async def get_all_vms(
                 "internal_ip": vm.internal_ip,
                 "created_at": str(vm.created_at) if vm.created_at else None,
                 "expires_at": str(vm.expires_at) if vm.expires_at else None,
+                "purpose": vm.purpose,
             }
             try:
                 proxmox = get_proxmox_for_server(server)
@@ -211,6 +212,7 @@ async def get_my_vms(
             "internal_ip": vm.internal_ip,
             "created_at": str(vm.created_at) if vm.created_at else None,
             "expires_at": str(vm.expires_at) if vm.expires_at else None,
+            "purpose": vm.purpose,
         }
         try:
             if vm.server_id not in proxmox_cache:
@@ -284,6 +286,7 @@ async def get_vm_status(
             "vm_password": vm_record.vm_password,
             "created_at": str(vm_record.created_at) if vm_record.created_at else None,
             "expires_at": str(vm_record.expires_at) if vm_record.expires_at else None,
+            "purpose": vm_record.purpose,
             "node": vm_record.server.name,
             "public_ip": vm_record.server.ip_address,
         }
@@ -372,17 +375,17 @@ async def resize_vm(
         raise HTTPException(status_code=400, detail="변경할 값이 없습니다.")
 
     update_params = {}
-    max_memory = 32768  # 32GB
+    max_memory = 16384  # 16GB (PROJECT_CUSTOM 상한)
 
     if body.cores is not None:
-        # cores 값은 총 vCPU 수 (2,4,6,8), 소켓 1 고정 + cores로 조절
-        if body.cores not in (2, 4, 6, 8):
-            raise HTTPException(status_code=400, detail="vCPU는 2, 4, 6, 8 중 선택해주세요.")
+        # cores 값은 총 vCPU 수 (2,4), 소켓 1 고정 + cores로 조절
+        if body.cores not in (2, 4):
+            raise HTTPException(status_code=400, detail="vCPU는 2, 4 중 선택해주세요.")
         update_params["cores"] = body.cores
 
     if body.memory is not None:
         if not (4096 <= body.memory <= max_memory):
-            raise HTTPException(status_code=400, detail=f"RAM은 4096~{max_memory}MB (4~32GB) 범위입니다.")
+            raise HTTPException(status_code=400, detail=f"RAM은 4096~{max_memory}MB (4~16GB) 범위입니다.")
         update_params["memory"] = body.memory
         update_params["balloon"] = body.memory // 2
 
@@ -408,6 +411,23 @@ async def resize_vm(
         raise_proxmox_http_exception(e, default_detail="사양 변경에 실패했습니다.")
 
 
+@router.patch("/{node}/vms/{vmid}/purpose")
+async def update_vm_purpose(
+    node: str,
+    vmid: int,
+    body: VMPurposeUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """VM 사용 목적을 수정합니다. (소유자 또는 관리자)"""
+    vm_record = get_vm_with_owner_check(db, vmid, current_user, node)
+
+    vm_record.purpose = body.purpose
+    db.commit()
+
+    return {"success": True, "purpose": vm_record.purpose}
+
+
 @router.post("/{node}/vms/{vmid}/extend")
 async def extend_vm(
     node: str,
@@ -415,7 +435,7 @@ async def extend_vm(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """VM 만료 기간을 30일 연장합니다. 만료 15일 전부터 가능."""
+    """VM 만료 기간을 14일 연장합니다. 만료 7일 전부터 가능."""
     vm_record = get_vm_with_owner_check(db, vmid, current_user, node)
 
     if not vm_record.expires_at:
@@ -424,18 +444,18 @@ async def extend_vm(
     now = now_kst()
     days_until_expiry = (vm_record.expires_at - now).days
 
-    if days_until_expiry > 15:
+    if days_until_expiry > 7:
         raise HTTPException(
             status_code=400,
-            detail=f"만료 15일 전부터 연장할 수 있습니다. (남은 기간: {days_until_expiry}일)",
+            detail=f"만료 7일 전부터 연장할 수 있습니다. (남은 기간: {days_until_expiry}일)",
         )
 
-    vm_record.expires_at = vm_record.expires_at + timedelta(days=30)
+    vm_record.expires_at = vm_record.expires_at + timedelta(days=14)
     db.commit()
 
     return {
         "success": True,
-        "message": "VM 사용 기간이 30일 연장되었습니다.",
+        "message": "VM 사용 기간이 14일 연장되었습니다.",
         "expires_at": str(vm_record.expires_at),
     }
 

--- a/backend/api/routes/vmcontrol.py
+++ b/backend/api/routes/vmcontrol.py
@@ -9,11 +9,12 @@ from core.timezone import now_kst
 from fastapi import APIRouter, HTTPException, status, Depends, Request
 from sqlalchemy import text
 from sqlalchemy.orm import Session
-from schemas.vm_schema import VMAction, VMCreate, VMResize, SnapshotCreateRequest
+from schemas.vm_schema import VMAction, VMCreate, VMCreationJobResponse, VMResize, SnapshotCreateRequest
 from core.constants import AUTO_SNAP_PREFIX, PROVISIONING_UPTIME_THRESHOLD_SECONDS
 from services.proxmox_client import get_proxmox_for_server, raise_proxmox_http_exception
 from models.server import Server
-from services.vm_service import create_vm, delete_vm
+from services.vm_creation_queue import enqueue_vm_creation, get_vm_creation_job
+from services.vm_service import delete_vm
 from core.database import get_db
 from models.vm import Vm
 from models.user import User, UserRole
@@ -474,7 +475,7 @@ async def control_vm(
         raise_proxmox_http_exception(e, default_detail="서버 오류가 발생했습니다.")
 
 
-@router.post("/create", status_code=status.HTTP_201_CREATED)
+@router.post("/create", status_code=status.HTTP_202_ACCEPTED, response_model=VMCreationJobResponse)
 @limiter.limit("5/minute")
 async def create_vm_endpoint(
     request: Request,
@@ -482,21 +483,21 @@ async def create_vm_endpoint(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """새로운 VM 생성 (Auto-Provisioning 적용)"""
-    return create_vm(
-        db=db,
-        current_user=current_user,
-        tier=vm_config.tier,
-        os=vm_config.os,
-        node_name=vm_config.node_name,
-        name=vm_config.name,
-        custom_cores=vm_config.custom_cores,
-        custom_memory=vm_config.custom_memory,
-        custom_disk=vm_config.custom_disk,
-    )
+    """VM 생성 요청을 큐에 넣는다."""
+    return enqueue_vm_creation(db=db, current_user=current_user, vm_config=vm_config)
 
 
 # ── 스냅샷 관리 ─────────────────────────────────────────────
+
+
+@router.get("/jobs/{job_id}", response_model=VMCreationJobResponse)
+async def get_vm_creation_job_status(
+    job_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """VM 생성 큐 작업 상태를 조회한다."""
+    return get_vm_creation_job(db=db, job_id=job_id, current_user=current_user)
 
 
 @router.get("/{node}/vms/{vmid}/snapshots")

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
     CORS_ORIGINS: List[str] = ["http://localhost:3000", "http://localhost:5173"]
 
     # VM 프로비저닝
-    MAX_VMS_PER_USER: int = 3
+    MAX_VMS_PER_USER: int = 2
     TEMPLATE_VMID: int = 1000                       # Ubuntu 22.04 cloud-init 템플릿
     TEMPLATE_VMID_WINDOWS: int = 1001               # Windows Server 템플릿
     VM_DEFAULT_USER: str = "ubuntu"                  # cloud-init 기본 유저명 (Ubuntu)

--- a/backend/core/constants.py
+++ b/backend/core/constants.py
@@ -2,12 +2,10 @@ from schemas.vm_schema import VMTier
 
 # VM 티어별 리소스 정의
 TIER_SPECS = {
-    VMTier.MICRO:  {"memory": 2048, "cores": 1, "disk": 30},
-    VMTier.SMALL:  {"memory": 4096, "cores": 2, "disk": 40},
-    VMTier.MEDIUM: {"memory": 6144, "cores": 2, "disk": 50},
-    VMTier.LARGE:  {"memory": 8192, "cores": 4, "disk": 50},
-    # 프로젝트 오너 전용 (최대 8 vCPU, 32GB RAM, 70GB SSD)
-    VMTier.PROJECT_CUSTOM: {"memory": 32768, "cores": 8, "disk": 70},
+    VMTier.BASIC:    {"memory": 2048, "cores": 1, "disk": 20},
+    VMTier.STANDARD: {"memory": 4096, "cores": 2, "disk": 20},
+    # 프로젝트 오너 전용 (최대 4 vCPU, 16GB RAM, 50GB SSD)
+    VMTier.PROJECT_CUSTOM: {"memory": 16384, "cores": 4, "disk": 50},
 }
 
 AUTO_SNAP_PREFIX = "auto-daily"

--- a/backend/core/constants.py
+++ b/backend/core/constants.py
@@ -4,8 +4,8 @@ from schemas.vm_schema import VMTier
 TIER_SPECS = {
     VMTier.BASIC:    {"memory": 2048, "cores": 1, "disk": 20},
     VMTier.STANDARD: {"memory": 4096, "cores": 2, "disk": 20},
-    # 프로젝트 오너 전용 (최대 4 vCPU, 16GB RAM, 50GB SSD)
-    VMTier.PROJECT_CUSTOM: {"memory": 16384, "cores": 4, "disk": 50},
+    # 프로젝트 오너 전용 (최대 4 vCPU, 16GB RAM, 40GB SSD)
+    VMTier.PROJECT_CUSTOM: {"memory": 16384, "cores": 4, "disk": 40},
 }
 
 AUTO_SNAP_PREFIX = "auto-daily"

--- a/backend/main.py
+++ b/backend/main.py
@@ -94,13 +94,13 @@ def _notify_admins_background_failure(task_name: str, consecutive_failures: int)
 
 
 def _send_admin_expiry_notifications(db, now) -> None:
-    """7일 이내 만료 VM 목록을 ADMIN 전체에 알림 1개씩 발송."""
+    """3일 이내 만료 VM 목록을 ADMIN 전체에 알림 1개씩 발송."""
     soon_vms = (
         db.query(Vm)
         .filter(
             Vm.expires_at.isnot(None),
             Vm.expires_at > now,
-            Vm.expires_at <= now + timedelta(days=7),
+            Vm.expires_at <= now + timedelta(days=3),
         )
         .all()
     )
@@ -253,13 +253,13 @@ async def _expire_vms_loop():
                     db.rollback()
                     logger.error(f"[expire] VM {vmid} 삭제 실패: {e}")
 
-            # 3. 만료 임박(15일 이내) VM 알림 (하루 1회)
+            # 3. 만료 임박(3일 이내) VM 알림 (하루 1회)
             soon_vms = (
                 db.query(Vm)
                 .filter(
                     Vm.expires_at.isnot(None),
                     Vm.expires_at > now,
-                    Vm.expires_at <= now + timedelta(days=15),
+                    Vm.expires_at <= now + timedelta(days=3),
                 )
                 .all()
             )
@@ -594,7 +594,7 @@ def _collect_discord_daily_report(db, now) -> dict:
         .filter(
             Vm.expires_at.isnot(None),
             Vm.expires_at > now,
-            Vm.expires_at <= now + timedelta(days=7),
+            Vm.expires_at <= now + timedelta(days=3),
         )
         .order_by(Vm.expires_at.asc())
         .all()

--- a/backend/main.py
+++ b/backend/main.py
@@ -33,6 +33,8 @@ from models.notification import Notification
 from models.user import User, UserRole
 from models.server import Server
 from services.mon_service import get_server_resource_usage
+from models.vm_creation_job import VmCreationJob  # noqa: F401
+from services.vm_creation_queue import start_vm_creation_worker, stop_vm_creation_worker
 from models.faq_question import FaqQuestion  # noqa: F401 — create_all 자동 반영
 from models.vm_port import VmPort  # noqa: F401 — create_all 자동 반영
 
@@ -703,6 +705,7 @@ async def lifespan(app: FastAPI):
     expiry_notify_task = asyncio.create_task(_admin_expiry_notify_loop())
     # Discord 일일 모니터링 리포트 (KST DISCORD_DAILY_HOUR시)
     discord_daily_task = asyncio.create_task(_discord_daily_loop())
+    start_vm_creation_worker()
 
     yield
     # ── 종료 시 ──
@@ -712,6 +715,7 @@ async def lifespan(app: FastAPI):
     oauth_cleanup_task.cancel()
     expiry_notify_task.cancel()
     discord_daily_task.cancel()
+    stop_vm_creation_worker()
     await serverless._http_client.aclose()
 
 

--- a/backend/models/vm.py
+++ b/backend/models/vm.py
@@ -46,6 +46,9 @@ class Vm(Base):
 
     # 자동 스냅샷 활성화 여부
     auto_snapshot = Column(Boolean, default=False)
+
+    # 사용 목적 (생성 시 필수 입력, 이후 수정 가능. 기존 VM은 NULL)
+    purpose = Column(String, nullable=True)
     
     # 서버 객체와의 역참조 관계 (ORM을 통해 vm.server 로 해당 서버 정보를 바로 꺼낼 수 있음)
     server = relationship("Server", backref="vms")

--- a/backend/models/vm_creation_job.py
+++ b/backend/models/vm_creation_job.py
@@ -1,0 +1,45 @@
+import json
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+
+from core.database import Base
+from core.timezone import now_kst
+
+
+class VmCreationJob(Base):
+    __tablename__ = "vm_creation_jobs"
+
+    id = Column(String(36), primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    status = Column(String(20), nullable=False, default="queued", index=True)
+    tier = Column(String(32), nullable=False)
+    os = Column(String(32), nullable=False)
+    node_name = Column(String(128), nullable=True, index=True)
+    requested_name = Column(String(128), nullable=True)
+    queued_at = Column(DateTime(timezone=True), default=now_kst, nullable=False)
+    started_at = Column(DateTime(timezone=True), nullable=True)
+    finished_at = Column(DateTime(timezone=True), nullable=True)
+    vmid = Column(Integer, nullable=True, index=True)
+    attempts = Column(Integer, default=0, nullable=False)
+    payload_json = Column(Text, nullable=False)
+    result_json = Column(Text, nullable=True)
+    message = Column(Text, nullable=True)
+    error_message = Column(Text, nullable=True)
+
+    user = relationship("User")
+
+    @property
+    def payload(self) -> dict:
+        return json.loads(self.payload_json) if self.payload_json else {}
+
+    @payload.setter
+    def payload(self, value: dict) -> None:
+        self.payload_json = json.dumps(value, ensure_ascii=False)
+
+    @property
+    def result(self) -> dict | None:
+        return json.loads(self.result_json) if self.result_json else None
+
+    @result.setter
+    def result(self, value: dict | None) -> None:
+        self.result_json = json.dumps(value, ensure_ascii=False, default=str) if value is not None else None

--- a/backend/schemas/vm_schema.py
+++ b/backend/schemas/vm_schema.py
@@ -1,7 +1,9 @@
 import re
-from pydantic import BaseModel, Field, field_validator
-from typing import Optional
+from datetime import datetime
 from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field, field_validator
 
 
 class VMTier(str, Enum):
@@ -9,7 +11,7 @@ class VMTier(str, Enum):
     SMALL = "small"
     MEDIUM = "medium"
     LARGE = "large"
-    # 프로젝트 오너 전용 커스텀 티어
+    # 프로젝트 오너 전용 커스텀 스펙
     PROJECT_CUSTOM = "project_custom"
 
 
@@ -34,8 +36,8 @@ class VMAction(BaseModel):
 class VMResize(BaseModel):
     """VM 사양 변경 요청 모델 (핫플러그)"""
 
-    cores: Optional[int] = None  # vCPU 수
-    memory: Optional[int] = None  # RAM (MB 단위)
+    cores: Optional[int] = None
+    memory: Optional[int] = None
 
 
 class SnapshotCreateRequest(BaseModel):
@@ -44,16 +46,15 @@ class SnapshotCreateRequest(BaseModel):
 
 
 class VMCreate(BaseModel):
-    """VM 생성 요청 모델 — 사용자는 os, tier와 선택적으로 node_name만 입력"""
+    """VM 생성 요청 모델 - 사용자는 os, tier와 선택적으로 node_name만 입력"""
 
     tier: VMTier = VMTier.MICRO
     os: VMOs = VMOs.UBUNTU2204
-    node_name: Optional[str] = None  # 미지정 시 Auto Provisioning
-    name: Optional[str] = None  # 미지정 시 자동 생성
-    # project_custom 전용 커스텀 스펙 (미입력 시 기본값 사용)
-    custom_cores: Optional[int] = None  # vCPU 수 (1~8)
-    custom_memory: Optional[int] = None  # RAM (MB 단위, 1024~32768)
-    custom_disk: Optional[int] = None  # 디스크 (GB 단위, 30~70)
+    node_name: Optional[str] = None
+    name: Optional[str] = None
+    custom_cores: Optional[int] = None
+    custom_memory: Optional[int] = None
+    custom_disk: Optional[int] = None
 
     @field_validator("name")
     @classmethod
@@ -67,3 +68,26 @@ class VMCreate(BaseModel):
                 "VM 이름은 영문·숫자로 시작하고 영문·숫자·하이픈·언더스코어만 허용합니다."
             )
         return v
+
+
+class VMCreationJobStatus(str, Enum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class VMCreationJobResponse(BaseModel):
+    """VM 생성 큐 작업 상태 응답."""
+
+    job_id: str
+    status: VMCreationJobStatus
+    position: Optional[int] = None
+    requested_at: datetime
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    vmid: Optional[int] = None
+    node_name: Optional[str] = None
+    message: Optional[str] = None
+    error_message: Optional[str] = None
+    result: Optional[dict] = None

--- a/backend/schemas/vm_schema.py
+++ b/backend/schemas/vm_schema.py
@@ -46,11 +46,11 @@ class SnapshotCreateRequest(BaseModel):
 
 
 class VMCreate(BaseModel):
-    """VM 생성 요청 모델 - 사용자는 os, tier와 선택적으로 node_name만 입력"""
+    """VM 생성 요청 모델 - 사용자는 os, tier, node_name을 입력 (node_name 필수)"""
 
     tier: VMTier = VMTier.MICRO
     os: VMOs = VMOs.UBUNTU2204
-    node_name: Optional[str] = None
+    node_name: Optional[str] = None  # 큐 경로에서 필수 검증, vm_service 직접 호출 시 None 허용
     name: Optional[str] = None
     custom_cores: Optional[int] = None
     custom_memory: Optional[int] = None

--- a/backend/schemas/vm_schema.py
+++ b/backend/schemas/vm_schema.py
@@ -7,10 +7,8 @@ from pydantic import BaseModel, Field, field_validator
 
 
 class VMTier(str, Enum):
-    MICRO = "micro"
-    SMALL = "small"
-    MEDIUM = "medium"
-    LARGE = "large"
+    BASIC = "basic"
+    STANDARD = "standard"
     # 프로젝트 오너 전용 커스텀 스펙
     PROJECT_CUSTOM = "project_custom"
 
@@ -46,12 +44,13 @@ class SnapshotCreateRequest(BaseModel):
 
 
 class VMCreate(BaseModel):
-    """VM 생성 요청 모델 - 사용자는 os, tier, node_name을 입력 (node_name 필수)"""
+    """VM 생성 요청 모델 - 사용자는 os, tier, node_name, purpose를 입력 (node_name·purpose 필수)"""
 
-    tier: VMTier = VMTier.MICRO
+    tier: VMTier = VMTier.BASIC
     os: VMOs = VMOs.UBUNTU2204
     node_name: Optional[str] = None  # 큐 경로에서 필수 검증, vm_service 직접 호출 시 None 허용
     name: Optional[str] = None
+    purpose: str  # 사용 목적 (모든 역할 필수)
     custom_cores: Optional[int] = None
     custom_memory: Optional[int] = None
     custom_disk: Optional[int] = None
@@ -67,6 +66,32 @@ class VMCreate(BaseModel):
             raise ValueError(
                 "VM 이름은 영문·숫자로 시작하고 영문·숫자·하이픈·언더스코어만 허용합니다."
             )
+        return v
+
+    @field_validator("purpose")
+    @classmethod
+    def validate_purpose(cls, v):
+        v = v.strip()
+        if not v:
+            raise ValueError("사용 목적을 입력해주세요.")
+        if len(v) > 100:
+            raise ValueError("사용 목적은 100자 이하여야 합니다.")
+        return v
+
+
+class VMPurposeUpdate(BaseModel):
+    """VM 사용 목적 수정 요청 모델"""
+
+    purpose: str
+
+    @field_validator("purpose")
+    @classmethod
+    def validate_purpose(cls, v):
+        v = v.strip()
+        if not v:
+            raise ValueError("사용 목적을 입력해주세요.")
+        if len(v) > 100:
+            raise ValueError("사용 목적은 100자 이하여야 합니다.")
         return v
 
 

--- a/backend/services/vm_creation_queue.py
+++ b/backend/services/vm_creation_queue.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import queue
 import threading
@@ -78,15 +77,25 @@ def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMC
 
     if current_user.role == UserRole.USER:
         user_vm_count = db.query(Vm).filter(Vm.owner_id == current_user.id).count()
-        if user_vm_count >= settings.MAX_VMS_PER_USER:
+        active_jobs_count = db.query(VmCreationJob).filter(
+            VmCreationJob.user_id == current_user.id,
+            VmCreationJob.status.in_([
+                VMCreationJobStatus.QUEUED.value,
+                VMCreationJobStatus.RUNNING.value,
+            ]),
+        ).count()
+        if user_vm_count + active_jobs_count >= settings.MAX_VMS_PER_USER:
             raise HTTPException(
                 status_code=409,
-                detail=f"생성 가능한 최대 VM 개수({settings.MAX_VMS_PER_USER}개)를 초과했습니다.",
+                detail=(
+                    "생성 대기/진행 중인 작업을 포함하여 "
+                    f"생성 가능한 최대 VM 개수({settings.MAX_VMS_PER_USER}개)를 초과했습니다."
+                ),
             )
 
     server = (
         db.query(Server)
-        .filter(Server.name == vm_config.node_name, Server.is_active == True)
+        .filter(Server.name == vm_config.node_name, Server.is_active.is_(True))
         .first()
     )
     if not server:
@@ -101,7 +110,6 @@ def enqueue_vm_creation(db: Session, current_user: User, vm_config: VMCreate) ->
     """VM 생성 요청을 큐에 넣고 작업 정보를 반환한다."""
     validate_vm_creation_request(db, current_user, vm_config)
 
-    payload = vm_config.model_dump()
     job = VmCreationJob(
         id=str(uuid4()),
         user_id=current_user.id,
@@ -110,8 +118,8 @@ def enqueue_vm_creation(db: Session, current_user: User, vm_config: VMCreate) ->
         os=vm_config.os.value,
         node_name=vm_config.node_name,
         requested_name=vm_config.name,
-        payload_json=json.dumps(payload, ensure_ascii=False),
     )
+    job.payload = vm_config.model_dump(mode="json")
     db.add(job)
     db.commit()
     db.refresh(job)
@@ -167,11 +175,6 @@ def process_vm_creation_job(job_id: str) -> None:
             custom_disk=payload.get("custom_disk"),
         )
 
-        job = job_db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
-        if not job:
-            logger.warning("[vm-queue] 완료 후 작업을 재조회할 수 없음: %s", job_id)
-            return
-
         job.status = VMCreationJobStatus.COMPLETED.value
         job.finished_at = now_kst()
         job.vmid = result.get("vmid")
@@ -210,7 +213,10 @@ def _worker_loop() -> None:
         try:
             if job_id == _QUEUE_STOP_SENTINEL:
                 return
-            process_vm_creation_job(job_id)
+            try:
+                process_vm_creation_job(job_id)
+            except Exception as exc:
+                logger.exception("[vm-queue] 워커 루프에서 예외 발생: %s", exc)
         finally:
             _vm_creation_queue.task_done()
 
@@ -221,6 +227,28 @@ def start_vm_creation_worker() -> None:
         if _worker_thread and _worker_thread.is_alive():
             return
         _worker_stop_event.clear()
+
+        db = SessionLocal()
+        try:
+            queued_jobs = (
+                db.query(VmCreationJob)
+                .filter(VmCreationJob.status == VMCreationJobStatus.QUEUED.value)
+                .order_by(VmCreationJob.queued_at.asc())
+                .all()
+            )
+            for job in queued_jobs:
+                _vm_creation_queue.put(job.id)
+            if queued_jobs:
+                logger.info(
+                    "[vm-queue] DB에서 %d개의 대기 작업을 큐에 재적재했습니다.",
+                    len(queued_jobs),
+                )
+        except Exception as exc:
+            logger.exception("[vm-queue] 대기 작업 재적재 중 오류 발생: %s", exc)
+        finally:
+            db.close()
+            db = None
+
         _worker_thread = threading.Thread(
             target=_worker_loop,
             name="vm-creation-worker",
@@ -238,5 +266,8 @@ def stop_vm_creation_worker() -> None:
         _worker_stop_event.set()
         _vm_creation_queue.put(_QUEUE_STOP_SENTINEL)
         _worker_thread.join(timeout=5)
-        _worker_thread = None
-        logger.info("[vm-queue] VM 생성 워커 종료")
+        if not _worker_thread.is_alive():
+            _worker_thread = None
+            logger.info("[vm-queue] VM 생성 워커 종료")
+        else:
+            logger.warning("[vm-queue] VM 생성 워커가 아직 실행 중입니다 (타임아웃).")

--- a/backend/services/vm_creation_queue.py
+++ b/backend/services/vm_creation_queue.py
@@ -5,6 +5,7 @@ from typing import Optional
 from uuid import uuid4
 
 from fastapi import HTTPException
+from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
 
 from core.config import settings
@@ -49,7 +50,13 @@ def _get_queue_position(db: Session, job: VmCreationJob) -> int | None:
         db.query(VmCreationJob)
         .filter(
             VmCreationJob.status == VMCreationJobStatus.QUEUED.value,
-            VmCreationJob.queued_at <= job.queued_at,
+            or_(
+                VmCreationJob.queued_at < job.queued_at,
+                and_(
+                    VmCreationJob.queued_at == job.queued_at,
+                    VmCreationJob.id <= job.id,
+                ),
+            ),
         )
         .count()
     )
@@ -144,19 +151,32 @@ def process_vm_creation_job(job_id: str) -> None:
     job_db = SessionLocal()
     work_db = SessionLocal()
     try:
+        claimed_at = now_kst()
+        claimed_rows = (
+            job_db.query(VmCreationJob)
+            .filter(
+                VmCreationJob.id == job_id,
+                VmCreationJob.status == VMCreationJobStatus.QUEUED.value,
+            )
+            .update(
+                {
+                    VmCreationJob.status: VMCreationJobStatus.RUNNING.value,
+                    VmCreationJob.started_at: claimed_at,
+                    VmCreationJob.attempts: VmCreationJob.attempts + 1,
+                },
+                synchronize_session=False,
+            )
+        )
+        if claimed_rows == 0:
+            job_db.rollback()
+            logger.info("[vm-queue] 작업 %s는 이미 다른 워커가 처리했거나 상태가 변경됨", job_id)
+            return
+        job_db.commit()
+
         job = job_db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
         if not job:
             logger.warning("[vm-queue] 작업을 찾을 수 없음: %s", job_id)
             return
-
-        if job.status != VMCreationJobStatus.QUEUED.value:
-            logger.info("[vm-queue] 작업 %s는 이미 처리된 상태(%s)라 건너뜀", job_id, job.status)
-            return
-
-        job.status = VMCreationJobStatus.RUNNING.value
-        job.started_at = now_kst()
-        job.attempts += 1
-        job_db.commit()
 
         payload = job.payload
         user = work_db.query(User).filter(User.id == job.user_id).first()

--- a/backend/services/vm_creation_queue.py
+++ b/backend/services/vm_creation_queue.py
@@ -1,0 +1,242 @@
+import json
+import logging
+import queue
+import threading
+from typing import Optional
+from uuid import uuid4
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from core.config import settings
+from core.database import SessionLocal
+from core.timezone import now_kst
+from models.server import Server
+from models.user import User, UserRole
+from models.vm import Vm
+from models.vm_creation_job import VmCreationJob
+from schemas.vm_schema import VMCreate, VMCreationJobResponse, VMCreationJobStatus, VMOs, VMTier
+from services.vm_service import create_vm
+
+logger = logging.getLogger(__name__)
+
+_QUEUE_STOP_SENTINEL = "__STOP__"
+_vm_creation_queue: "queue.Queue[str]" = queue.Queue()
+_worker_thread: Optional[threading.Thread] = None
+_worker_lock = threading.Lock()
+_worker_stop_event = threading.Event()
+
+
+def _serialize_job(job: VmCreationJob, position: int | None = None) -> VMCreationJobResponse:
+    return VMCreationJobResponse(
+        job_id=job.id,
+        status=VMCreationJobStatus(job.status),
+        position=position,
+        requested_at=job.queued_at,
+        started_at=job.started_at,
+        finished_at=job.finished_at,
+        vmid=job.vmid,
+        node_name=job.node_name,
+        message=job.message,
+        error_message=job.error_message,
+        result=job.result,
+    )
+
+
+def _get_queue_position(db: Session, job: VmCreationJob) -> int | None:
+    if job.status != VMCreationJobStatus.QUEUED.value:
+        return None
+    return (
+        db.query(VmCreationJob)
+        .filter(
+            VmCreationJob.status == VMCreationJobStatus.QUEUED.value,
+            VmCreationJob.queued_at <= job.queued_at,
+        )
+        .count()
+    )
+
+
+def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMCreate) -> Server:
+    """큐에 넣기 전에 최소한의 선검증만 수행한다."""
+    if not vm_config.node_name:
+        raise HTTPException(status_code=400, detail="node_name을 지정해 주세요.")
+
+    if current_user.role == UserRole.USER and vm_config.node_name == settings.PROJECT_NODE_NAME:
+        raise HTTPException(
+            status_code=403,
+            detail="일반 사용자는 프로젝트 전용 노드에 VM을 생성할 수 없습니다.",
+        )
+
+    if vm_config.tier == VMTier.PROJECT_CUSTOM and current_user.role not in (
+        UserRole.ADMIN,
+        UserRole.PROJECT_OWNER,
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="프로젝트 커스텀 티어는 프로젝트 오너만 사용할 수 있습니다.",
+        )
+
+    if current_user.role == UserRole.USER:
+        user_vm_count = db.query(Vm).filter(Vm.owner_id == current_user.id).count()
+        if user_vm_count >= settings.MAX_VMS_PER_USER:
+            raise HTTPException(
+                status_code=409,
+                detail=f"생성 가능한 최대 VM 개수({settings.MAX_VMS_PER_USER}개)를 초과했습니다.",
+            )
+
+    server = (
+        db.query(Server)
+        .filter(Server.name == vm_config.node_name, Server.is_active == True)
+        .first()
+    )
+    if not server:
+        raise HTTPException(
+            status_code=404,
+            detail=f"노드 '{vm_config.node_name}'을(를) 찾을 수 없거나 비활성 상태입니다.",
+        )
+    return server
+
+
+def enqueue_vm_creation(db: Session, current_user: User, vm_config: VMCreate) -> VMCreationJobResponse:
+    """VM 생성 요청을 큐에 넣고 작업 정보를 반환한다."""
+    validate_vm_creation_request(db, current_user, vm_config)
+
+    payload = vm_config.model_dump()
+    job = VmCreationJob(
+        id=str(uuid4()),
+        user_id=current_user.id,
+        status=VMCreationJobStatus.QUEUED.value,
+        tier=vm_config.tier.value,
+        os=vm_config.os.value,
+        node_name=vm_config.node_name,
+        requested_name=vm_config.name,
+        payload_json=json.dumps(payload, ensure_ascii=False),
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    _vm_creation_queue.put(job.id)
+    return _serialize_job(job, position=_get_queue_position(db, job))
+
+
+def get_vm_creation_job(db: Session, job_id: str, current_user: User) -> VMCreationJobResponse:
+    job = db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
+    if not job:
+        raise HTTPException(status_code=404, detail="VM 생성 작업을 찾을 수 없습니다.")
+
+    if current_user.role != UserRole.ADMIN and job.user_id != current_user.id:
+        raise HTTPException(status_code=404, detail="VM 생성 작업을 찾을 수 없습니다.")
+
+    return _serialize_job(job, position=_get_queue_position(db, job))
+
+
+def process_vm_creation_job(job_id: str) -> None:
+    """큐에서 꺼낸 단일 작업을 처리한다."""
+    job_db = SessionLocal()
+    work_db = SessionLocal()
+    try:
+        job = job_db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
+        if not job:
+            logger.warning("[vm-queue] 작업을 찾을 수 없음: %s", job_id)
+            return
+
+        if job.status != VMCreationJobStatus.QUEUED.value:
+            logger.info("[vm-queue] 작업 %s는 이미 처리된 상태(%s)라 건너뜀", job_id, job.status)
+            return
+
+        job.status = VMCreationJobStatus.RUNNING.value
+        job.started_at = now_kst()
+        job.attempts += 1
+        job_db.commit()
+
+        payload = job.payload
+        user = work_db.query(User).filter(User.id == job.user_id).first()
+        if not user:
+            raise HTTPException(status_code=404, detail="작업 소유자를 찾을 수 없습니다.")
+
+        result = create_vm(
+            db=work_db,
+            current_user=user,
+            tier=VMTier(payload["tier"]),
+            os=VMOs(payload["os"]),
+            node_name=payload.get("node_name"),
+            name=payload.get("name"),
+            custom_cores=payload.get("custom_cores"),
+            custom_memory=payload.get("custom_memory"),
+            custom_disk=payload.get("custom_disk"),
+        )
+
+        job = job_db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
+        if not job:
+            logger.warning("[vm-queue] 완료 후 작업을 재조회할 수 없음: %s", job_id)
+            return
+
+        job.status = VMCreationJobStatus.COMPLETED.value
+        job.finished_at = now_kst()
+        job.vmid = result.get("vmid")
+        job.node_name = result.get("assigned_node") or job.node_name
+        job.message = result.get("message")
+        job.result = result
+        job.error_message = None
+        job_db.commit()
+        logger.info("[vm-queue] 작업 완료: %s -> VMID %s", job_id, job.vmid)
+    except Exception as exc:
+        logger.exception("[vm-queue] 작업 실패: %s", job_id)
+        try:
+            job_db.rollback()
+            job = job_db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
+            if job:
+                job.status = VMCreationJobStatus.FAILED.value
+                job.finished_at = now_kst()
+                job.error_message = getattr(exc, "detail", None) or str(exc)
+                job.message = "VM 생성에 실패했습니다."
+                job_db.commit()
+        except Exception:
+            job_db.rollback()
+            logger.exception("[vm-queue] 실패 상태 기록 중 오류: %s", job_id)
+    finally:
+        work_db.close()
+        job_db.close()
+
+
+def _worker_loop() -> None:
+    while not _worker_stop_event.is_set():
+        try:
+            job_id = _vm_creation_queue.get(timeout=1)
+        except queue.Empty:
+            continue
+
+        try:
+            if job_id == _QUEUE_STOP_SENTINEL:
+                return
+            process_vm_creation_job(job_id)
+        finally:
+            _vm_creation_queue.task_done()
+
+
+def start_vm_creation_worker() -> None:
+    global _worker_thread
+    with _worker_lock:
+        if _worker_thread and _worker_thread.is_alive():
+            return
+        _worker_stop_event.clear()
+        _worker_thread = threading.Thread(
+            target=_worker_loop,
+            name="vm-creation-worker",
+            daemon=True,
+        )
+        _worker_thread.start()
+        logger.info("[vm-queue] VM 생성 워커 시작")
+
+
+def stop_vm_creation_worker() -> None:
+    global _worker_thread
+    with _worker_lock:
+        if not _worker_thread or not _worker_thread.is_alive():
+            return
+        _worker_stop_event.set()
+        _vm_creation_queue.put(_QUEUE_STOP_SENTINEL)
+        _worker_thread.join(timeout=5)
+        _worker_thread = None
+        logger.info("[vm-queue] VM 생성 워커 종료")

--- a/backend/services/vm_creation_queue.py
+++ b/backend/services/vm_creation_queue.py
@@ -1,8 +1,10 @@
-import logging
+﻿import logging
+import os
 import queue
+import time
 import threading
+from itertools import count
 from typing import Optional
-from uuid import uuid4
 
 from fastapi import HTTPException
 from sqlalchemy import and_, or_
@@ -25,6 +27,12 @@ _vm_creation_queue: "queue.Queue[str]" = queue.Queue()
 _worker_thread: Optional[threading.Thread] = None
 _worker_lock = threading.Lock()
 _worker_stop_event = threading.Event()
+_job_id_counter = count()
+
+
+def _next_job_id() -> str:
+    """?쒓컙???뺣젹??媛?ν븳 VM ?앹꽦 ?묒뾽 ID瑜?留뚮뱺??"""
+    return f"{time.time_ns():019d}-{os.getpid():05d}-{next(_job_id_counter):06d}"
 
 
 def _serialize_job(job: VmCreationJob, position: int | None = None) -> VMCreationJobResponse:
@@ -62,15 +70,41 @@ def _get_queue_position(db: Session, job: VmCreationJob) -> int | None:
     )
 
 
+def _recover_pending_jobs(db: Session) -> list[VmCreationJob]:
+    """?ъ떆????泥섎━ 以묒씠???묒뾽源뚯? ?ㅼ떆 ?湲곗뿴濡??섎룎由곕떎."""
+    pending_jobs = (
+        db.query(VmCreationJob)
+        .filter(
+            VmCreationJob.status.in_([
+                VMCreationJobStatus.QUEUED.value,
+                VMCreationJobStatus.RUNNING.value,
+            ]),
+        )
+        .order_by(VmCreationJob.queued_at.asc(), VmCreationJob.id.asc())
+        .all()
+    )
+
+    for job in pending_jobs:
+        if job.status == VMCreationJobStatus.RUNNING.value:
+            job.status = VMCreationJobStatus.QUEUED.value
+            job.started_at = None
+        _vm_creation_queue.put(job.id)
+
+    if pending_jobs:
+        db.commit()
+
+    return pending_jobs
+
+
 def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMCreate) -> Server:
-    """큐에 넣기 전에 최소한의 선검증만 수행한다."""
+    """?먯뿉 ?ｊ린 ?꾩뿉 理쒖냼?쒖쓽 ?좉?利앸쭔 ?섑뻾?쒕떎."""
     if not vm_config.node_name:
-        raise HTTPException(status_code=400, detail="node_name을 지정해 주세요.")
+        raise HTTPException(status_code=400, detail="node_name??吏?뺥빐 二쇱꽭??")
 
     if current_user.role == UserRole.USER and vm_config.node_name == settings.PROJECT_NODE_NAME:
         raise HTTPException(
             status_code=403,
-            detail="일반 사용자는 프로젝트 전용 노드에 VM을 생성할 수 없습니다.",
+            detail="?쇰컲 ?ъ슜?먮뒗 ?꾨줈?앺듃 ?꾩슜 ?몃뱶??VM???앹꽦?????놁뒿?덈떎.",
         )
 
     if vm_config.tier == VMTier.PROJECT_CUSTOM and current_user.role not in (
@@ -79,7 +113,7 @@ def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMC
     ):
         raise HTTPException(
             status_code=403,
-            detail="프로젝트 커스텀 티어는 프로젝트 오너만 사용할 수 있습니다.",
+            detail="?꾨줈?앺듃 而ㅼ뒪? ?곗뼱???꾨줈?앺듃 ?ㅻ꼫留??ъ슜?????덉뒿?덈떎.",
         )
 
     if current_user.role == UserRole.USER:
@@ -95,8 +129,8 @@ def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMC
             raise HTTPException(
                 status_code=409,
                 detail=(
-                    "생성 대기/진행 중인 작업을 포함하여 "
-                    f"생성 가능한 최대 VM 개수({settings.MAX_VMS_PER_USER}개)를 초과했습니다."
+                    "?앹꽦 ?湲?吏꾪뻾 以묒씤 ?묒뾽???ы븿?섏뿬 "
+                    f"?앹꽦 媛?ν븳 理쒕? VM 媛쒖닔({settings.MAX_VMS_PER_USER}媛?瑜?珥덇낵?덉뒿?덈떎."
                 ),
             )
 
@@ -108,17 +142,17 @@ def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMC
     if not server:
         raise HTTPException(
             status_code=404,
-            detail=f"노드 '{vm_config.node_name}'을(를) 찾을 수 없거나 비활성 상태입니다.",
+            detail=f"?몃뱶 '{vm_config.node_name}'??瑜? 李얠쓣 ???녾굅??鍮꾪솢???곹깭?낅땲??",
         )
     return server
 
 
 def enqueue_vm_creation(db: Session, current_user: User, vm_config: VMCreate) -> VMCreationJobResponse:
-    """VM 생성 요청을 큐에 넣고 작업 정보를 반환한다."""
+    """VM ?앹꽦 ?붿껌???먯뿉 ?ｊ퀬 ?묒뾽 ?뺣낫瑜?諛섑솚?쒕떎."""
     validate_vm_creation_request(db, current_user, vm_config)
 
     job = VmCreationJob(
-        id=str(uuid4()),
+        id=_next_job_id(),
         user_id=current_user.id,
         status=VMCreationJobStatus.QUEUED.value,
         tier=vm_config.tier.value,
@@ -138,16 +172,16 @@ def enqueue_vm_creation(db: Session, current_user: User, vm_config: VMCreate) ->
 def get_vm_creation_job(db: Session, job_id: str, current_user: User) -> VMCreationJobResponse:
     job = db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
     if not job:
-        raise HTTPException(status_code=404, detail="VM 생성 작업을 찾을 수 없습니다.")
+        raise HTTPException(status_code=404, detail="VM ?앹꽦 ?묒뾽??李얠쓣 ???놁뒿?덈떎.")
 
     if current_user.role != UserRole.ADMIN and job.user_id != current_user.id:
-        raise HTTPException(status_code=404, detail="VM 생성 작업을 찾을 수 없습니다.")
+        raise HTTPException(status_code=404, detail="VM ?앹꽦 ?묒뾽??李얠쓣 ???놁뒿?덈떎.")
 
     return _serialize_job(job, position=_get_queue_position(db, job))
 
 
 def process_vm_creation_job(job_id: str) -> None:
-    """큐에서 꺼낸 단일 작업을 처리한다."""
+    """?먯뿉??爰쇰궦 ?⑥씪 ?묒뾽??泥섎━?쒕떎."""
     job_db = SessionLocal()
     work_db = SessionLocal()
     try:
@@ -169,19 +203,19 @@ def process_vm_creation_job(job_id: str) -> None:
         )
         if claimed_rows == 0:
             job_db.rollback()
-            logger.info("[vm-queue] 작업 %s는 이미 다른 워커가 처리했거나 상태가 변경됨", job_id)
+            logger.info("[vm-queue] ?묒뾽 %s???대? ?ㅻⅨ ?뚯빱媛 泥섎━?덇굅???곹깭媛 蹂寃쎈맖", job_id)
             return
         job_db.commit()
 
         job = job_db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
         if not job:
-            logger.warning("[vm-queue] 작업을 찾을 수 없음: %s", job_id)
+            logger.warning("[vm-queue] ?묒뾽??李얠쓣 ???놁쓬: %s", job_id)
             return
 
         payload = job.payload
         user = work_db.query(User).filter(User.id == job.user_id).first()
         if not user:
-            raise HTTPException(status_code=404, detail="작업 소유자를 찾을 수 없습니다.")
+            raise HTTPException(status_code=404, detail="?묒뾽 ?뚯쑀?먮? 李얠쓣 ???놁뒿?덈떎.")
 
         result = create_vm(
             db=work_db,
@@ -203,9 +237,9 @@ def process_vm_creation_job(job_id: str) -> None:
         job.result = result
         job.error_message = None
         job_db.commit()
-        logger.info("[vm-queue] 작업 완료: %s -> VMID %s", job_id, job.vmid)
+        logger.info("[vm-queue] ?묒뾽 ?꾨즺: %s -> VMID %s", job_id, job.vmid)
     except Exception as exc:
-        logger.exception("[vm-queue] 작업 실패: %s", job_id)
+        logger.exception("[vm-queue] ?묒뾽 ?ㅽ뙣: %s", job_id)
         try:
             job_db.rollback()
             job = job_db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
@@ -213,11 +247,11 @@ def process_vm_creation_job(job_id: str) -> None:
                 job.status = VMCreationJobStatus.FAILED.value
                 job.finished_at = now_kst()
                 job.error_message = getattr(exc, "detail", None) or str(exc)
-                job.message = "VM 생성에 실패했습니다."
+                job.message = "VM ?앹꽦???ㅽ뙣?덉뒿?덈떎."
                 job_db.commit()
         except Exception:
             job_db.rollback()
-            logger.exception("[vm-queue] 실패 상태 기록 중 오류: %s", job_id)
+            logger.exception("[vm-queue] ?ㅽ뙣 ?곹깭 湲곕줉 以??ㅻ쪟: %s", job_id)
     finally:
         work_db.close()
         job_db.close()
@@ -236,7 +270,7 @@ def _worker_loop() -> None:
             try:
                 process_vm_creation_job(job_id)
             except Exception as exc:
-                logger.exception("[vm-queue] 워커 루프에서 예외 발생: %s", exc)
+                logger.exception("[vm-queue] ?뚯빱 猷⑦봽?먯꽌 ?덉쇅 諛쒖깮: %s", exc)
         finally:
             _vm_creation_queue.task_done()
 
@@ -250,21 +284,14 @@ def start_vm_creation_worker() -> None:
 
         db = SessionLocal()
         try:
-            queued_jobs = (
-                db.query(VmCreationJob)
-                .filter(VmCreationJob.status == VMCreationJobStatus.QUEUED.value)
-                .order_by(VmCreationJob.queued_at.asc())
-                .all()
-            )
-            for job in queued_jobs:
-                _vm_creation_queue.put(job.id)
+            queued_jobs = _recover_pending_jobs(db)
             if queued_jobs:
                 logger.info(
-                    "[vm-queue] DB에서 %d개의 대기 작업을 큐에 재적재했습니다.",
+                    "[vm-queue] DB?먯꽌 %d媛쒖쓽 ?湲?/?ㅽ뻾 ?묒뾽???먯뿉 ?ъ쟻?ы뻽?듬땲??",
                     len(queued_jobs),
                 )
         except Exception as exc:
-            logger.exception("[vm-queue] 대기 작업 재적재 중 오류 발생: %s", exc)
+            logger.exception("[vm-queue] ?湲??묒뾽 ?ъ쟻??以??ㅻ쪟 諛쒖깮: %s", exc)
         finally:
             db.close()
             db = None
@@ -275,7 +302,7 @@ def start_vm_creation_worker() -> None:
             daemon=True,
         )
         _worker_thread.start()
-        logger.info("[vm-queue] VM 생성 워커 시작")
+        logger.info("[vm-queue] VM ?앹꽦 ?뚯빱 ?쒖옉")
 
 
 def stop_vm_creation_worker() -> None:
@@ -288,6 +315,6 @@ def stop_vm_creation_worker() -> None:
         _worker_thread.join(timeout=5)
         if not _worker_thread.is_alive():
             _worker_thread = None
-            logger.info("[vm-queue] VM 생성 워커 종료")
+            logger.info("[vm-queue] VM ?앹꽦 ?뚯빱 醫낅즺")
         else:
-            logger.warning("[vm-queue] VM 생성 워커가 아직 실행 중입니다 (타임아웃).")
+            logger.warning("[vm-queue] VM ?앹꽦 ?뚯빱媛 ?꾩쭅 ?ㅽ뻾 以묒엯?덈떎 (??꾩븘??.")

--- a/backend/services/vm_creation_queue.py
+++ b/backend/services/vm_creation_queue.py
@@ -213,7 +213,6 @@ def process_vm_creation_job(job_id: str) -> None:
             logger.warning("[vm-queue] 작업을 찾을 수 없음: %s", job_id)
             return
 
-        # 멱등성 보장: vmid가 이미 설정된 경우 VM이 이미 생성된 것으로 간주
         if job.vmid is not None:
             logger.warning("[vm-queue] 작업 %s에 vmid %s가 이미 설정되어 있음, 중복 생성 방지", job_id, job.vmid)
             job.status = VMCreationJobStatus.COMPLETED.value

--- a/backend/services/vm_creation_queue.py
+++ b/backend/services/vm_creation_queue.py
@@ -235,6 +235,7 @@ def process_vm_creation_job(job_id: str) -> None:
             custom_cores=payload.get("custom_cores"),
             custom_memory=payload.get("custom_memory"),
             custom_disk=payload.get("custom_disk"),
+            purpose=payload.get("purpose"),
         )
 
         job.status = VMCreationJobStatus.COMPLETED.value

--- a/backend/services/vm_creation_queue.py
+++ b/backend/services/vm_creation_queue.py
@@ -1,4 +1,4 @@
-﻿import logging
+import logging
 import os
 import queue
 import time
@@ -31,7 +31,7 @@ _job_id_counter = count()
 
 
 def _next_job_id() -> str:
-    """?쒓컙???뺣젹??媛?ν븳 VM ?앹꽦 ?묒뾽 ID瑜?留뚮뱺??"""
+    """타임스탬프 기반의 유일한 VM 생성 작업 ID를 생성한다."""
     return f"{time.time_ns():019d}-{os.getpid():05d}-{next(_job_id_counter):06d}"
 
 
@@ -71,7 +71,7 @@ def _get_queue_position(db: Session, job: VmCreationJob) -> int | None:
 
 
 def _recover_pending_jobs(db: Session) -> list[VmCreationJob]:
-    """?ъ떆????泥섎━ 以묒씠???묒뾽源뚯? ?ㅼ떆 ?湲곗뿴濡??섎룎由곕떎."""
+    """재시작 후 미처리 상태인 작업들을 다시 큐로 되돌린다."""
     pending_jobs = (
         db.query(VmCreationJob)
         .filter(
@@ -88,6 +88,7 @@ def _recover_pending_jobs(db: Session) -> list[VmCreationJob]:
         if job.status == VMCreationJobStatus.RUNNING.value:
             job.status = VMCreationJobStatus.QUEUED.value
             job.started_at = None
+            job.attempts += 1
         _vm_creation_queue.put(job.id)
 
     if pending_jobs:
@@ -97,14 +98,14 @@ def _recover_pending_jobs(db: Session) -> list[VmCreationJob]:
 
 
 def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMCreate) -> Server:
-    """?먯뿉 ?ｊ린 ?꾩뿉 理쒖냼?쒖쓽 ?좉?利앸쭔 ?섑뻾?쒕떎."""
+    """큐에 넣기 전에 기본적인 유효성 검증을 수행한다."""
     if not vm_config.node_name:
-        raise HTTPException(status_code=400, detail="node_name??吏?뺥빐 二쇱꽭??")
+        raise HTTPException(status_code=400, detail="node_name을 지정해 주세요.")
 
     if current_user.role == UserRole.USER and vm_config.node_name == settings.PROJECT_NODE_NAME:
         raise HTTPException(
             status_code=403,
-            detail="?쇰컲 ?ъ슜?먮뒗 ?꾨줈?앺듃 ?꾩슜 ?몃뱶??VM???앹꽦?????놁뒿?덈떎.",
+            detail="일반 사용자는 프로젝트 전용 노드에 VM을 생성할 수 없습니다.",
         )
 
     if vm_config.tier == VMTier.PROJECT_CUSTOM and current_user.role not in (
@@ -113,7 +114,7 @@ def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMC
     ):
         raise HTTPException(
             status_code=403,
-            detail="?꾨줈?앺듃 而ㅼ뒪? ?곗뼱???꾨줈?앺듃 ?ㅻ꼫留??ъ슜?????덉뒿?덈떎.",
+            detail="프로젝트 티어는 프로젝트 오너만 사용할 수 있습니다.",
         )
 
     if current_user.role == UserRole.USER:
@@ -129,8 +130,8 @@ def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMC
             raise HTTPException(
                 status_code=409,
                 detail=(
-                    "?앹꽦 ?湲?吏꾪뻾 以묒씤 ?묒뾽???ы븿?섏뿬 "
-                    f"?앹꽦 媛?ν븳 理쒕? VM 媛쒖닔({settings.MAX_VMS_PER_USER}媛?瑜?珥덇낵?덉뒿?덈떎."
+                    "생성 대기/실행 중인 작업을 포함하여 "
+                    f"생성 가능한 최대 VM 개수({settings.MAX_VMS_PER_USER}개)를 초과합니다."
                 ),
             )
 
@@ -142,13 +143,13 @@ def validate_vm_creation_request(db: Session, current_user: User, vm_config: VMC
     if not server:
         raise HTTPException(
             status_code=404,
-            detail=f"?몃뱶 '{vm_config.node_name}'??瑜? 李얠쓣 ???녾굅??鍮꾪솢???곹깭?낅땲??",
+            detail=f"노드 '{vm_config.node_name}'을(를) 찾을 수 없거나 비활성 상태입니다.",
         )
     return server
 
 
 def enqueue_vm_creation(db: Session, current_user: User, vm_config: VMCreate) -> VMCreationJobResponse:
-    """VM ?앹꽦 ?붿껌???먯뿉 ?ｊ퀬 ?묒뾽 ?뺣낫瑜?諛섑솚?쒕떎."""
+    """VM 생성 요청을 큐에 넣고 작업 정보를 반환한다."""
     validate_vm_creation_request(db, current_user, vm_config)
 
     job = VmCreationJob(
@@ -172,16 +173,16 @@ def enqueue_vm_creation(db: Session, current_user: User, vm_config: VMCreate) ->
 def get_vm_creation_job(db: Session, job_id: str, current_user: User) -> VMCreationJobResponse:
     job = db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
     if not job:
-        raise HTTPException(status_code=404, detail="VM ?앹꽦 ?묒뾽??李얠쓣 ???놁뒿?덈떎.")
+        raise HTTPException(status_code=404, detail="VM 생성 작업을 찾을 수 없습니다.")
 
     if current_user.role != UserRole.ADMIN and job.user_id != current_user.id:
-        raise HTTPException(status_code=404, detail="VM ?앹꽦 ?묒뾽??李얠쓣 ???놁뒿?덈떎.")
+        raise HTTPException(status_code=404, detail="VM 생성 작업을 찾을 수 없습니다.")
 
     return _serialize_job(job, position=_get_queue_position(db, job))
 
 
 def process_vm_creation_job(job_id: str) -> None:
-    """?먯뿉??爰쇰궦 ?⑥씪 ?묒뾽??泥섎━?쒕떎."""
+    """큐에서 가져온 단일 작업을 처리한다."""
     job_db = SessionLocal()
     work_db = SessionLocal()
     try:
@@ -203,19 +204,27 @@ def process_vm_creation_job(job_id: str) -> None:
         )
         if claimed_rows == 0:
             job_db.rollback()
-            logger.info("[vm-queue] ?묒뾽 %s???대? ?ㅻⅨ ?뚯빱媛 泥섎━?덇굅???곹깭媛 蹂寃쎈맖", job_id)
+            logger.info("[vm-queue] 작업 %s는 이미 다른 워커가 처리했거나 상태가 변경됨", job_id)
             return
         job_db.commit()
 
         job = job_db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
         if not job:
-            logger.warning("[vm-queue] ?묒뾽??李얠쓣 ???놁쓬: %s", job_id)
+            logger.warning("[vm-queue] 작업을 찾을 수 없음: %s", job_id)
+            return
+
+        # 멱등성 보장: vmid가 이미 설정된 경우 VM이 이미 생성된 것으로 간주
+        if job.vmid is not None:
+            logger.warning("[vm-queue] 작업 %s에 vmid %s가 이미 설정되어 있음, 중복 생성 방지", job_id, job.vmid)
+            job.status = VMCreationJobStatus.COMPLETED.value
+            job.finished_at = now_kst()
+            job_db.commit()
             return
 
         payload = job.payload
         user = work_db.query(User).filter(User.id == job.user_id).first()
         if not user:
-            raise HTTPException(status_code=404, detail="?묒뾽 ?뚯쑀?먮? 李얠쓣 ???놁뒿?덈떎.")
+            raise RuntimeError(f"작업 사용자를 찾을 수 없습니다: user_id={job.user_id}")
 
         result = create_vm(
             db=work_db,
@@ -237,9 +246,9 @@ def process_vm_creation_job(job_id: str) -> None:
         job.result = result
         job.error_message = None
         job_db.commit()
-        logger.info("[vm-queue] ?묒뾽 ?꾨즺: %s -> VMID %s", job_id, job.vmid)
+        logger.info("[vm-queue] 작업 완료: %s -> VMID %s", job_id, job.vmid)
     except Exception as exc:
-        logger.exception("[vm-queue] ?묒뾽 ?ㅽ뙣: %s", job_id)
+        logger.exception("[vm-queue] 작업 실패: %s", job_id)
         try:
             job_db.rollback()
             job = job_db.query(VmCreationJob).filter(VmCreationJob.id == job_id).first()
@@ -247,11 +256,11 @@ def process_vm_creation_job(job_id: str) -> None:
                 job.status = VMCreationJobStatus.FAILED.value
                 job.finished_at = now_kst()
                 job.error_message = getattr(exc, "detail", None) or str(exc)
-                job.message = "VM ?앹꽦???ㅽ뙣?덉뒿?덈떎."
+                job.message = "VM 생성에 실패했습니다."
                 job_db.commit()
         except Exception:
             job_db.rollback()
-            logger.exception("[vm-queue] ?ㅽ뙣 ?곹깭 湲곕줉 以??ㅻ쪟: %s", job_id)
+            logger.exception("[vm-queue] 실패 상태 기록 중 오류: %s", job_id)
     finally:
         work_db.close()
         job_db.close()
@@ -270,7 +279,7 @@ def _worker_loop() -> None:
             try:
                 process_vm_creation_job(job_id)
             except Exception as exc:
-                logger.exception("[vm-queue] ?뚯빱 猷⑦봽?먯꽌 ?덉쇅 諛쒖깮: %s", exc)
+                logger.exception("[vm-queue] 워커 루프에서 예외 발생: %s", exc)
         finally:
             _vm_creation_queue.task_done()
 
@@ -287,11 +296,11 @@ def start_vm_creation_worker() -> None:
             queued_jobs = _recover_pending_jobs(db)
             if queued_jobs:
                 logger.info(
-                    "[vm-queue] DB?먯꽌 %d媛쒖쓽 ?湲?/?ㅽ뻾 ?묒뾽???먯뿉 ?ъ쟻?ы뻽?듬땲??",
+                    "[vm-queue] DB에서 %d개의 대기/실행 작업을 큐에 적재했습니다",
                     len(queued_jobs),
                 )
         except Exception as exc:
-            logger.exception("[vm-queue] ?湲??묒뾽 ?ъ쟻??以??ㅻ쪟 諛쒖깮: %s", exc)
+            logger.exception("[vm-queue] 대기 작업 적재 중 오류 발생: %s", exc)
         finally:
             db.close()
             db = None
@@ -302,7 +311,7 @@ def start_vm_creation_worker() -> None:
             daemon=True,
         )
         _worker_thread.start()
-        logger.info("[vm-queue] VM ?앹꽦 ?뚯빱 ?쒖옉")
+        logger.info("[vm-queue] VM 생성 워커 시작")
 
 
 def stop_vm_creation_worker() -> None:
@@ -315,6 +324,6 @@ def stop_vm_creation_worker() -> None:
         _worker_thread.join(timeout=5)
         if not _worker_thread.is_alive():
             _worker_thread = None
-            logger.info("[vm-queue] VM ?앹꽦 ?뚯빱 醫낅즺")
+            logger.info("[vm-queue] VM 생성 워커 종료")
         else:
-            logger.warning("[vm-queue] VM ?앹꽦 ?뚯빱媛 ?꾩쭅 ?ㅽ뻾 以묒엯?덈떎 (??꾩븘??.")
+            logger.warning("[vm-queue] VM 생성 워커가 여전히 실행 중입니다 (강제 종료).")

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -342,8 +342,8 @@ def create_vm(
                 raise HTTPException(status_code=400, detail=f"RAM은 2048~{max_specs['memory']}MB 범위입니다.")
             specs["memory"] = custom_memory
         if custom_disk is not None:
-            if not (30 <= custom_disk <= max_specs["disk"]):
-                raise HTTPException(status_code=400, detail=f"디스크는 30~{max_specs['disk']}GB 범위입니다.")
+            if not (20 <= custom_disk <= max_specs["disk"]):
+                raise HTTPException(status_code=400, detail=f"디스크는 20~{max_specs['disk']}GB 범위입니다.")
             specs["disk"] = custom_disk
 
     # 1. 서버 선택

--- a/backend/services/vm_service.py
+++ b/backend/services/vm_service.py
@@ -290,6 +290,7 @@ def create_vm(
     custom_cores: int = None,
     custom_memory: int = None,
     custom_disk: int = None,
+    purpose: str = None,
 ):
     """
     VM 생성 (Full Clone + Cloud-Init + 포트포워딩)
@@ -338,7 +339,7 @@ def create_vm(
             specs["cores"] = custom_cores
         if custom_memory is not None:
             if not (2048 <= custom_memory <= max_specs["memory"]):
-                raise HTTPException(status_code=400, detail=f"RAM은 2048~{max_specs['memory']}MB (2~32GB) 범위입니다.")
+                raise HTTPException(status_code=400, detail=f"RAM은 2048~{max_specs['memory']}MB 범위입니다.")
             specs["memory"] = custom_memory
         if custom_disk is not None:
             if not (30 <= custom_disk <= max_specs["disk"]):
@@ -408,7 +409,7 @@ def create_vm(
     internal_ip = _allocate_internal_ip(db)
     expires_at = None
     if current_user.role == UserRole.USER:
-        expires_at = now_kst() + timedelta(days=30)
+        expires_at = now_kst() + timedelta(days=7)
 
     new_vm = Vm(
         hypervisor_vmid=vmid,
@@ -421,6 +422,7 @@ def create_vm(
         internal_ip=internal_ip,
         vm_password=vm_password,
         expires_at=expires_at,
+        purpose=purpose,
     )
     db.add(new_vm)
     db.flush()  # new_vm.id 확보

--- a/backend/tests/test_background_tasks.py
+++ b/backend/tests/test_background_tasks.py
@@ -174,13 +174,13 @@ def _make_vm(db, name, server, expires_at, owner=None, vmid=100):
 class TestSendAdminExpiryNotifications:
     """_send_admin_expiry_notifications 단위 테스트."""
 
-    def test_vms_within_7_days_sends_list(self, db):
-        """7일 이내 만료 VM 있으면 목록 포함 메시지 발송."""
+    def test_vms_within_3_days_sends_list(self, db):
+        """3일 이내 만료 VM 있으면 목록 포함 메시지 발송."""
         from main import _send_admin_expiry_notifications
         now = datetime(2026, 5, 26, 12, 0, 0)
         server = _make_server(db)
         admin = _make_admin(db, "admin@gsm.hs.kr")
-        _make_vm(db, "vm-alpha", server, now + timedelta(days=3, hours=4))
+        _make_vm(db, "vm-alpha", server, now + timedelta(days=2, hours=4))
         db.commit()
 
         _send_admin_expiry_notifications(db, now)
@@ -189,11 +189,11 @@ class TestSendAdminExpiryNotifications:
         notifs = db.query(Notification).filter(Notification.user_id == admin.id).all()
         assert len(notifs) == 1
         assert "만료 임박 VM 1개" in notifs[0].message
-        assert "vm-alpha(3일 4시간)" in notifs[0].message
+        assert "vm-alpha(2일 4시간)" in notifs[0].message
         assert notifs[0].type == "info"
 
     def test_no_vms_sends_no_notification(self, db):
-        """7일 이내 만료 VM 없으면 알림 발송 안 함."""
+        """3일 이내 만료 VM 없으면 알림 발송 안 함."""
         from main import _send_admin_expiry_notifications
         now = datetime(2026, 5, 26, 12, 0, 0)
         admin = _make_admin(db, "admin2@gsm.hs.kr")
@@ -218,13 +218,13 @@ class TestSendAdminExpiryNotifications:
         db.expire_all()
         assert db.query(Notification).filter(Notification.user_id == admin.id).count() == 0
 
-    def test_vm_beyond_7_days_excluded(self, db):
-        """8일 후 만료 VM은 포함 안 됨."""
+    def test_vm_beyond_3_days_excluded(self, db):
+        """4일 후 만료 VM은 포함 안 됨."""
         from main import _send_admin_expiry_notifications
         now = datetime(2026, 5, 26, 12, 0, 0)
         server = _make_server(db)
         admin = _make_admin(db, "admin4@gsm.hs.kr")
-        _make_vm(db, "far-vm", server, now + timedelta(days=8))
+        _make_vm(db, "far-vm", server, now + timedelta(days=4))
         db.commit()
 
         _send_admin_expiry_notifications(db, now)

--- a/backend/tests/test_discord_daily_report.py
+++ b/backend/tests/test_discord_daily_report.py
@@ -104,8 +104,8 @@ class TestCollectDiscordDailyReport:
         assert report["nodes"][0]["cpu_pct"] is None
         assert report["nodes"][0]["ok"] is False
 
-    def test_includes_vm_expiring_within_7_days(self, db):
-        """7일 이내 만료 VM을 days_left와 함께 포함."""
+    def test_includes_vm_expiring_within_3_days(self, db):
+        """3일 이내 만료 VM을 days_left와 함께 포함."""
         user = _make_user(db)
         server = _make_server(db, "gsmgpu1")
         now = now_kst()
@@ -130,15 +130,15 @@ class TestCollectDiscordDailyReport:
         assert report["vms"][0]["owner_email"] == "hong@gsm.hs.kr"
         assert report["vms"][0]["days_left"] == 3
 
-    def test_excludes_vm_expiring_after_7_days(self, db):
-        """7일 이후 만료 VM은 제외."""
+    def test_excludes_vm_expiring_after_3_days(self, db):
+        """3일 이후 만료 VM은 제외."""
         server = _make_server(db, "gsmgpu1")
         now = now_kst()
         db.add(Vm(
             hypervisor_vmid=102,
             name="vm-far",
             server_id=server.id,
-            expires_at=now + timedelta(days=10),
+            expires_at=now + timedelta(days=5),
         ))
         db.commit()
 

--- a/backend/tests/test_vm_lifecycle.py
+++ b/backend/tests/test_vm_lifecycle.py
@@ -9,6 +9,7 @@ from unittest.mock import patch, MagicMock
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from core.timezone import now_kst
 from core.database import Base
 from models.user import User, UserRole
 from models.server import Server
@@ -21,6 +22,7 @@ from models.vm_creation_job import VmCreationJob
 from services.vm_creation_queue import (
     enqueue_vm_creation,
     get_vm_creation_job,
+    _get_queue_position,
     process_vm_creation_job,
 )
 from services.vm_service import (
@@ -817,3 +819,35 @@ class TestVMCreationQueue:
 
         result_admin = get_vm_creation_job(db=db, job_id=queued.job_id, current_user=admin_user)
         assert result_admin.job_id == queued.job_id
+
+    def test_queue_position_is_deterministic_for_same_timestamp(self, db, user, server):
+        queued_at = now_kst()
+        first_job = VmCreationJob(
+            id="00000000-0000-0000-0000-000000000001",
+            user_id=user.id,
+            status=VMCreationJobStatus.QUEUED.value,
+            tier=VMTier.MICRO.value,
+            os="ubuntu2204",
+            node_name=server.name,
+            requested_name="first",
+            queued_at=queued_at,
+        )
+        first_job.payload = {"tier": VMTier.MICRO.value, "os": "ubuntu2204", "node_name": server.name, "name": "first"}
+
+        second_job = VmCreationJob(
+            id="00000000-0000-0000-0000-000000000002",
+            user_id=user.id,
+            status=VMCreationJobStatus.QUEUED.value,
+            tier=VMTier.MICRO.value,
+            os="ubuntu2204",
+            node_name=server.name,
+            requested_name="second",
+            queued_at=queued_at,
+        )
+        second_job.payload = {"tier": VMTier.MICRO.value, "os": "ubuntu2204", "node_name": server.name, "name": "second"}
+
+        db.add_all([first_job, second_job])
+        db.commit()
+
+        assert _get_queue_position(db, first_job) == 1
+        assert _get_queue_position(db, second_job) == 2

--- a/backend/tests/test_vm_lifecycle.py
+++ b/backend/tests/test_vm_lifecycle.py
@@ -222,7 +222,7 @@ class TestVMCreationCleanup:
 
         from fastapi import HTTPException
         with pytest.raises(HTTPException) as exc_info:
-            create_vm(db, user, VMTier.MICRO, node_name="test-node")
+            create_vm(db, user, VMTier.BASIC, node_name="test-node")
 
         assert exc_info.value.status_code == 500
         # Proxmox VM 삭제 시도 확인
@@ -247,7 +247,7 @@ class TestVMCreationCleanup:
 
         from fastapi import HTTPException
         with pytest.raises(HTTPException) as exc_info:
-            create_vm(db, user, VMTier.MICRO, node_name="test-node")
+            create_vm(db, user, VMTier.BASIC, node_name="test-node")
 
         assert exc_info.value.status_code == 500
         # Proxmox VM 삭제 시도
@@ -324,37 +324,37 @@ class TestVMNameValidation:
     def test_command_injection_rejected(self):
         """VM-TC-08: 명령어 인젝션 시도 → 422"""
         with pytest.raises(ValueError):
-            VMCreate(tier=VMTier.MICRO, name="test; rm -rf /")
+            VMCreate(tier=VMTier.BASIC, purpose="테스트용", name="test; rm -rf /")
 
     def test_too_long_name_rejected(self):
         """VM-TC-09: 41자 이상 이름 → 422"""
         with pytest.raises(ValueError):
-            VMCreate(tier=VMTier.MICRO, name="a" * 41)
+            VMCreate(tier=VMTier.BASIC, purpose="테스트용", name="a" * 41)
 
     def test_valid_name_accepted(self):
         """VM-TC-10: 정상 이름 통과"""
-        vm = VMCreate(tier=VMTier.MICRO, name="valid-name_1")
+        vm = VMCreate(tier=VMTier.BASIC, purpose="테스트용", name="valid-name_1")
         assert vm.name == "valid-name_1"
 
     def test_none_name_accepted(self):
         """이름 미지정 시 자동 생성 (None 통과)"""
-        vm = VMCreate(tier=VMTier.MICRO, name=None)
+        vm = VMCreate(tier=VMTier.BASIC, purpose="테스트용", name=None)
         assert vm.name is None
 
     def test_name_starting_with_dash_rejected(self):
         """대시로 시작하는 이름 거부"""
         with pytest.raises(ValueError):
-            VMCreate(tier=VMTier.MICRO, name="-invalid")
+            VMCreate(tier=VMTier.BASIC, purpose="테스트용", name="-invalid")
 
     def test_korean_name_rejected(self):
         """한글 이름 거부"""
         with pytest.raises(ValueError):
-            VMCreate(tier=VMTier.MICRO, name="테스트VM")
+            VMCreate(tier=VMTier.BASIC, purpose="테스트용", name="테스트VM")
 
     def test_name_with_spaces_rejected(self):
         """공백 포함 이름 거부"""
         with pytest.raises(ValueError):
-            VMCreate(tier=VMTier.MICRO, name="my vm")
+            VMCreate(tier=VMTier.BASIC, purpose="테스트용", name="my vm")
 
 
 # ── VM-TC-11: Proxmox 오프라인 시 update_server_stats ─────────
@@ -428,7 +428,7 @@ class TestVMCountLimit:
 
         from fastapi import HTTPException
         with pytest.raises(HTTPException) as exc_info:
-            create_vm(db, user, VMTier.MICRO, node_name="test-node")
+            create_vm(db, user, VMTier.BASIC, node_name="test-node")
         assert exc_info.value.status_code == 409
 
 
@@ -450,14 +450,14 @@ class TestVMCreationHappyPath:
         proxmox = _make_mock_proxmox(200)
         mock_proxmox_fn.return_value = proxmox
 
-        result = create_vm(db, user, VMTier.MICRO, node_name="test-node")
+        result = create_vm(db, user, VMTier.BASIC, node_name="test-node")
 
         assert result["success"] is True
         assert result["vmid"] == 200
         assert result["internal_ip"] == "10.0.0.100"
         assert "ssh_user" in result
         assert "ssh_password" in result
-        assert result["tier"] == "micro"
+        assert result["tier"] == "basic"
 
         # DB에 VM 레코드 생성 확인
         vm = db.query(Vm).filter(Vm.hypervisor_vmid == 200).first()
@@ -704,7 +704,7 @@ class TestBestServerRoleFilters:
         from fastapi import HTTPException
 
         with pytest.raises(HTTPException) as exc_info:
-            create_vm(db, admin_user, VMTier.MICRO)
+            create_vm(db, admin_user, VMTier.BASIC)
 
         assert exc_info.value.status_code == 400
 
@@ -782,7 +782,7 @@ class TestVMCreationQueue:
     @patch("services.vm_creation_queue.create_vm")
     @patch("services.vm_creation_queue.SessionLocal", new=TestSession)
     def test_enqueue_and_process_job(self, mock_create_vm, db, user, server):
-        vm_config = VMCreate(tier=VMTier.MICRO, node_name=server.name, name="queued-vm")
+        vm_config = VMCreate(tier=VMTier.BASIC, purpose="테스트용", node_name=server.name, name="queued-vm")
 
         queued = enqueue_vm_creation(db=db, current_user=user, vm_config=vm_config)
         assert queued.status == VMCreationJobStatus.QUEUED
@@ -798,7 +798,7 @@ class TestVMCreationQueue:
             "assigned_node": server.name,
             "vmid": 301,
             "name": "queued-vm",
-            "tier": "micro",
+            "tier": "basic",
             "internal_ip": "10.0.0.150",
             "ssh_user": "ubuntu",
             "ssh_password": "secret",
@@ -813,7 +813,7 @@ class TestVMCreationQueue:
         assert job.message is not None
 
     def test_job_access_is_owner_only_or_admin(self, db, user, admin_user, server):
-        vm_config = VMCreate(tier=VMTier.MICRO, node_name=server.name, name="owner-vm")
+        vm_config = VMCreate(tier=VMTier.BASIC, purpose="테스트용", node_name=server.name, name="owner-vm")
         queued = enqueue_vm_creation(db=db, current_user=user, vm_config=vm_config)
 
         result = get_vm_creation_job(db=db, job_id=queued.job_id, current_user=user)
@@ -837,7 +837,7 @@ class TestVMCreationQueue:
         db.commit()
         db.refresh(other_user)
 
-        vm_config = VMCreate(tier=VMTier.MICRO, node_name=server.name, name="private-vm")
+        vm_config = VMCreate(tier=VMTier.BASIC, purpose="테스트용", node_name=server.name, name="private-vm")
         queued = enqueue_vm_creation(db=db, current_user=user, vm_config=vm_config)
 
         with pytest.raises(FastAPIHTTPException) as exc_info:
@@ -850,25 +850,25 @@ class TestVMCreationQueue:
             id="00000000-0000-0000-0000-000000000001",
             user_id=user.id,
             status=VMCreationJobStatus.QUEUED.value,
-            tier=VMTier.MICRO.value,
+            tier=VMTier.BASIC.value,
             os="ubuntu2204",
             node_name=server.name,
             requested_name="first",
             queued_at=queued_at,
         )
-        first_job.payload = {"tier": VMTier.MICRO.value, "os": "ubuntu2204", "node_name": server.name, "name": "first"}
+        first_job.payload = {"tier": VMTier.BASIC.value, "os": "ubuntu2204", "node_name": server.name, "name": "first"}
 
         second_job = VmCreationJob(
             id="00000000-0000-0000-0000-000000000002",
             user_id=user.id,
             status=VMCreationJobStatus.QUEUED.value,
-            tier=VMTier.MICRO.value,
+            tier=VMTier.BASIC.value,
             os="ubuntu2204",
             node_name=server.name,
             requested_name="second",
             queued_at=queued_at,
         )
-        second_job.payload = {"tier": VMTier.MICRO.value, "os": "ubuntu2204", "node_name": server.name, "name": "second"}
+        second_job.payload = {"tier": VMTier.BASIC.value, "os": "ubuntu2204", "node_name": server.name, "name": "second"}
 
         db.add_all([first_job, second_job])
         db.commit()
@@ -888,26 +888,26 @@ class TestVMCreationQueue:
             id="00000000-0000-0000-0000-000000000010",
             user_id=user.id,
             status=VMCreationJobStatus.QUEUED.value,
-            tier=VMTier.MICRO.value,
+            tier=VMTier.BASIC.value,
             os="ubuntu2204",
             node_name=server.name,
             requested_name="queued",
             queued_at=now_kst(),
         )
-        queued_job.payload = {"tier": VMTier.MICRO.value, "os": "ubuntu2204", "node_name": server.name, "name": "queued"}
+        queued_job.payload = {"tier": VMTier.BASIC.value, "os": "ubuntu2204", "node_name": server.name, "name": "queued"}
 
         running_job = VmCreationJob(
             id="00000000-0000-0000-0000-000000000011",
             user_id=user.id,
             status=VMCreationJobStatus.RUNNING.value,
-            tier=VMTier.MICRO.value,
+            tier=VMTier.BASIC.value,
             os="ubuntu2204",
             node_name=server.name,
             requested_name="running",
             queued_at=now_kst(),
             started_at=now_kst(),
         )
-        running_job.payload = {"tier": VMTier.MICRO.value, "os": "ubuntu2204", "node_name": server.name, "name": "running"}
+        running_job.payload = {"tier": VMTier.BASIC.value, "os": "ubuntu2204", "node_name": server.name, "name": "running"}
 
         db.add_all([queued_job, running_job])
         db.commit()

--- a/backend/tests/test_vm_lifecycle.py
+++ b/backend/tests/test_vm_lifecycle.py
@@ -23,6 +23,8 @@ from services.vm_creation_queue import (
     enqueue_vm_creation,
     get_vm_creation_job,
     _get_queue_position,
+    _next_job_id,
+    _recover_pending_jobs,
     process_vm_creation_job,
 )
 from services.vm_service import (
@@ -851,3 +853,49 @@ class TestVMCreationQueue:
 
         assert _get_queue_position(db, first_job) == 1
         assert _get_queue_position(db, second_job) == 2
+
+    def test_next_job_id_is_monotonic(self):
+        first_id = _next_job_id()
+        second_id = _next_job_id()
+
+        assert first_id != second_id
+        assert first_id < second_id
+
+    def test_recover_pending_jobs_requeues_running_jobs(self, db, user, server):
+        queued_job = VmCreationJob(
+            id="00000000-0000-0000-0000-000000000010",
+            user_id=user.id,
+            status=VMCreationJobStatus.QUEUED.value,
+            tier=VMTier.MICRO.value,
+            os="ubuntu2204",
+            node_name=server.name,
+            requested_name="queued",
+            queued_at=now_kst(),
+        )
+        queued_job.payload = {"tier": VMTier.MICRO.value, "os": "ubuntu2204", "node_name": server.name, "name": "queued"}
+
+        running_job = VmCreationJob(
+            id="00000000-0000-0000-0000-000000000011",
+            user_id=user.id,
+            status=VMCreationJobStatus.RUNNING.value,
+            tier=VMTier.MICRO.value,
+            os="ubuntu2204",
+            node_name=server.name,
+            requested_name="running",
+            queued_at=now_kst(),
+            started_at=now_kst(),
+        )
+        running_job.payload = {"tier": VMTier.MICRO.value, "os": "ubuntu2204", "node_name": server.name, "name": "running"}
+
+        db.add_all([queued_job, running_job])
+        db.commit()
+
+        recovered = _recover_pending_jobs(db)
+
+        db.refresh(queued_job)
+        db.refresh(running_job)
+
+        assert [job.id for job in recovered] == [queued_job.id, running_job.id]
+        assert queued_job.status == VMCreationJobStatus.QUEUED.value
+        assert running_job.status == VMCreationJobStatus.QUEUED.value
+        assert running_job.started_at is None

--- a/backend/tests/test_vm_lifecycle.py
+++ b/backend/tests/test_vm_lifecycle.py
@@ -15,8 +15,14 @@ from models.server import Server
 from models.vm import Vm
 from models.vm_port import VmPort
 from models.notification import Notification
-from schemas.vm_schema import VMCreate, VMTier, SnapshotCreateRequest
+from schemas.vm_schema import VMCreate, VMCreationJobStatus, VMTier, SnapshotCreateRequest
 from api.routes.vmcontrol import create_snapshot
+from models.vm_creation_job import VmCreationJob
+from services.vm_creation_queue import (
+    enqueue_vm_creation,
+    get_vm_creation_job,
+    process_vm_creation_job,
+)
 from services.vm_service import (
     create_vm,
     delete_vm,
@@ -764,3 +770,50 @@ class TestSnapshotCreation:
         )
 
         assert result["success"] is True
+
+
+class TestVMCreationQueue:
+    """VM 생성 큐 동작 검증"""
+
+    @patch("services.vm_creation_queue.create_vm")
+    @patch("services.vm_creation_queue.SessionLocal", new=TestSession)
+    def test_enqueue_and_process_job(self, mock_create_vm, db, user, server):
+        vm_config = VMCreate(tier=VMTier.MICRO, node_name=server.name, name="queued-vm")
+
+        queued = enqueue_vm_creation(db=db, current_user=user, vm_config=vm_config)
+        assert queued.status == VMCreationJobStatus.QUEUED
+        assert queued.position == 1
+
+        job = db.query(VmCreationJob).filter(VmCreationJob.id == queued.job_id).first()
+        assert job is not None
+        assert job.status == "queued"
+
+        mock_create_vm.return_value = {
+            "success": True,
+            "message": "VM queued-vm(301)가 노드 'test-node'에 생성되었습니다.",
+            "assigned_node": server.name,
+            "vmid": 301,
+            "name": "queued-vm",
+            "tier": "micro",
+            "internal_ip": "10.0.0.150",
+            "ssh_user": "ubuntu",
+            "ssh_password": "secret",
+        }
+
+        process_vm_creation_job(queued.job_id)
+
+        db.refresh(job)
+        assert job.status == "completed"
+        assert job.vmid == 301
+        assert job.result["vmid"] == 301
+        assert job.message is not None
+
+    def test_job_access_is_owner_only_or_admin(self, db, user, admin_user, server):
+        vm_config = VMCreate(tier=VMTier.MICRO, node_name=server.name, name="owner-vm")
+        queued = enqueue_vm_creation(db=db, current_user=user, vm_config=vm_config)
+
+        result = get_vm_creation_job(db=db, job_id=queued.job_id, current_user=user)
+        assert result.job_id == queued.job_id
+
+        result_admin = get_vm_creation_job(db=db, job_id=queued.job_id, current_user=admin_user)
+        assert result_admin.job_id == queued.job_id

--- a/backend/tests/test_vm_lifecycle.py
+++ b/backend/tests/test_vm_lifecycle.py
@@ -822,6 +822,28 @@ class TestVMCreationQueue:
         result_admin = get_vm_creation_job(db=db, job_id=queued.job_id, current_user=admin_user)
         assert result_admin.job_id == queued.job_id
 
+    def test_job_access_denied_for_other_user(self, db, user, server):
+        """다른 일반 사용자는 타인의 잡에 접근할 수 없다 (404 반환)."""
+        import pytest
+        from fastapi import HTTPException as FastAPIHTTPException
+
+        other_user = User(
+            email="other@gsm.hs.kr",
+            hashed_password="hashed",
+            role=UserRole.USER,
+            is_active=True,
+        )
+        db.add(other_user)
+        db.commit()
+        db.refresh(other_user)
+
+        vm_config = VMCreate(tier=VMTier.MICRO, node_name=server.name, name="private-vm")
+        queued = enqueue_vm_creation(db=db, current_user=user, vm_config=vm_config)
+
+        with pytest.raises(FastAPIHTTPException) as exc_info:
+            get_vm_creation_job(db=db, job_id=queued.job_id, current_user=other_user)
+        assert exc_info.value.status_code == 404
+
     def test_queue_position_is_deterministic_for_same_timestamp(self, db, user, server):
         queued_at = now_kst()
         first_job = VmCreationJob(

--- a/backend/tests/test_vm_policy.py
+++ b/backend/tests/test_vm_policy.py
@@ -101,7 +101,7 @@ class TestTierSpecs:
     def test_basic_standard_specs(self):
         assert TIER_SPECS[VMTier.BASIC] == {"memory": 2048, "cores": 1, "disk": 20}
         assert TIER_SPECS[VMTier.STANDARD] == {"memory": 4096, "cores": 2, "disk": 20}
-        assert TIER_SPECS[VMTier.PROJECT_CUSTOM] == {"memory": 16384, "cores": 4, "disk": 50}
+        assert TIER_SPECS[VMTier.PROJECT_CUSTOM] == {"memory": 16384, "cores": 4, "disk": 40}
 
     def test_removed_tiers_rejected(self):
         with pytest.raises(ValidationError):

--- a/backend/tests/test_vm_policy.py
+++ b/backend/tests/test_vm_policy.py
@@ -1,0 +1,253 @@
+"""
+DevFest 이후 인스턴스 정책 변경 테스트
+
+- 티어: BASIC/STANDARD 스펙, 만료 7일
+- 연장: 만료 7일 전부터 +14일
+- purpose: 필수 입력·수정
+"""
+import asyncio
+from datetime import timedelta
+
+import pytest
+from pydantic import ValidationError
+from unittest.mock import patch, MagicMock
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from core.timezone import now_kst
+from core.database import Base
+from core.constants import TIER_SPECS
+from models.user import User, UserRole
+from models.server import Server
+from models.vm import Vm
+from schemas.vm_schema import VMCreate, VMPurposeUpdate, VMTier
+from services.vm_service import create_vm
+
+TEST_DB_URL = "sqlite:///./test_vm_policy.db"
+engine = create_engine(TEST_DB_URL, connect_args={"check_same_thread": False})
+TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def db():
+    session = TestSession()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+
+
+@pytest.fixture
+def user(db):
+    u = User(
+        email="policy-user@gsm.hs.kr",
+        hashed_password="hashed",
+        role=UserRole.USER,
+        is_active=True,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+@pytest.fixture
+def server(db):
+    s = Server(
+        name="test-node",
+        ip_address="192.168.1.10",
+        port=8006,
+        api_user="root@pam",
+        api_password="password",
+        ssh_user="root",
+        ssh_password="sshpass",
+        is_active=True,
+        gateway_ip="192.168.1.1",
+        gateway_user="admin",
+        gateway_password="gwpass",
+        base_port=21000,
+        last_free_ram_mb=16000,
+    )
+    db.add(s)
+    db.commit()
+    db.refresh(s)
+    return s
+
+
+def _make_mock_proxmox(vmid=200):
+    proxmox = MagicMock()
+    proxmox.cluster.nextid.get.return_value = str(vmid)
+    node = proxmox.nodes.return_value
+    node.qemu.return_value.clone.post.return_value = None
+    node.qemu.return_value.config.get.return_value = {"name": "test"}
+    node.qemu.return_value.config.put.return_value = None
+    node.qemu.return_value.resize.put.return_value = None
+    node.qemu.return_value.status.start.post.return_value = None
+    node.qemu.return_value.status.current.get.return_value = {"status": "running"}
+    return proxmox
+
+
+# ── 티어 스펙 ─────────────────────────────────────────────────
+
+class TestTierSpecs:
+    def test_basic_standard_specs(self):
+        assert TIER_SPECS[VMTier.BASIC] == {"memory": 2048, "cores": 1, "disk": 20}
+        assert TIER_SPECS[VMTier.STANDARD] == {"memory": 4096, "cores": 2, "disk": 20}
+        assert TIER_SPECS[VMTier.PROJECT_CUSTOM] == {"memory": 16384, "cores": 4, "disk": 50}
+
+    def test_removed_tiers_rejected(self):
+        with pytest.raises(ValidationError):
+            VMCreate(tier="micro", purpose="테스트")
+        with pytest.raises(ValidationError):
+            VMCreate(tier="large", purpose="테스트")
+
+
+# ── 만료 7일 ─────────────────────────────────────────────────
+
+class TestExpiry7Days:
+    @patch("services.vm_service._delete_snippet")
+    @patch("services.vm_service._upload_snippet")
+    @patch("services.vm_service.manage_iptables", return_value=True)
+    @patch("services.vm_service.get_proxmox_for_server")
+    @patch("services.vm_service._allocate_internal_ip", return_value="10.0.0.100")
+    def test_user_vm_expires_in_7_days(
+        self, mock_alloc, mock_proxmox_fn, mock_iptables,
+        mock_upload, mock_del_snippet, db, user, server
+    ):
+        mock_proxmox_fn.return_value = _make_mock_proxmox(200)
+
+        before = now_kst().replace(tzinfo=None)
+        create_vm(db, user, VMTier.BASIC, node_name="test-node", purpose="과제 서버")
+        after = now_kst().replace(tzinfo=None)
+
+        vm = db.query(Vm).filter(Vm.hypervisor_vmid == 200).first()
+        assert vm.purpose == "과제 서버"
+        # SQLite는 naive datetime으로 저장되므로 naive 기준으로 비교
+        expires_at = vm.expires_at.replace(tzinfo=None)
+        assert before + timedelta(days=7) <= expires_at <= after + timedelta(days=7)
+
+
+# ── 연장 (만료 7일 전부터 +14일) ─────────────────────────────
+
+class TestExtendVm:
+    def _make_vm(self, db, user, server, expires_at):
+        vm = Vm(
+            hypervisor_vmid=300,
+            name="extend-vm",
+            server_id=server.id,
+            owner_id=user.id,
+            expires_at=expires_at,
+        )
+        db.add(vm)
+        db.commit()
+        db.refresh(vm)
+        return vm
+
+    def test_extend_rejected_before_window(self, db, user, server):
+        """만료까지 7일 초과 남으면 400."""
+        from fastapi import HTTPException
+        from api.routes.vmcontrol import extend_vm
+
+        # SQLite는 naive datetime으로 저장되므로 now_kst도 naive로 패치
+        now = now_kst().replace(tzinfo=None)
+        self._make_vm(db, user, server, now + timedelta(days=10))
+
+        with patch("api.routes.vmcontrol.now_kst", return_value=now):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(extend_vm("test-node", 300, db=db, current_user=user))
+        assert exc_info.value.status_code == 400
+        assert "만료 7일 전부터" in exc_info.value.detail
+
+    def test_extend_adds_14_days(self, db, user, server):
+        """만료 7일 이내면 expires_at + 14일."""
+        from api.routes.vmcontrol import extend_vm
+
+        now = now_kst().replace(tzinfo=None)
+        original = now + timedelta(days=5)
+        vm = self._make_vm(db, user, server, original)
+
+        with patch("api.routes.vmcontrol.now_kst", return_value=now):
+            result = asyncio.run(extend_vm("test-node", 300, db=db, current_user=user))
+
+        assert result["success"] is True
+        assert "14일" in result["message"]
+        db.refresh(vm)
+        assert vm.expires_at == original + timedelta(days=14)
+
+
+# ── purpose 검증·수정 ────────────────────────────────────────
+
+class TestPurpose:
+    def test_purpose_required(self):
+        with pytest.raises(ValidationError):
+            VMCreate(tier=VMTier.BASIC)
+
+    def test_purpose_blank_rejected(self):
+        with pytest.raises(ValidationError):
+            VMCreate(tier=VMTier.BASIC, purpose="   ")
+
+    def test_purpose_too_long_rejected(self):
+        with pytest.raises(ValidationError):
+            VMCreate(tier=VMTier.BASIC, purpose="a" * 101)
+
+    def test_purpose_stripped(self):
+        vm = VMCreate(tier=VMTier.BASIC, purpose="  웹 서버 실습  ")
+        assert vm.purpose == "웹 서버 실습"
+
+    def test_update_purpose_endpoint(self, db, user, server):
+        from api.routes.vmcontrol import update_vm_purpose
+
+        vm = Vm(
+            hypervisor_vmid=400,
+            name="purpose-vm",
+            server_id=server.id,
+            owner_id=user.id,
+            purpose="이전 목적",
+        )
+        db.add(vm)
+        db.commit()
+
+        result = asyncio.run(update_vm_purpose(
+            "test-node", 400, VMPurposeUpdate(purpose="새 목적"),
+            db=db, current_user=user,
+        ))
+
+        assert result == {"success": True, "purpose": "새 목적"}
+        db.refresh(vm)
+        assert vm.purpose == "새 목적"
+
+    def test_update_purpose_other_user_404(self, db, user, server):
+        from fastapi import HTTPException
+        from api.routes.vmcontrol import update_vm_purpose
+
+        other = User(
+            email="other@gsm.hs.kr",
+            hashed_password="hashed",
+            role=UserRole.USER,
+            is_active=True,
+        )
+        db.add(other)
+        vm = Vm(
+            hypervisor_vmid=401,
+            name="other-vm",
+            server_id=server.id,
+            owner_id=user.id,
+        )
+        db.add(vm)
+        db.commit()
+        db.refresh(other)
+
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(update_vm_purpose(
+                "test-node", 401, VMPurposeUpdate(purpose="탈취 시도"),
+                db=db, current_user=other,
+            ))
+        assert exc_info.value.status_code == 404


### PR DESCRIPTION
## Summary
- **티어 전면 개편**: MICRO/SMALL/MEDIUM/LARGE 제거 → `BASIC`(1c/2G/20G)·`STANDARD`(2c/4G/20G), `PROJECT_CUSTOM` 상한 8c/32G/70G → **4c/16G/40G** (커스텀 디스크 20~40GB)
- **인당 인스턴스**: `MAX_VMS_PER_USER` 3 → **2**
- **유지 기간**: 생성 시 만료 30일 → **7일**, 연장은 만료 **7일 전부터 +14일** (기존 15일 전 +30일)
- **만료 임박 알림**: 디스코드 일일 리포트·사용자/어드민 인앱 알림 모두 **3일 이내**로 통일
- **사용 목적(purpose)**: 생성 시 전 역할 필수 입력(1~100자), `PATCH /vm/{node}/vms/{vmid}/purpose`로 수정, 목록·상세·admin all-vms 응답 포함
- **리사이즈 상한**: PO/ADMIN 핫플러그 2·4코어 / 4~16GB로 조정
- ※ 이 PR에는 develop에 먼저 머지된 **VM 생성 큐(#146)** 변경도 함께 포함됩니다

> ⚠️ 배포 전 수동 마이그레이션 필요: `ALTER TABLE vms ADD COLUMN purpose VARCHAR;`

## Test plan
- [x] `test_vm_policy.py` 신규 11개 — 티어 스펙·만료 7일·연장 창/+14일·purpose 검증/수정/권한
- [x] 기존 알림·디스코드 테스트 3일 윈도우로 조정
- [x] 영향 테스트 112개 통과
